### PR TITLE
Add scroll to searched settings

### DIFF
--- a/packages/client/src/pages/settings/index.vue
+++ b/packages/client/src/pages/settings/index.vue
@@ -57,6 +57,7 @@ import { i18n } from "@/i18n";
 import MkInfo from "@/components/MkInfo.vue";
 import MkSuperMenu from "@/components/MkSuperMenu.vue";
 import { scroll } from "@/scripts/scroll";
+import { nextTick } from "vue";
 import { signout, $i } from "@/account";
 import { unisonReload } from "@/scripts/unison-reload";
 import { instance } from "@/instance";
@@ -313,21 +314,23 @@ const menuDef = computed(() => [
 watch($$(narrow), () => {});
 
 onMounted(() => {
-	ro.observe(el.value);
+        ro.observe(el.value);
 
-	narrow = el.value.offsetWidth < NARROW_THRESHOLD;
+        narrow = el.value.offsetWidth < NARROW_THRESHOLD;
 
-	if (!narrow && currentPage?.route.name == null) {
-		router.replace("/settings/profile");
-	}
+        if (!narrow && currentPage?.route.name == null) {
+                router.replace("/settings/profile");
+        }
+        scrollToSettingFromQuery();
 });
 
 onActivated(() => {
-	narrow = el.value.offsetWidth < NARROW_THRESHOLD;
+        narrow = el.value.offsetWidth < NARROW_THRESHOLD;
 
-	if (!narrow && currentPage?.route.name == null) {
-		router.replace("/settings/profile");
-	}
+        if (!narrow && currentPage?.route.name == null) {
+                router.replace("/settings/profile");
+        }
+        scrollToSettingFromQuery();
 });
 
 onUnmounted(() => {
@@ -335,13 +338,14 @@ onUnmounted(() => {
 });
 
 watch(router.currentRef, (to) => {
-	if (
-		to.route.name === "settings" &&
-		to.child?.route.name == null &&
-		!narrow
-	) {
-		router.replace("/settings/profile");
-	}
+        if (
+                to.route.name === "settings" &&
+                to.child?.route.name == null &&
+                !narrow
+        ) {
+                router.replace("/settings/profile");
+        }
+        scrollToSettingFromQuery();
 });
 
 const emailNotConfigured = computed(
@@ -361,6 +365,23 @@ const headerActions = $computed(() => []);
 const headerTabs = $computed(() => []);
 
 definePageMetadata(INFO);
+
+function scrollToSettingFromQuery() {
+       const key = router.currentRoute.value.query.setting as string | undefined;
+       if (!key) return;
+       nextTick(() => {
+               const rootEl = el.value;
+               const blocks = rootEl?.querySelectorAll("._formBlock");
+               const text = i18n.ts[key] as unknown as string | undefined;
+               if (!blocks || !text) return;
+               for (const block of blocks) {
+                       if (block.textContent && block.textContent.includes(text)) {
+                               scroll(block as HTMLElement, { behavior: "smooth" });
+                               break;
+                       }
+               }
+       });
+}
 // w 890
 // h 700
 </script>

--- a/packages/client/src/pages/settings/mkkey-settings.vue
+++ b/packages/client/src/pages/settings/mkkey-settings.vue
@@ -29,13 +29,13 @@
 			>{{ "？" }}</MkButton
 		>
 		<template v-for="item in items">
-			<FormLink
-				:key="item.key"
-				v-if="!notSetOnly || defaultStore.isDefault(item.key)"
-				:to="`/settings/${item.def.page}`"
-				style="overflow: hidden; text-overflow: ellipsis"
-				class="_formBlock"
-			>
+                        <FormLink
+                                :key="item.key"
+                                v-if="!notSetOnly || defaultStore.isDefault(item.key)"
+                                :to="`/settings/${item.def.page}?setting=${item.key}`"
+                                style="overflow: hidden; text-overflow: ellipsis"
+                                class="_formBlock"
+                        >
 				<span
 					v-if="
 						!notSetOnly &&


### PR DESCRIPTION
## Summary
- add query parameter to navigate to specific setting from mkkey settings page
- scroll to the matching setting block when loading a settings page

## Testing
- `pnpm test` *(fails: Request was cancelled due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_6870ce3e1e2c8326bd6e7996619c8fdd