### PR TITLE
Add links from queue hosts to instance info

### DIFF
--- a/packages/client/src/pages/admin/queue.chart.vue
+++ b/packages/client/src/pages/admin/queue.chart.vue
@@ -40,12 +40,18 @@
 		</div>
 		<div class="jobs">
 			<div v-if="jobs.length > 0">
-				<div v-for="job in jobs" :key="job[0]">
-					<span>{{ job[0] }}</span>
-					<span style="margin-left: 0.5rem; opacity: 0.7"
-						>({{ number(job[1]) }} jobs)</span
-					>
-				</div>
+                                <div v-for="job in jobs" :key="job[0]">
+                                        <MkA
+                                                class="_link"
+                                                :to="`/instance-info/${job[0]}`"
+                                        >
+                                                {{ job[0] }}
+                                        </MkA>
+                                        <span
+                                                style="margin-left: 0.5rem; opacity: 0.7"
+                                                >({{ number(job[1]) }} jobs)</span
+                                        >
+                                </div>
 			</div>
 			<span v-else style="opacity: 0.5">{{ i18n.ts.noJobs }}</span>
 		</div>


### PR DESCRIPTION
## Summary
- admin job queue: link the domain names of delayed hosts to `/instance-info/<domain>` so moderators can inspect unresponsive servers directly

## Testing
- `pnpm test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68745441e5a083268228aa6986596de4