### PR TITLE
カテゴリ取得失敗時のキャッシュ利用

### DIFF
--- a/packages/client/src/instance.ts
+++ b/packages/client/src/instance.ts
@@ -59,28 +59,37 @@ export async function emojiLoad() {
 }
 
 export async function fetchCustomCategory() {
-	if (defaultStore.state.followCategories?.length) {
-		followCategories = await api("categories/show", {
-			categoryId: Array.from(new Set(defaultStore.state.followCategories))
-		});
-		let emojiStr = $computed(() =>
-			instance.emojis.map((x) => `:${x.name}:`)
-		);
-		followCategories = followCategories.map((x) => {
-			if (!x.contents) return x;
-			x.contents = x.contents.map((emoji) => {
-				if (emoji.includes("@") && emojiStr?.includes(emoji.replace(/@(\S+)$/, ":"))) {
-					return emoji.replace(/@(\S+)$/, ":")
-				}
-				return emoji;
-			})
-			return x;
-		})
-	} else {
-		followCategories = []
-	}
-	localStorage.setItem("followCategories", JSON.stringify(followCategories))
-	localStorage.setItem("followCategoriesTime", String(Date.now()))
+        if (defaultStore.state.followCategories?.length) {
+                try {
+                        followCategories = await api("categories/show", {
+                                categoryId: Array.from(new Set(defaultStore.state.followCategories))
+                        });
+                        let emojiStr = $computed(() =>
+                                instance.emojis.map((x) => `:${x.name}:`)
+                        );
+                        followCategories = followCategories.map((x) => {
+                                if (!x.contents) return x;
+                                x.contents = x.contents.map((emoji) => {
+                                        if (emoji.includes("@") && emojiStr?.includes(emoji.replace(/@(\S+)$/, ":"))) {
+                                                return emoji.replace(/@(\S+)$/, ":")
+                                        }
+                                        return emoji;
+                                })
+                                return x;
+                        })
+                        localStorage.setItem("followCategories", JSON.stringify(followCategories))
+                        localStorage.setItem("followCategoriesTime", String(Date.now()))
+                } catch (_) {
+                        const cache = localStorage.getItem("followCategories");
+                        if (cache) {
+                                followCategories = JSON.parse(cache);
+                        }
+                }
+        } else {
+                followCategories = []
+                localStorage.setItem("followCategories", JSON.stringify(followCategories))
+                localStorage.setItem("followCategoriesTime", String(Date.now()))
+        }
 }
 
 export function sortCustomCategory() {


### PR DESCRIPTION
## 概要
- カスタム絵文字カテゴリ取得に失敗した場合、前回取得したデータをキャッシュから読み込むよう `fetchCustomCategory` を改修しました
- 取得に成功した場合のみキャッシュを更新し、失敗時は既存データを保持します

## テスト結果
- `pnpm lint` は依存パッケージの取得に失敗し実行できませんでした
- `pnpm test` も同様に依存関係不足で失敗しました


------
https://chatgpt.com/codex/tasks/task_e_68818e162acc83268bf3b48ed027e80a