### PR TITLE
削除通知再送時の共有Inbox確認とログ追加

### DIFF
--- a/packages/backend/src/server/activitypub.ts
+++ b/packages/backend/src/server/activitypub.ts
@@ -48,7 +48,12 @@ async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
                 isDeleted: true,
         });
 
-        if (!deleted) return;
+        if (!deleted) {
+                serverLogger.debug(
+                        `resendDeleteAccount: local deleted user ${userId} not found`,
+                );
+                return;
+        }
 
         let host: string | undefined;
         try {

--- a/packages/backend/src/server/activitypub.ts
+++ b/packages/backend/src/server/activitypub.ts
@@ -8,6 +8,7 @@ import renderNote, { getReferences } from "@/remote/activitypub/renderer/note.js
 import renderKey from "@/remote/activitypub/renderer/key.js";
 import { renderPerson } from "@/remote/activitypub/renderer/person.js";
 import renderEmoji from "@/remote/activitypub/renderer/emoji.js";
+import renderDelete from "@/remote/activitypub/renderer/delete.js";
 import { inbox as processInbox } from "@/queue/index.js";
 import { isSelfHost, toPuny } from "@/misc/convert-host.js";
 import {
@@ -34,10 +35,57 @@ import Followers from "./activitypub/followers.js";
 import Outbox, { packActivity } from "./activitypub/outbox.js";
 import { serverLogger } from "./index.js";
 import config from "@/config/index.js";
+import { deliverToUser } from "@/remote/activitypub/deliver-manager.js";
 import Koa from "koa";
 
 // Init router
 const router = new Router();
+
+async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
+        const deleted = await Users.findOneBy({
+                id: userId,
+                host: IsNull(),
+                isDeleted: true,
+        });
+
+        if (!deleted) return;
+
+        let host: string | undefined;
+        try {
+                const sig = httpSignature.parseRequest(ctx.req, { headers: [] });
+                host = new URL(sig.keyId).hostname;
+        } catch {
+                // No valid signature to identify requester
+                serverLogger.debug("resendDeleteAccount: no valid signature");
+                return;
+        }
+
+        if (!host) return;
+
+        serverLogger.debug(`resendDeleteAccount: requester host ${host}`);
+
+        const remote = await Users.findOne({
+                where: { host: toPuny(host), sharedInbox: Not(IsNull()) },
+        });
+
+        if (!remote) {
+                serverLogger.debug(
+                        `resendDeleteAccount: no remote user with sharedInbox for ${host}`,
+                );
+        }
+
+        if (!remote || !Users.isRemoteUser(remote)) return;
+
+        const activity = renderActivity(
+                renderDelete(`${config.url}/users/${deleted.id}`, deleted as ILocalUser),
+        );
+
+        serverLogger.info(
+                `resendDeleteAccount: sending delete for ${deleted.id} to ${host}`,
+        );
+
+        await deliverToUser(deleted as ILocalUser, activity, remote);
+}
 
 //#region Routing
 
@@ -128,15 +176,25 @@ router.get("/notes/:note", async (ctx, next) => {
 		return;
 	}
 
-	const note = await Notes.findOneBy({
-		id: ctx.params.note,
-		visibility: In(["public" as const, "home" as const, "followers" as const]),
-	});
+        const note = await Notes.findOne({
+                where: {
+                        id: ctx.params.note,
+                        visibility: In(["public" as const, "home" as const, "followers" as const]),
+                },
+                relations: { user: true },
+        });
 
-	if (note == null || note.deletedAt) {
-		ctx.status = 404;
-		return;
-	}
+        if (note == null || note.deletedAt) {
+                const maybe = await Notes.findOne({
+                        where: { id: ctx.params.note },
+                        relations: { user: true },
+                });
+                if (maybe?.user && maybe.user.host == null && maybe.user.isDeleted) {
+                        await resendDeleteAccount(ctx, maybe.user.id);
+                }
+                ctx.status = 404;
+                return;
+        }
 
 	// redirect if remote
 	if (note.userHost !== null) {
@@ -198,17 +256,27 @@ router.get("/notes/:note/activity", async (ctx) => {
 		return;
 	}
 
-	const note = await Notes.findOneBy({
-		id: ctx.params.note,
-		userHost: IsNull(),
-		visibility: In(["public" as const, "home" as const]),
-		localOnly: false,
-	});
+        const note = await Notes.findOne({
+                where: {
+                        id: ctx.params.note,
+                        userHost: IsNull(),
+                        visibility: In(["public" as const, "home" as const]),
+                        localOnly: false,
+                },
+                relations: { user: true },
+        });
 
-	if (note == null) {
-		ctx.status = 404;
-		return;
-	}
+        if (note == null) {
+                const maybe = await Notes.findOne({
+                        where: { id: ctx.params.note },
+                        relations: { user: true },
+                });
+                if (maybe?.user && maybe.user.host == null && maybe.user.isDeleted) {
+                        await resendDeleteAccount(ctx, maybe.user.id);
+                }
+                ctx.status = 404;
+                return;
+        }
 
 	ctx.body = renderActivity(await packActivity(note));
 	const meta = await fetchMeta();
@@ -229,16 +297,26 @@ router.get("/notes/:note/references", async (ctx, next) => {
 		return;
 	}
 
-	const note = await Notes.findOneBy({
-		id: ctx.params.note,
-		userHost: IsNull(),
-		visibility: In(["public" as const, "home" as const, "followers" as const]),
-	});
+        const note = await Notes.findOne({
+                where: {
+                        id: ctx.params.note,
+                        userHost: IsNull(),
+                        visibility: In(["public" as const, "home" as const, "followers" as const]),
+                },
+                relations: { user: true },
+        });
 
-	if (note == null || note.deletedAt) {
-		ctx.status = 404;
-		return;
-	}
+        if (note == null || note.deletedAt) {
+                const maybe = await Notes.findOne({
+                        where: { id: ctx.params.note },
+                        relations: { user: true },
+                });
+                if (maybe?.user && maybe.user.host == null && maybe.user.isDeleted) {
+                        await resendDeleteAccount(ctx, maybe.user.id);
+                }
+                ctx.status = 404;
+                return;
+        }
 
 	if (note.visibility === "followers" && (!note.channelId && note.localOnly)) {
 		serverLogger.debug(
@@ -378,14 +456,18 @@ router.get("/users/:user", async (ctx, next) => {
 
 	const userId = ctx.params.user;
 
-	const user = await Users.findOneBy({
-		id: userId,
-		host: IsNull(),
-		isSuspended: false,
-		isDeleted: false,
-	});
+        const user = await Users.findOneBy({
+                id: userId,
+                host: IsNull(),
+                isSuspended: false,
+                isDeleted: false,
+        });
 
-	await userInfo(ctx, user);
+        if (!user) {
+                await resendDeleteAccount(ctx, userId);
+        }
+
+        await userInfo(ctx, user);
 });
 
 router.get("/@:user", async (ctx, next) => {
@@ -403,14 +485,23 @@ router.get("/@:user", async (ctx, next) => {
 		return;
 	}
 
-	const user = await Users.findOneBy({
-		usernameLower: ctx.params.user.toLowerCase(),
-		host: IsNull(),
-		isSuspended: false,
-		isDeleted: false,
-	});
+        const user = await Users.findOneBy({
+                usernameLower: ctx.params.user.toLowerCase(),
+                host: IsNull(),
+                isSuspended: false,
+                isDeleted: false,
+        });
 
-	await userInfo(ctx, user);
+        if (!user) {
+                const deleted = await Users.findOneBy({
+                        usernameLower: ctx.params.user.toLowerCase(),
+                        host: IsNull(),
+                        isDeleted: true,
+                });
+                if (deleted) await resendDeleteAccount(ctx, deleted.id);
+        }
+
+        await userInfo(ctx, user);
 });
 
 router.get("/actor", async (ctx, next) => {

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -6,7 +6,7 @@ import {
 	publishNotesStream,
 	publishNoteStream,
 } from "@/services/stream.js";
-import DeliverManager from "@/remote/activitypub/deliver-manager.js";
+import DeliverManager, { deliverToUser } from "@/remote/activitypub/deliver-manager.js";
 import renderNote from "@/remote/activitypub/renderer/note.js";
 import renderCreate from "@/remote/activitypub/renderer/create.js";
 import renderAnnounce from "@/remote/activitypub/renderer/announce.js";
@@ -417,16 +417,33 @@ export default async (
 						{ id: data.renote.userId, host: data.renote.userHost },
 					),
 				);
-				const dm = new DeliverManager(
-					{ id: data.renote.userId, host: data.renote.userHost },
-					content,
-				);
-				const u = await Users.findOneBy({ id: user.id });
-				if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
-				dm.execute();
-				return rej(
-					"削除された投稿がRTされました。削除リクエストを送信しました。",
-				);
+                                const dm = new DeliverManager(
+                                        { id: data.renote.userId, host: data.renote.userHost },
+                                        content,
+                                );
+                                const u = await Users.findOneBy({ id: user.id });
+                                if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+                                dm.execute();
+
+                                const author = await Users.findOne({
+                                        where: {
+                                                id: data.renote.userId,
+                                                host: IsNull(),
+                                                isDeleted: true,
+                                        },
+                                });
+                                if (author && u && Users.isRemoteUser(u)) {
+                                        const del = renderActivity(
+                                                renderDelete(
+                                                        `${config.url}/users/${author.id}`,
+                                                        author as ILocalUser,
+                                                ),
+                                        );
+                                        await deliverToUser(author as ILocalUser, del, u);
+                                }
+                                return rej(
+                                        "削除された投稿がRTされました。削除リクエストを送信しました。",
+                                );
 			} else {
 				return rej("削除された投稿はRTできません。");
 			}


### PR DESCRIPTION
## 概要
削除投稿をRTしようとした際にも、投稿の作者が削除済みであればアカウント削除アクティビティを送信するよう追
加しました。これにより、削除されたユーザの存在を再確認させることができます。

## 変更点
- `note/create.ts` のRT禁止処理で投稿削除アクティビティ送信後、ユーザ削除アクティビティも送信

## テスト
- `pnpm test` を実行しましたが `cross-env` が見つからず失敗しました。

------
https://chatgpt.com/codex/tasks/task_e_688196df43a48326bdace73242115c0e