### PR TITLE
配送停止確認ジョブの改善

### DIFF
--- a/packages/backend/src/queue/index.ts
+++ b/packages/backend/src/queue/index.ts
@@ -549,16 +549,25 @@ export default function () {
 		},
 	);
 
-	systemQueue.add(
-		"cleanAntennaNotes",
-		{},
-		{
-			repeat: { cron: "0 15 * * *" },
-			jobId: "clean-antennanotes",
-		},
-	);
+        systemQueue.add(
+                "cleanAntennaNotes",
+                {},
+                {
+                        repeat: { cron: "0 15 * * *" },
+                        jobId: "clean-antennanotes",
+                },
+        );
 
-	processSystemQueue(systemQueue);
+        systemQueue.add(
+                "checkSuspendedInstances",
+                {},
+                {
+                        repeat: { cron: "0 4 */14 * *" },
+                        jobId: "check-suspended-instances",
+                },
+        );
+
+        processSystemQueue(systemQueue);
 }
 
 export function destroy() {

--- a/packages/backend/src/queue/processors/system/check-suspended-instances.ts
+++ b/packages/backend/src/queue/processors/system/check-suspended-instances.ts
@@ -1,0 +1,104 @@
+import type Bull from "bull";
+import { Instances } from "@/models/index.js";
+import { fetchInstanceMetadata } from "@/services/fetch-instance-metadata.js";
+import { LessThan } from "typeorm";
+import { queueLogger } from "../../logger.js";
+
+const logger = queueLogger.createSubLogger("check-suspended-instances");
+
+export async function checkSuspendedInstances(
+        job: Bull.Job<Record<string, unknown>>,
+        done: any,
+): Promise<void> {
+        logger.info("Checking suspended instances...");
+        job.log("info - Checking suspended instances...");
+
+        const twoWeeksAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 14);
+
+        const notSuspended = await Instances.find({
+                where: {
+                        isSuspended: false,
+                        isNotResponding: true,
+                        infoUpdatedAt: LessThan(twoWeeksAgo),
+                        latestRequestReceivedAt: LessThan(twoWeeksAgo),
+                        lastCommunicatedAt: LessThan(twoWeeksAgo),
+                },
+        });
+
+        for (const inst of notSuspended) {
+                try {
+                        const ok = await fetchInstanceMetadata(inst, true);
+
+                        const update: Record<string, any> = {
+                                latestRequestSentAt: new Date(),
+                        };
+                        if (ok) {
+                                update.isNotResponding = false;
+                                update.lastCommunicatedAt = new Date();
+                        } else {
+                                update.isSuspended = true;
+                        }
+
+                        await Instances.update(inst.id, update);
+
+                        if (ok) {
+                                logger.succ(`recovered ${inst.host}`);
+                                job.log(`succ - recovered ${inst.host}`);
+                        } else {
+                                logger.warn(`suspend ${inst.host}`);
+                                job.log(`warn - suspend ${inst.host}`);
+                        }
+                } catch (err) {
+                        await Instances.update(inst.id, {
+                                latestRequestSentAt: new Date(),
+                                isSuspended: true,
+                        });
+                        logger.warn(`check failed for ${inst.host}: ${err}`);
+                        job.log(`warn - check failed for ${inst.host}: ${err}`);
+                }
+        }
+
+        const targets = await Instances.find({
+                where: {
+                        isSuspended: true,
+                        latestRequestSentAt: LessThan(twoWeeksAgo),
+                },
+        });
+
+        for (const inst of targets) {
+                if (
+                        inst.latestStatus === 410 ||
+                        (inst.latestStatus == null && inst.isNotResponding)
+                )
+                        continue;
+
+                try {
+                        const ok = await fetchInstanceMetadata(inst, true);
+
+                        const update: Record<string, any> = {
+                                latestRequestSentAt: new Date(),
+                        };
+
+                        if (ok) {
+                                update.isSuspended = false;
+                                update.isNotResponding = false;
+                                update.lastCommunicatedAt = new Date();
+                                logger.succ(`unsuspended ${inst.host}`);
+                                job.log(`succ - unsuspended ${inst.host}`);
+                        }
+
+                        await Instances.update(inst.id, update);
+                } catch (err) {
+                        await Instances.update(inst.id, {
+                                latestRequestSentAt: new Date(),
+                        });
+                        logger.warn(`check failed for ${inst.host}: ${err}`);
+                        job.log(`warn - check failed for ${inst.host}: ${err}`);
+                }
+        }
+
+        logger.succ("Check finished.");
+        job.log("succ - Check finished.");
+        job.progress(100);
+        done();
+}

--- a/packages/backend/src/queue/processors/system/index.ts
+++ b/packages/backend/src/queue/processors/system/index.ts
@@ -7,6 +7,7 @@ import { clean } from "./clean.js";
 import { cleanEmojis } from "./clean-emojis.js";
 import { cleanReactions } from "./clean-reactions.js";
 import { cleanAntennaNotes } from "./clean-antennaNote.js";
+import { checkSuspendedInstances } from "./check-suspended-instances.js";
 
 const jobs = {
 	tickCharts,
@@ -15,8 +16,9 @@ const jobs = {
 	checkExpiredMutings,
 	clean,
 	cleanEmojis,
-	cleanReactions,
-	cleanAntennaNotes,
+        cleanReactions,
+        cleanAntennaNotes,
+        checkSuspendedInstances,
 } as Record<
 	string,
 	| Bull.ProcessCallbackFunction<Record<string, unknown>>

--- a/packages/backend/src/services/fetch-instance-metadata.ts
+++ b/packages/backend/src/services/fetch-instance-metadata.ts
@@ -14,19 +14,20 @@ import type { DOMWindow } from "jsdom";
 const logger = new Logger("metadata", "cyan");
 
 export async function fetchInstanceMetadata(
-	instance: Instance,
-	force = false,
-): Promise<void> {
-		if (!force) {
-		const _instance = await Instances.findOneBy({ host: instance.host });
-		const now = Date.now();
-		if (
-			_instance?.infoUpdatedAt &&
-			now - _instance.infoUpdatedAt.getTime() < 1000 * 60 * 60 * 24
-		) {
-			return;
-		}
-	}
+        instance: Instance,
+        force = false,
+): Promise<boolean> {
+        let success = false;
+        if (!force) {
+                const _instance = await Instances.findOneBy({ host: instance.host });
+                const now = Date.now();
+                if (
+                        _instance?.infoUpdatedAt &&
+                        now - _instance.infoUpdatedAt.getTime() < 1000 * 60 * 60 * 24
+                ) {
+                        return true;
+                }
+        }
 
 	const lock = await getFetchInstanceMetadataLock(instance.host);
 
@@ -146,15 +147,18 @@ export async function fetchInstanceMetadata(
 		if (favicon) updates.faviconUrl = favicon;
 		if (themeColor) updates.themeColor = themeColor;
 
-		await Instances.update(instance.id, updates);
+                await Instances.update(instance.id, updates);
 
-		logger.succ(`Successfuly updated metadata of ${instance.host}`);
+                logger.succ(`Successfuly updated metadata of ${instance.host}`);
+                success = true;
 	} catch (e) {
 		logger.error(`Failed to update metadata of ${instance.host}: ${e}`);
 		logger.error(JSON.stringify(updates, undefined, "\t"));
 	} finally {
-		await lock.release();
-	}
+                await lock.release();
+        }
+
+        return success;
 }
 
 type NodeInfo = {


### PR DESCRIPTION
## 概要
配送停止中インスタンスの確認処理を拡張しました。以下の条件に合致するサーバーにもメタデータ取得を試み、失敗時には配送停止フラグを立てるようにしました。
- 配送停止されていない
- `infoUpdatedAt`、`latestRequestReceivedAt`、`lastCommunicatedAt` が2週間以上前
- `isNotResponding` が真

また、チェック対象のサーバーには `latestRequestSentAt` が2週間以上前であることも条件に加え、メタデータ取得の成否に関わらず `latestRequestSentAt` を更新するようにしています。

## テスト
- `pnpm install` 失敗 (依存関係取得に失敗)
- `pnpm lint` 実行するも依存関係不足のためエラー



------
https://chatgpt.com/codex/tasks/task_e_6881b5956c108326a9818dae0630274c