### PR TITLE
削除ユーザ問い合わせ時のレスポンス修正

### DIFF
--- a/packages/backend/src/server/activitypub.ts
+++ b/packages/backend/src/server/activitypub.ts
@@ -36,7 +36,10 @@ import Outbox, { packActivity } from "./activitypub/outbox.js";
 import { serverLogger } from "./index.js";
 import config from "@/config/index.js";
 import { deliverToUser } from "@/remote/activitypub/deliver-manager.js";
+import { redisClient } from "@/db/redis.js";
 import Koa from "koa";
+
+const DELETE_RESEND_COOLDOWN_SEC = 60 * 15;
 
 // Init router
 const router = new Router();
@@ -69,6 +72,14 @@ async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
 
         serverLogger.debug(`resendDeleteAccount: requester host ${host}`);
 
+        const key = `deleteResend:${toPuny(host)}:${deleted.id}`;
+        if ((await redisClient.exists(key)) > 0) {
+                serverLogger.debug(
+                        `resendDeleteAccount: cooldown active for ${host}`,
+                );
+                return;
+        }
+
         const remote = await Users.findOne({
                 where: { host: toPuny(host), sharedInbox: Not(IsNull()) },
         });
@@ -90,6 +101,7 @@ async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
         );
 
         await deliverToUser(deleted as ILocalUser, activity, remote);
+        await redisClient.set(key, 1, "EX", DELETE_RESEND_COOLDOWN_SEC);
 }
 
 //#region Routing
@@ -459,9 +471,9 @@ router.get("/users/:user", async (ctx, next) => {
 		return;
 	}
 
-	const userId = ctx.params.user;
+        const userId = ctx.params.user;
 
-        const user = await Users.findOneBy({
+        let user = await Users.findOneBy({
                 id: userId,
                 host: IsNull(),
                 isSuspended: false,
@@ -469,7 +481,20 @@ router.get("/users/:user", async (ctx, next) => {
         });
 
         if (!user) {
-                await resendDeleteAccount(ctx, userId);
+                const deleted = await Users.findOneBy({
+                        id: userId,
+                        host: IsNull(),
+                        isDeleted: true,
+                });
+
+                if (deleted) {
+                        await resendDeleteAccount(ctx, deleted.id);
+                        await userInfo(ctx, deleted);
+                        return;
+                }
+
+                ctx.status = 404;
+                return;
         }
 
         await userInfo(ctx, user);
@@ -490,7 +515,7 @@ router.get("/@:user", async (ctx, next) => {
 		return;
 	}
 
-        const user = await Users.findOneBy({
+        let user = await Users.findOneBy({
                 usernameLower: ctx.params.user.toLowerCase(),
                 host: IsNull(),
                 isSuspended: false,
@@ -503,7 +528,15 @@ router.get("/@:user", async (ctx, next) => {
                         host: IsNull(),
                         isDeleted: true,
                 });
-                if (deleted) await resendDeleteAccount(ctx, deleted.id);
+
+                if (deleted) {
+                        await resendDeleteAccount(ctx, deleted.id);
+                        await userInfo(ctx, deleted);
+                        return;
+                }
+
+                ctx.status = 404;
+                return;
         }
 
         await userInfo(ctx, user);


### PR DESCRIPTION
## 変更内容
- 削除済みユーザが `/users/:id` や `/@:name` に問い合わせられた場合、404 を返さずユーザ情報を返すよう変更
- 削除済みユーザが存在する場合は再送抑制を確認した上で Delete を再送
- 依存取得および Lint は `pnpm` が存在せず実行失敗

## テスト結果
- `pnpm install` はコマンドが見つからず失敗【83b77b†L1-L26】
- `pnpm run lint` も同様に失敗【e81b1d†L1-L26】

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6881cce06a40832697a5aba2075c6ab2