### PR TITLE
followCategories設定消失バグの修正

### DIFF
--- a/packages/client/src/instance.ts
+++ b/packages/client/src/instance.ts
@@ -86,15 +86,20 @@ export async function fetchCustomCategory() {
                         }
                 }
         } else {
-                followCategories = []
+                const cache = localStorage.getItem("followCategories");
+                if (cache) {
+                        followCategories = JSON.parse(cache);
+                } else {
+                        followCategories = [];
+                }
                 localStorage.setItem("followCategories", JSON.stringify(followCategories))
                 localStorage.setItem("followCategoriesTime", String(Date.now()))
         }
 }
 
 export function sortCustomCategory() {
-	followCategories　= defaultStore.state.followCategories.map((x) => followCategories.find((y) => x === y.id)).filter(Boolean);
-	localStorage.setItem("followCategories", JSON.stringify(followCategories))
+        followCategories = defaultStore.state.followCategories.map((x) => followCategories.find((y) => x === y.id)).filter(Boolean);
+        localStorage.setItem("followCategories", JSON.stringify(followCategories))
 }
 
 export async function fetchInstance() {


### PR DESCRIPTION
## 概要
`followCategories` の取得前に設定を初期化してしまう場合があり、稀にカテゴリのフォロー設定が全て消える問題を修正しました。設定が空の場合でもローカルキャッシュを保持するようにし、ソート処理の変数名の全角スペースも修正しています。

## テスト結果
- `pnpm install` 実行時、GitHub への接続がブロックされたため依存関係をインストールできず、テストを実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_6886cb453e8883268b94f4a66775c2f2