### PR TITLE
絵文字ピッカー並び順処理の修正

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1087,25 +1087,24 @@
 						</template>
 					</template>
 				</div>
-				<div
-					v-once
-					v-if="
-						searchResultCustom.length <= 0 &&
-						(q == null || q === '') &&
-						!$store.state.categoryHidden
-					"
-					class="group"
-				>
-					<header>{{ i18n.ts.emoji }}</header>
-                                        <XSection
-                                                v-for="category in categories"
-                                                :key="category"
-                                                data-section="unicode"
-                                                :emojis="
-                                                        emojilist
-                                                                .filter((e) => e.category === category)
-                                                                .map((e) => e.char)
-						"
+                               <div
+                                       v-if="
+                                               searchResultCustom.length <= 0 &&
+                                               (q == null || q === '') &&
+                                               !$store.state.categoryHidden
+                                       "
+                                       class="group"
+                                       data-section="unicode"
+                               >
+                                       <header>{{ i18n.ts.emoji }}</header>
+                                       <XSection
+                                               v-for="category in categories"
+                                               :key="category"
+                                               :emojis="
+                                                       emojilist
+                                                               .filter((e) => e.category === category)
+                                                               .map((e) => e.char)
+                                               "
 						@chosen="chosen"
 						>{{ category }}</XSection
 					>
@@ -1811,28 +1810,49 @@ let original: HTMLElement[] | null = null;
 
 function reorderSections() {
        if (!emojis.value) return;
-       if (!original) original = Array.from(emojis.value.children) as HTMLElement[];
+       if (!original)
+               original = Array.from(
+                       emojis.value.querySelectorAll<HTMLElement>("[data-section]")
+               );
+
        const order = defaultStore.state.emojiPickerOrder;
+
        const sections = Array.from(
                emojis.value.querySelectorAll<HTMLElement>("[data-section]")
        );
        const map: Record<string, HTMLElement[]> = {};
+
        for (const el of sections) {
                const key = el.dataset.section ?? "";
+               if (!key) continue;
                (map[key] ||= []).push(el);
        }
+
        for (const key of order) {
                for (const k in map) {
                        if (k === key || k.startsWith(key + "-")) {
-                               for (const el of map[k]) emojis.value.appendChild(el);
+                               for (const el of map[k]) {
+                                       el.style.display = "";
+                                       emojis.value.appendChild(el);
+                               }
+                               delete map[k];
                        }
+               }
+       }
+
+       for (const k in map) {
+               for (const el of map[k]) {
+                       el.style.display = "none";
                }
        }
 }
 
 function restoreSections() {
        if (!emojis.value || !original) return;
-       for (const el of original) emojis.value.appendChild(el);
+       for (const el of original) {
+               el.style.display = "";
+               emojis.value.appendChild(el);
+       }
 }
 
 defineExpose({

--- a/packages/client/src/pages/settings/emoji-picker-order.vue
+++ b/packages/client/src/pages/settings/emoji-picker-order.vue
@@ -72,7 +72,7 @@ const items = ref(
 );
 
 async function addItem() {
-  const remain = Object.keys(orderItemDef).filter(k => !defaultStore.state.emojiPickerOrder.includes(k));
+  const remain = Object.keys(orderItemDef).filter(k => !items.value.some(i => i.type === k));
   const { canceled, result } = await os.select({
     title: i18n.ts.addItem,
     items: remain.map(k => ({ value: k, text: i18n.ts._emojiPickerSections[k] })),


### PR DESCRIPTION
## 概要
- 並び順設定から外れたセクションは DOM から削除せず非表示化するよう変更
- `reorderSections` で `querySelectorAll` を再利用し、`display` の切り替えで順序を制御
- `restoreSections` では非表示を解除して元の順序へ戻す
- `emoji-picker-order` 画面の項目追加ロジックを `items` 基準に修正済み

## 動作確認
- `pnpm lint` を実行しましたが依存関係取得に失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6886fd2780988326bea2767f9294860f