### PR TITLE
fix category reorder freeze

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1149,7 +1149,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, unref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, unref, computed, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
 import * as Misskey from "calckey-js";
 import XSection from "@/components/MkEmojiPicker.section.vue";
 import {
@@ -1869,7 +1869,9 @@ function reorderSections() {
                }
        }
 
-       ignoreMutation = false;
+       nextTick(() => {
+               ignoreMutation = false;
+       });
 }
 
 function restoreSections() {
@@ -1885,7 +1887,9 @@ function restoreSections() {
                        emojis.value.appendChild(el);
                }
        }
-       ignoreMutation = false;
+       nextTick(() => {
+               ignoreMutation = false;
+       });
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary
- 絵文字ピッカーでカテゴリ並び替えを有効化するとフリーズする不具合を修正

## Testing
- `pnpm install` *(fail: Could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688723803c808326ba4ef9a5aab7a987