### PR TITLE
プロフィールアイコンをタイムラインと同じ方法で表示

### DIFF
--- a/packages/client/src/components/global/MkAvatar.vue
+++ b/packages/client/src/components/global/MkAvatar.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, watch } from "vue";
+import { watch } from "vue";
 import * as misskey from "calckey-js";
 import { getStaticImageUrl } from "@/scripts/get-static-image-url";
 import { extractAvgColorFromBlurhash } from "@/scripts/extract-avg-color-from-blurhash";
@@ -116,17 +116,49 @@ const url = $computed(() =>
 		: props.user.avatarUrl
 );
 
+async function openAvatarImage() {
+        if (defaultStore.state.imageNewTab) {
+                window.open(url);
+                return;
+        }
+
+        await import("photoswipe/style.css");
+        const [pswp, pswpLightbox] = await Promise.all([
+                import("photoswipe"),
+                import("photoswipe/lightbox"),
+        ]);
+
+        const img = new Image();
+        img.onload = () => {
+                const lightbox = new pswpLightbox.default({
+                        dataSource: [
+                                {
+                                        src: url,
+                                        w: img.naturalWidth,
+                                        h: img.naturalHeight,
+                                },
+                        ],
+                        pswpModule: pswp.default,
+                        loop: false,
+                        padding:
+                                window.innerWidth > 500
+                                        ? { top: 32, bottom: 32, left: 32, right: 32 }
+                                        : { top: 0, bottom: 0, left: 0, right: 0 },
+                });
+                lightbox.on("close", () => lightbox.destroy());
+                lightbox.init();
+                lightbox.loadAndOpen(0);
+        };
+        img.src = url;
+}
+
 function onClick(ev: MouseEvent) {
-	if (props.clickToJumpAvatarImage) {
-		window.open(url);
-	}
-	emit("click", ev);
+        if (props.clickToJumpAvatarImage) openAvatarImage();
+        emit("click", ev);
 }
 
 function showAvatar(ev: MouseEvent) {
-	if (props.clickToJumpAvatarImage) {
-		window.open(url);
-	}
+        if (props.clickToJumpAvatarImage) openAvatarImage();
 }
 
 let color = $ref();


### PR DESCRIPTION
## 概要
- プロフィールアイコンをクリックした際、タイムライン画像と同じPhotoSwipeで表示
- 画像を新しいタブで開く設定時は従来通り新しいタブで表示
- 未使用だった onMounted インポートを削除

## テスト
- `pnpm install` (git+ssh依存を取得できず失敗)
- `pnpm lint` (node_modules 不足により失敗)
- `pnpm test` (node_modules 不足により失敗)


------
https://chatgpt.com/codex/tasks/task_e_688eda1cef6c8326a7b45390757e9389