### PR TITLE
Fix inability to follow multiple emoji categories

### DIFF
--- a/packages/client/src/components/MkCategoryFollowButton.vue
+++ b/packages/client/src/components/MkCategoryFollowButton.vue
@@ -48,11 +48,11 @@ watch(() => followCategories, () => {
 }, { immediate: true });
 
 function toggle() {
-	if (isActive) {
-		followCategories = followCategories.filter(id => id !== props.categoryId);
-	} else {
-		followCategories.push(props.categoryId);
-	}
+       if (isActive) {
+               followCategories = followCategories.filter(id => id !== props.categoryId);
+       } else {
+               followCategories = [...followCategories, props.categoryId];
+       }
 	isActive = !isActive;
 	fetchCustomCategory();
 	emit("update:active", isActive);


### PR DESCRIPTION
## Summary
- カテゴリフォローボタンで配列に新しいIDを追加する際、破壊的なpushではなく新しい配列として保存するよう変更

## Testing
- `pnpm --filter client run lint`（依存関係の取得に失敗）
- `pnpm test`（依存関係の不足により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68a43423cd94832698b2127c87eba1fc