### PR TITLE
fix: 絵文字ピッカーの並べ替え失敗時にリセット

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1799,13 +1799,13 @@ async function refetchEmoji(showToast = false) {
 onMounted(() => {
        focus();
        if (defaultStore.state.enableEmojiPickerOrder) {
-               reorderSections();
+               safeReorderSections();
        }
        if (emojis.value) {
                observer = new MutationObserver(() => {
                        if (ignoreMutation) return;
                        if (defaultStore.state.enableEmojiPickerOrder && !q.value)
-                               reorderSections();
+                               safeReorderSections();
                });
                observer.observe(emojis.value, { childList: true });
        }
@@ -1818,7 +1818,7 @@ watch(
        ],
        ([enabled]) => {
                if (enabled) {
-                       if (!q.value) reorderSections();
+                       if (!q.value) safeReorderSections();
                        else restoreSections();
                } else {
                        restoreSections();
@@ -1830,12 +1830,21 @@ watch(
 watch(q, (nv) => {
        if (!defaultStore.state.enableEmojiPickerOrder) return;
        if (nv) restoreSections();
-       else reorderSections();
+       else safeReorderSections();
 });
 
 let original: HTMLElement[] | null = null;
 let observer: MutationObserver | null = null;
 let ignoreMutation = false;
+
+function safeReorderSections() {
+       try {
+               reorderSections();
+       } catch (err) {
+               console.error("Failed to reorder emoji sections", err);
+               restoreSections();
+       }
+}
 
 function reorderSections() {
        if (!emojis.value) return;


### PR DESCRIPTION
## Summary
- 絵文字ピッカーの並べ替え処理が失敗した際にセクションを初期状態へ戻す処理を追加

## Testing
- `pnpm run format` ※依存関係の取得に失敗
- `pnpm -F client run lint` ※依存関係の取得に失敗
- `pnpm test` ※依存関係の取得に失敗

------
https://chatgpt.com/codex/tasks/task_e_68a4346bbb488326b677e3917cbda5be