### PR TITLE
非アクティブユーザー作成のページ・ギャラリーを人気・いいねから除外

### DIFF
--- a/packages/backend/src/server/api/endpoints/gallery/featured.ts
+++ b/packages/backend/src/server/api/endpoints/gallery/featured.ts
@@ -1,5 +1,6 @@
-import define from "../../define.js";
+import { DAY } from "@/const.js";
 import { GalleryPosts } from "@/models/index.js";
+import define from "../../define.js";
 
 export const meta = {
 	tags: ["gallery"],
@@ -27,14 +28,22 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	const query = GalleryPosts.createQueryBuilder("post")
-		.andWhere("post.createdAt > :date", {
-			date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
-		})
-		.andWhere("post.likedCount > 0")
-		.orderBy("post.likedCount", "DESC");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
 
-	const posts = await query.take(10).getMany();
+        const query = GalleryPosts.createQueryBuilder("post")
+                .innerJoinAndSelect("post.user", "user")
+                .andWhere("post.createdAt > :date", {
+                        date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+                })
+                .andWhere("post.likedCount > 0")
+                .andWhere("user.isDeleted = false")
+                .andWhere(
+                        "(user.updatedAt IS NULL OR user.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                )
+                .orderBy("post.likedCount", "DESC");
+
+        const posts = await query.take(10).getMany();
 
 	return await GalleryPosts.packMany(posts, me);
 });

--- a/packages/backend/src/server/api/endpoints/gallery/popular.ts
+++ b/packages/backend/src/server/api/endpoints/gallery/popular.ts
@@ -1,5 +1,6 @@
-import define from "../../define.js";
+import { DAY } from "@/const.js";
 import { GalleryPosts } from "@/models/index.js";
+import define from "../../define.js";
 
 export const meta = {
 	tags: ["gallery"],
@@ -27,9 +28,17 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	const query = GalleryPosts.createQueryBuilder("post")
-		.andWhere("post.likedCount > 0")
-		.orderBy("post.likedCount", "DESC");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
+
+        const query = GalleryPosts.createQueryBuilder("post")
+                .innerJoinAndSelect("post.user", "user")
+                .andWhere("post.likedCount > 0")
+                .andWhere("user.isDeleted = false")
+                .andWhere(
+                        "(user.updatedAt IS NULL OR user.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                )
+                .orderBy("post.likedCount", "DESC");
 
 	const posts = await query.take(10).getMany();
 

--- a/packages/backend/src/server/api/endpoints/gallery/posts.ts
+++ b/packages/backend/src/server/api/endpoints/gallery/posts.ts
@@ -1,6 +1,7 @@
-import define from "../../define.js";
-import { makePaginationQuery } from "../../common/make-pagination-query.js";
+import { DAY } from "@/const.js";
 import { GalleryPosts } from "@/models/index.js";
+import { makePaginationQuery } from "../../common/make-pagination-query.js";
+import define from "../../define.js";
 
 export const meta = {
 	tags: ["gallery"],
@@ -30,13 +31,21 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	const query = makePaginationQuery(
-		GalleryPosts.createQueryBuilder("post"),
-		ps.sinceId,
-		ps.untilId,
-	).innerJoinAndSelect("post.user", "user");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
 
-	const posts = await query.take(ps.limit).getMany();
+        const query = makePaginationQuery(
+                GalleryPosts.createQueryBuilder("post"),
+                ps.sinceId,
+                ps.untilId,
+        )
+                .innerJoinAndSelect("post.user", "user")
+                .andWhere("user.isDeleted = false")
+                .andWhere(
+                        "(user.updatedAt IS NULL OR user.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                );
+
+        const posts = await query.take(ps.limit).getMany();
 
 	return await GalleryPosts.packMany(posts, me);
 });

--- a/packages/backend/src/server/api/endpoints/gallery/posts/show.ts
+++ b/packages/backend/src/server/api/endpoints/gallery/posts/show.ts
@@ -1,6 +1,7 @@
+import { DAY } from "@/const.js";
+import { GalleryPosts } from "@/models/index.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
-import { GalleryPosts } from "@/models/index.js";
 
 export const meta = {
 	tags: ["gallery"],
@@ -33,13 +34,25 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	const post = await GalleryPosts.findOneBy({
-		id: ps.postId,
-	});
+        const post = await GalleryPosts.findOne({
+                where: { id: ps.postId },
+                relations: { user: true },
+        });
 
-	if (post == null) {
-		throw new ApiError(meta.errors.noSuchPost);
-	}
+        if (post == null) {
+                throw new ApiError(meta.errors.noSuchPost);
+        }
 
-	return await GalleryPosts.pack(post, me);
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
+        const author = post.user;
+
+        if (
+                author == null ||
+                author.isDeleted ||
+                (author.updatedAt != null && author.updatedAt < activeThreshold)
+        ) {
+                throw new ApiError(meta.errors.noSuchPost);
+        }
+
+        return await GalleryPosts.pack(post, me);
 });

--- a/packages/backend/src/server/api/endpoints/i/gallery/likes.ts
+++ b/packages/backend/src/server/api/endpoints/i/gallery/likes.ts
@@ -1,6 +1,7 @@
-import define from "../../../define.js";
+import { DAY } from "@/const.js";
 import { GalleryLikes } from "@/models/index.js";
 import { makePaginationQuery } from "../../../common/make-pagination-query.js";
+import define from "../../../define.js";
 
 export const meta = {
 	tags: ["account", "gallery"],
@@ -46,15 +47,23 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, user) => {
-	const query = makePaginationQuery(
-		GalleryLikes.createQueryBuilder("like"),
-		ps.sinceId,
-		ps.untilId,
-	)
-		.andWhere("like.userId = :meId", { meId: user.id })
-		.leftJoinAndSelect("like.post", "post");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
 
-	const likes = await query.take(ps.limit).getMany();
+        const query = makePaginationQuery(
+                GalleryLikes.createQueryBuilder("like"),
+                ps.sinceId,
+                ps.untilId,
+        )
+                .andWhere("like.userId = :meId", { meId: user.id })
+                .innerJoinAndSelect("like.post", "post")
+                .innerJoinAndSelect("post.user", "postUser")
+                .andWhere("postUser.isDeleted = false")
+                .andWhere(
+                        "(postUser.updatedAt IS NULL OR postUser.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                );
+
+        const likes = await query.take(ps.limit).getMany();
 
 	return await GalleryLikes.packMany(likes, user);
 });

--- a/packages/backend/src/server/api/endpoints/i/page-likes.ts
+++ b/packages/backend/src/server/api/endpoints/i/page-likes.ts
@@ -1,3 +1,4 @@
+import { DAY } from "@/const.js";
 import { PageLikes } from "@/models/index.js";
 import define from "../../define.js";
 import { makePaginationQuery } from "../../common/make-pagination-query.js";
@@ -44,15 +45,23 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, user) => {
-	const query = makePaginationQuery(
-		PageLikes.createQueryBuilder("like"),
-		ps.sinceId,
-		ps.untilId,
-	)
-		.andWhere("like.userId = :meId", { meId: user.id })
-		.leftJoinAndSelect("like.page", "page");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
 
-	const likes = await query.take(ps.limit).getMany();
+        const query = makePaginationQuery(
+                PageLikes.createQueryBuilder("like"),
+                ps.sinceId,
+                ps.untilId,
+        )
+                .andWhere("like.userId = :meId", { meId: user.id })
+                .innerJoinAndSelect("like.page", "page")
+                .innerJoinAndSelect("page.user", "pageUser")
+                .andWhere("pageUser.isDeleted = false")
+                .andWhere(
+                        "(pageUser.updatedAt IS NULL OR pageUser.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                );
 
-	return PageLikes.packMany(likes, user);
+        const likes = await query.take(ps.limit).getMany();
+
+        return PageLikes.packMany(likes, user);
 });

--- a/packages/backend/src/server/api/endpoints/pages/featured.ts
+++ b/packages/backend/src/server/api/endpoints/pages/featured.ts
@@ -1,3 +1,4 @@
+import { DAY } from "@/const.js";
 import { Pages } from "@/models/index.js";
 import define from "../../define.js";
 
@@ -29,13 +30,21 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	const query = Pages.createQueryBuilder("page")
-		.where("page.visibility = 'public'")
-		.andWhere("page.isPublic = true")
-		.andWhere("(page.likedCount * 10) + page.userPv > 0")
-		.orderBy("(page.likedCount * 10) + page.userPv", "DESC");
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
 
-	const pages = await query.take(ps.limit || 10).getMany();
+        const query = Pages.createQueryBuilder("page")
+                .innerJoinAndSelect("page.user", "user")
+                .where("page.visibility = 'public'")
+                .andWhere("page.isPublic = true")
+                .andWhere("user.isDeleted = false")
+                .andWhere(
+                        "(user.updatedAt IS NULL OR user.updatedAt >= :activeThreshold)",
+                        { activeThreshold },
+                )
+                .andWhere("(page.likedCount * 10) + page.userPv > 0")
+                .orderBy("(page.likedCount * 10) + page.userPv", "DESC");
 
-	return await Pages.packMany(pages, me);
+        const pages = await query.take(ps.limit || 10).getMany();
+
+        return await Pages.packMany(pages, me);
 });

--- a/packages/backend/src/server/api/endpoints/pages/show.ts
+++ b/packages/backend/src/server/api/endpoints/pages/show.ts
@@ -1,5 +1,6 @@
-import { IsNull } from "typeorm";
+import { DAY } from "@/const.js";
 import { Pages, Users } from "@/models/index.js";
+import { IsNull } from "typeorm";
 import type { Page } from "@/models/entities/page.js";
 import define from "../../define.js";
 import { ApiError } from "../../error.js";
@@ -71,10 +72,21 @@ export default define(meta, paramDef, async (ps, user) => {
 		throw new ApiError(meta.errors.noSuchPage);
 	}
 
-	if (page && user && user.id !== page.userId) {
-		if (user) {
-			Pages.createQueryBuilder()
-				.update()
+        const activeThreshold = new Date(Date.now() - 60 * DAY);
+        const pageAuthor = await Users.findOneBy({ id: page.userId });
+
+        if (
+                pageAuthor == null ||
+                pageAuthor.isDeleted ||
+                (pageAuthor.updatedAt != null && pageAuthor.updatedAt < activeThreshold)
+        ) {
+                throw new ApiError(meta.errors.noSuchPage);
+        }
+
+        if (page && user && user.id !== page.userId) {
+                if (user) {
+                        Pages.createQueryBuilder()
+                                .update()
 				.set({
 					userpv: () => `"userpv" + 1`,
 				})


### PR DESCRIPTION
## 概要
- ページとギャラリーの人気・いいね・新着取得APIにおいて、削除済みまたは最終投稿から2か月以上経過したユーザーの投稿を除外しました
- ページ詳細・ギャラリー詳細APIでも同条件の投稿は404扱いとし、直接URL指定時にも非表示となるようにしました
- 非アクティブ判定に `user.updatedAt` を使用するよう調整しました

## テスト
- ⚠️ `pnpm lint` （依存未導入のため typecheck が失敗）

------
https://chatgpt.com/codex/tasks/task_e_68cbb34c83188326bc629c994f8e0319