### PR TITLE
ローカルTLのRenote単体表示調整

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -12,6 +12,7 @@ import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.j
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import type { Packed } from "@/misc/schema.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -44,9 +45,9 @@ export const meta = {
 } as const;
 
 export const paramDef = {
-	type: "object",
-	properties: {
-		withFiles: {
+        type: "object",
+        properties: {
+                withFiles: {
 			type: "boolean",
 			default: false,
 			description: "Only show notes that have attached files.",
@@ -71,12 +72,87 @@ export const paramDef = {
 		untilDate: { type: "integer" },
 		host: { type: "string" },
 	},
-	required: [],
+        required: [],
 } as const;
 
+function hasRenoteOnlyContent(note: Packed<"Note">): boolean {
+        if (!note.text && (!note.files || note.files.length === 0) && !note.poll) {
+                return false;
+        }
+
+        if (note.text && note.text.trim().length > 0) {
+                return true;
+        }
+
+        if (note.files && note.files.length > 0) {
+                return true;
+        }
+
+        if (note.poll) {
+                return true;
+        }
+
+        return false;
+}
+
+function isRenoteOnly(note: Packed<"Note">): boolean {
+        if (!note.renote) return false;
+
+        return !hasRenoteOnlyContent(note);
+}
+
+function filterRenoteOnlyForLocalTimeline(
+        notes: Packed<"Note">[],
+): Packed<"Note">[] {
+        if (notes.length === 0) return notes;
+
+        const noteMap = new Map<string, Packed<"Note">>();
+        const renoteOnlyMap = new Map<string, Packed<"Note">[]>();
+
+        for (const note of notes) {
+                noteMap.set(note.id, note);
+
+                if (!isRenoteOnly(note)) continue;
+
+                const targetId = note.renote?.id;
+                if (!targetId) continue;
+
+                if (!renoteOnlyMap.has(targetId)) {
+                        renoteOnlyMap.set(targetId, []);
+                }
+
+                renoteOnlyMap.get(targetId)!.push(note);
+        }
+
+        return notes.filter((note) => {
+                if (!isRenoteOnly(note)) return true;
+
+                const targetId = note.renote?.id;
+                if (!targetId) return true;
+
+                if (noteMap.has(targetId)) {
+                        return false;
+                }
+
+                const candidates = renoteOnlyMap.get(targetId);
+                if (!candidates || candidates.length === 0) {
+                        return true;
+                }
+
+                let oldest = candidates[0];
+                for (const candidate of candidates) {
+                        if (candidate.id < oldest.id) {
+                                oldest = candidate;
+                        }
+                }
+
+                return note.id === oldest.id;
+        });
+}
+
 export default define(meta, paramDef, async (ps, user) => {
-	const m = await fetchMeta();
-	if (m.disableLocalTimeline) {
+        const m = await fetchMeta();
+        if (m.disableLocalTimeline) {
 		if (user == null || !(user.isAdmin || user.isModerator)) {
 			throw new ApiError(meta.errors.ltlDisabled);
 		}
@@ -221,23 +297,31 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	// We fetch more than requested because some may be filtered out, and if there's less than
 	// requested, the pagination stops.
-	const found = [];
-	const take = Math.floor(ps.limit * 1.5);
-	let skip = 0;
-	try {
-		while (found.length < ps.limit) {
-			const notes = await query.take(take).skip(skip).getMany();
-			found.push(...(await Notes.packMany(notes, user)));
-			skip += take;
-			if (notes.length < take) break;
-		}
-	} catch (error) {
-		throw new ApiError(meta.errors.queryError);
-	}
+        const rawNotes: Packed<"Note">[] = [];
+        const take = Math.floor(ps.limit * 1.5);
+        let skip = 0;
+        try {
+                while (true) {
+                        const notes = await query.take(take).skip(skip).getMany();
+                        if (notes.length === 0) break;
 
-	if (found.length > ps.limit) {
-		found.length = ps.limit;
-	}
+                        const packedNotes = await Notes.packMany(notes, user);
+                        rawNotes.push(...packedNotes);
 
-	return found;
+                        const filtered = filterRenoteOnlyForLocalTimeline(rawNotes);
+                        if (filtered.length >= ps.limit) {
+                                return filtered.slice(0, ps.limit);
+                        }
+
+                        if (notes.length < take) {
+                                return filtered;
+                        }
+
+                        skip += take;
+                }
+        } catch (error) {
+                throw new ApiError(meta.errors.queryError);
+        }
+
+        return filterRenoteOnlyForLocalTimeline(rawNotes).slice(0, ps.limit);
 });

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -4,12 +4,41 @@ import { getWordHardMute } from "@/misc/check-word-mute.js";
 import { isUserRelated } from "@/misc/is-user-related.js";
 import type { Packed } from "@/misc/schema.js";
 
+const RECENT_RENOTE_TARGET_LIMIT = 128;
+
+function hasRenoteOnlyContent(note: Packed<"Note">): boolean {
+        if (!note.text && (!note.files || note.files.length === 0) && !note.poll) {
+                return false;
+        }
+
+        if (note.text && note.text.trim().length > 0) {
+                return true;
+        }
+
+        if (note.files && note.files.length > 0) {
+                return true;
+        }
+
+        if (note.poll) {
+                return true;
+        }
+
+        return false;
+}
+
+function isRenoteOnly(note: Packed<"Note">): boolean {
+        if (!note.renote) return false;
+
+        return !hasRenoteOnlyContent(note);
+}
+
 export default class extends Channel {
-	public readonly chName = "localTimeline";
-	public static shouldShare = true;
-	public static requireCredential = false;
-	private withBelowPublic: boolean;
-	private showReplyMode: "all" | "notBotOnly" | "personalOnly";
+        public readonly chName = "localTimeline";
+        public static shouldShare = true;
+        public static requireCredential = false;
+        private withBelowPublic: boolean;
+        private showReplyMode: "all" | "notBotOnly" | "personalOnly";
+        private recentRenoteTargets: Map<string, string> = new Map();
 
 	constructor(id: string, connection: Channel["connection"]) {
 		super(id, connection);
@@ -78,17 +107,21 @@ export default class extends Channel {
 
 		if (note.renote && !note.text && isUserRelated(note, this.renoteMuting))
 			return;
-		if (
-			note.renote &&
-			!note.text &&
-			(!this.user || !this.user!.localShowRenote)
-		)
-			return;
+                if (
+                        note.renote &&
+                        !note.text &&
+                        (!this.user || !this.user!.localShowRenote)
+                )
+                        return;
 
-		// 流れてきたNoteがミュートすべきNoteだったら無視する
-		// TODO: 将来的には、単にMutedNoteテーブルにレコードがあるかどうかで判定したい(以下の理由により難しそうではある)
-		// 現状では、ワードミュートにおけるMutedNoteレコードの追加処理はストリーミングに流す処理と並列で行われるため、
-		// レコードが追加されるNoteでも追加されるより先にここのストリーミングの処理に到達することが起こる。
+                if (isRenoteOnly(note) && this.shouldSkipRenoteOnly(note)) {
+                        return;
+                }
+
+                // 流れてきたNoteがミュートすべきNoteだったら無視する
+                // TODO: 将来的には、単にMutedNoteテーブルにレコードがあるかどうかで判定したい(以下の理由により難しそうではある)
+                // 現状では、ワードミュートにおけるMutedNoteレコードの追加処理はストリーミングに流す処理と並列で行われるため、
+                // レコードが追加されるNoteでも追加されるより先にここのストリーミングの処理に到達することが起こる。
 		// そのためレコードが存在するかのチェックでは不十分なので、改めてgetWordHardMuteを呼んでいる
 		if (
 			this.userProfile &&
@@ -96,13 +129,56 @@ export default class extends Channel {
 		)
 			return;
 
-		this.connection.cacheNote(note);
+                this.connection.cacheNote(note);
 
-		this.send("note", note);
-	}
+                if (isRenoteOnly(note)) {
+                        this.rememberRenoteOnly(note);
+                } else if (this.recentRenoteTargets.has(note.id)) {
+                        this.recentRenoteTargets.delete(note.id);
+                }
 
-	public dispose() {
-		// Unsubscribe events
-		this.subscriber.off("notesStream", this.onNote);
-	}
+                this.send("note", note);
+        }
+
+        public dispose() {
+                // Unsubscribe events
+                this.subscriber.off("notesStream", this.onNote);
+        }
+
+        private shouldSkipRenoteOnly(note: Packed<"Note">): boolean {
+                if (!isRenoteOnly(note)) return false;
+
+                const targetId = note.renote?.id;
+                if (!targetId) return false;
+
+                if (this.connection.hasCachedNote(targetId)) {
+                        return true;
+                }
+
+                const existing = this.recentRenoteTargets.get(targetId);
+                if (!existing) {
+                        return false;
+                }
+
+                if (existing <= note.id) {
+                        return true;
+                }
+
+                this.recentRenoteTargets.set(targetId, note.id);
+                return false;
+        }
+
+        private rememberRenoteOnly(note: Packed<"Note">) {
+                const targetId = note.renote?.id;
+                if (!targetId) return;
+
+                this.recentRenoteTargets.set(targetId, note.id);
+
+                if (this.recentRenoteTargets.size > RECENT_RENOTE_TARGET_LIMIT) {
+                        const oldestKey = this.recentRenoteTargets.keys().next().value;
+                        if (oldestKey !== undefined) {
+                                this.recentRenoteTargets.delete(oldestKey);
+                        }
+                }
+        }
 }

--- a/packages/backend/src/server/api/stream/index.ts
+++ b/packages/backend/src/server/api/stream/index.ts
@@ -313,11 +313,11 @@ export default class Connection {
 		this.sendMessageToWs(data.type, data.body);
 	}
 
-	public cacheNote(note: Packed<"Note">) {
-		const add = (note: Packed<"Note">) => {
-			const existIndex = this.cachedNotes.findIndex((n) => n.id === note.id);
-			if (existIndex > -1) {
-				this.cachedNotes[existIndex] = note;
+        public cacheNote(note: Packed<"Note">) {
+                const add = (note: Packed<"Note">) => {
+                        const existIndex = this.cachedNotes.findIndex((n) => n.id === note.id);
+                        if (existIndex > -1) {
+                                this.cachedNotes[existIndex] = note;
 				return;
 			}
 
@@ -328,9 +328,13 @@ export default class Connection {
 		};
 
 		add(note);
-		if (note.reply) add(note.reply);
-		if (note.renote) add(note.renote);
-	}
+                if (note.reply) add(note.reply);
+                if (note.renote) add(note.renote);
+        }
+
+        public hasCachedNote(id: string): boolean {
+                return this.cachedNotes.some((note) => note.id === id);
+        }
 
 	private readNote(body: any) {
 		const id = body.id;


### PR DESCRIPTION
## 概要
- ローカルTL取得時にRenote単体が同一取得単位内で重複しないようフィルタリング
- ローカルTLストリームでもRenote単体の重複通知を抑制
- ストリーミング接続で投稿キャッシュを参照するためのメソッドを追加

## テスト
- `pnpm lint` (依存関係が未インストールのため失敗)
- `pnpm install --frozen-lockfile` (lockfileが壊れているため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68cca07847708326b1a5e8cfa2d845cb