### PR TITLE
proxyフォロー補助処理の追加とclean順序調整

### DIFF
--- a/packages/backend/src/queue/processors/system/clean.ts
+++ b/packages/backend/src/queue/processors/system/clean.ts
@@ -1,11 +1,18 @@
 import type Bull from "bull";
-import { Brackets, IsNull, LessThan } from "typeorm";
-import { Notes, UserIps } from "@/models/index.js";
+import { Brackets, LessThan } from "typeorm";
+import { Notes, UserIps, Users } from "@/models/index.js";
 
 import { queueLogger } from "../../logger.js";
 import { genId } from "@/misc/gen-id.js";
 import { Note } from "@/models/entities/note.js";
 import { db } from "@/db/postgre.js";
+import type { User } from "@/models/entities/user.js";
+import { fetchProxyAccount } from "@/misc/fetch-proxy-account.js";
+import createFollowing from "@/services/following/create.js";
+import deleteFollowing from "@/services/following/delete.js";
+import { UserListJoining } from "@/models/entities/user-list-joining.js";
+import { Following } from "@/models/entities/following.js";
+import { FollowRequest } from "@/models/entities/follow-request.js";
 
 const logger = queueLogger.createSubLogger("clean");
 
@@ -22,12 +29,12 @@ export async function clean(
 		createdAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24 * 90)),
 	});
 
-	logger.succ("UserIps Cleaned.");
-	job.log("succ - " + "UserIps Cleaned.");
+        logger.succ("UserIps Cleaned.");
+        job.log("succ - " + "UserIps Cleaned.");
 
-	job.progress(0);
+        job.progress(0);
 
-	logger.info("Notes Cleaning...");
+        logger.info("Notes Cleaning...");
 	job.log("info - " + "Notes Cleaning...");
 
 	{
@@ -111,9 +118,149 @@ export async function clean(
 		job.log(`succ - Notes Cleaned. (${deleteCount}${failedCount ? ` / ${failedCount}` : ""
 			})`,
 		);
-	}
+        }
 
-	db.query(`VACUUM ANALYZE`);
+        logger.info("Proxyアカウントのフォロー状態を確認します...");
+        job.log("info - Proxyアカウントのフォロー状態を確認します...");
+
+        const proxy = await fetchProxyAccount();
+        if (!proxy) {
+                logger.info("Proxyアカウントが設定されていないためスキップします。");
+                job.log("info - Proxyアカウントが設定されていないためスキップします。");
+        } else {
+                const describeUser = (user: User) =>
+                        `${user.username}${user.host ? `@${user.host}` : ""} (${user.id})`;
+
+                const initialFollowingCount = proxy.followingCount ?? 0;
+                let currentProxyFollowingCount = initialFollowingCount;
+
+                const followCandidates = await Users.createQueryBuilder("user")
+                        .select("user.id", "id")
+                        .innerJoin(UserListJoining, "joining", "joining.userId = user.id")
+                        .leftJoin(
+                                Following,
+                                "localFollow",
+                                "localFollow.followeeId = user.id AND localFollow.followerHost IS NULL",
+                        )
+                        .leftJoin(
+                                Following,
+                                "proxyFollow",
+                                "proxyFollow.followeeId = user.id AND proxyFollow.followerId = :proxyId",
+                                { proxyId: proxy.id },
+                        )
+                        .leftJoin(
+                                FollowRequest,
+                                "proxyRequest",
+                                "proxyRequest.followeeId = user.id AND proxyRequest.followerId = :proxyId",
+                                { proxyId: proxy.id },
+                        )
+                        .where("user.host IS NOT NULL")
+                        .andWhere("proxyFollow.id IS NULL")
+                        .andWhere("proxyRequest.id IS NULL")
+                        .groupBy("user.id")
+                        .having("COUNT(localFollow.id) = 0")
+                        .getRawMany<{ id: string }>();
+
+                logger.info(`Proxyフォロー追加候補: ${followCandidates.length}件`);
+                job.log(`info - Proxyフォロー追加候補: ${followCandidates.length}件`);
+
+                for (const { id } of followCandidates) {
+                        const target = await Users.findOneBy({ id });
+                        if (!target) {
+                                logger.warn(`対象ユーザーが見つかりません: ${id}`);
+                                job.log(`warn - 対象ユーザーが見つかりません: ${id}`);
+                                continue;
+                        }
+
+                        const description = describeUser(target);
+
+                        logger.info(`Proxyでフォロー処理を実行します: ${description}`);
+                        job.log(`info - Proxyでフォロー処理を実行します: ${description}`);
+
+                        try {
+                                await createFollowing(proxy, target);
+                                currentProxyFollowingCount += 1;
+                                proxy.followingCount = currentProxyFollowingCount;
+                                logger.succ(`Proxyでフォローしました: ${description}`);
+                                job.log(`succ - Proxyでフォローしました: ${description}`);
+                        } catch (err) {
+                                const errorMessage = err instanceof Error ? err.message : `${err}`;
+                                logger.error(
+                                        `Proxyでのフォローに失敗しました: ${description} - ${errorMessage}`,
+                                );
+                                job.log(
+                                        `error - Proxyでのフォローに失敗しました: ${description} - ${errorMessage}`,
+                                );
+                        }
+                }
+
+                const unfollowCandidates = await Users.createQueryBuilder("user")
+                        .select("user.id", "id")
+                        .innerJoin(
+                                Following,
+                                "proxyFollow",
+                                "proxyFollow.followeeId = user.id AND proxyFollow.followerId = :proxyId",
+                                { proxyId: proxy.id },
+                        )
+                        .leftJoin(UserListJoining, "joining", "joining.userId = user.id")
+                        .where("user.host IS NOT NULL")
+                        .andWhere("joining.id IS NULL")
+                        .getRawMany<{ id: string }>();
+
+                logger.info(`Proxyフォロー解除候補: ${unfollowCandidates.length}件`);
+                job.log(`info - Proxyフォロー解除候補: ${unfollowCandidates.length}件`);
+
+                for (const { id } of unfollowCandidates) {
+                        const target = await Users.findOneBy({ id });
+                        if (!target) {
+                                logger.warn(`対象ユーザーが見つかりません: ${id}`);
+                                job.log(`warn - 対象ユーザーが見つかりません: ${id}`);
+                                continue;
+                        }
+
+                        const description = describeUser(target);
+
+                        logger.info(`Proxyでフォロー解除処理を実行します: ${description}`);
+                        job.log(`info - Proxyでフォロー解除処理を実行します: ${description}`);
+
+                        try {
+                                await deleteFollowing(proxy, target, true);
+                                currentProxyFollowingCount = Math.max(
+                                        0,
+                                        currentProxyFollowingCount - 1,
+                                );
+                                proxy.followingCount = currentProxyFollowingCount;
+                                logger.succ(`Proxyでフォロー解除しました: ${description}`);
+                                job.log(`succ - Proxyでフォロー解除しました: ${description}`);
+                        } catch (err) {
+                                const errorMessage = err instanceof Error ? err.message : `${err}`;
+                                logger.error(
+                                        `Proxyでのフォロー解除に失敗しました: ${description} - ${errorMessage}`,
+                                );
+                                job.log(
+                                        `error - Proxyでのフォロー解除に失敗しました: ${description} - ${errorMessage}`,
+                                );
+                        }
+                }
+
+                const latestProxy = await Users.findOneBy({ id: proxy.id });
+                if (latestProxy) {
+                        const finalFollowingCount = latestProxy.followingCount ?? 0;
+                        const diff = finalFollowingCount - initialFollowingCount;
+                        const diffText = diff > 0 ? `+${diff}` : `${diff}`;
+                        logger.info(
+                                `Proxyフォロー数変動: ${initialFollowingCount} -> ${finalFollowingCount} (${diffText})`,
+                        );
+                        job.log(
+                                `info - Proxyフォロー数変動: ${initialFollowingCount} -> ${finalFollowingCount} (${diffText})`,
+                        );
+                } else {
+                        logger.warn("Proxyアカウントの最終状態取得に失敗しました。");
+                        job.log("warn - Proxyアカウントの最終状態取得に失敗しました。");
+                }
+        }
+
+        db.query(`VACUUM ANALYZE`);
 
 	logger.succ(`VACUUM ANALYZE`);
 	job.log(`succ - VACUUM ANALYZE`),

--- a/packages/backend/src/services/blocking/create.ts
+++ b/packages/backend/src/services/blocking/create.ts
@@ -8,27 +8,32 @@ import renderReject from "@/remote/activitypub/renderer/reject.js";
 import type { Blocking } from "@/models/entities/blocking.js";
 import type { User } from "@/models/entities/user.js";
 import {
-	Blockings,
-	Users,
-	FollowRequests,
-	Followings,
-	UserListJoinings,
-	UserLists,
+        Blockings,
+        Users,
+        FollowRequests,
+        Followings,
+        UserListJoinings,
+        UserLists,
 } from "@/models/index.js";
 import { perUserFollowingChart } from "@/services/chart/index.js";
 import { genId } from "@/misc/gen-id.js";
 import { IdentifiableError } from "@/misc/identifiable-error.js";
 import { getActiveWebhooks } from "@/misc/webhook-cache.js";
 import { webhookDeliver } from "@/queue/index.js";
+import { ensureProxyFollowsListedUser } from "../user-list/ensure-proxy-follow.js";
 
 export default async function (blocker: User, blockee: User) {
-	await Promise.all([
-		cancelRequest(blocker, blockee),
-		cancelRequest(blockee, blocker),
-		unFollow(blocker, blockee),
-		unFollow(blockee, blocker),
-		removeFromList(blockee, blocker),
-	]);
+        await Promise.all([
+                cancelRequest(blocker, blockee),
+                cancelRequest(blockee, blocker),
+                unFollow(blocker, blockee),
+                unFollow(blockee, blocker),
+                removeFromList(blockee, blocker),
+        ]);
+
+        if (Users.isLocalUser(blocker) && Users.isRemoteUser(blockee)) {
+                await ensureProxyFollowsListedUser(blockee);
+        }
 
 	const blocking = {
 		id: genId(),

--- a/packages/backend/src/services/following/delete.ts
+++ b/packages/backend/src/services/following/delete.ts
@@ -6,6 +6,7 @@ import renderReject from "@/remote/activitypub/renderer/reject.js";
 import { deliver, webhookDeliver } from "@/queue/index.js";
 import Logger from "../logger.js";
 import { registerOrFetchInstanceDoc } from "../register-or-fetch-instance-doc.js";
+import { ensureProxyFollowsListedUser } from "../user-list/ensure-proxy-follow.js";
 import type { User } from "@/models/entities/user.js";
 import { Followings, Users, Instances } from "@/models/index.js";
 import {
@@ -83,12 +84,13 @@ export default async function (
 		});
 	}
 
-	if (Users.isLocalUser(follower) && Users.isRemoteUser(followee)) {
-		const content = renderActivity(
-			renderUndo(renderFollow(follower, followee), follower),
-		);
-		deliver(follower, content, followee.inbox);
-	}
+        if (Users.isLocalUser(follower) && Users.isRemoteUser(followee)) {
+                const content = renderActivity(
+                        renderUndo(renderFollow(follower, followee), follower),
+                );
+                deliver(follower, content, followee.inbox);
+                await ensureProxyFollowsListedUser(followee.id);
+        }
 
 	if (Users.isLocalUser(followee) && Users.isRemoteUser(follower)) {
 		// local user has null host

--- a/packages/backend/src/services/user-list/ensure-proxy-follow.ts
+++ b/packages/backend/src/services/user-list/ensure-proxy-follow.ts
@@ -1,0 +1,69 @@
+import Logger from "../logger.js";
+import type { User } from "@/models/entities/user.js";
+import { Users, Followings, FollowRequests, UserListJoinings } from "@/models/index.js";
+import { fetchProxyAccount } from "@/misc/fetch-proxy-account.js";
+import createFollowing from "../following/create.js";
+
+const logger = new Logger("user-list/proxy-follow");
+
+type Target = User | User["id"];
+
+async function resolveUser(target: Target): Promise<User | null> {
+        if (typeof target === "string") {
+                return await Users.findOneBy({ id: target });
+        }
+        return target;
+}
+
+export async function ensureProxyFollowsListedUser(targetInput: Target): Promise<void> {
+        const user = await resolveUser(targetInput);
+        if (!user) {
+                logger.warn("対象ユーザーの取得に失敗したため、proxyフォロー判定をスキップします。");
+                return;
+        }
+
+        if (!Users.isRemoteUser(user)) {
+                return;
+        }
+
+        const proxy = await fetchProxyAccount();
+        if (!proxy) {
+                return;
+        }
+
+        const [listCount, localFollowersCount, proxyFollowing, proxyRequest] = await Promise.all([
+                UserListJoinings.countBy({ userId: user.id }),
+                Followings.createQueryBuilder("following")
+                        .where("following.followeeId = :userId", { userId: user.id })
+                        .andWhere("following.followerHost IS NULL")
+                        .getCount(),
+                Followings.findOneBy({ followerId: proxy.id, followeeId: user.id }),
+                FollowRequests.findOneBy({ followerId: proxy.id, followeeId: user.id }),
+        ]);
+
+        if (listCount === 0) {
+                return;
+        }
+
+        if (localFollowersCount > 0) {
+                return;
+        }
+
+        if (proxyFollowing || proxyRequest) {
+                return;
+        }
+
+        try {
+                await createFollowing(proxy, user);
+                logger.info(
+                        `proxyアカウントでリスト対象のユーザーをフォローしました: ${user.username}` +
+                                `${user.host ? `@${user.host}` : ""} (${user.id})`,
+                );
+        } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                logger.warn(
+                        `proxyアカウントでのフォローに失敗しました: ${user.username}` +
+                                `${user.host ? `@${user.host}` : ""} (${user.id}) - ${message}`,
+                );
+        }
+}

--- a/packages/backend/src/services/user-list/push.ts
+++ b/packages/backend/src/services/user-list/push.ts
@@ -1,11 +1,10 @@
 import { publishUserListStream } from "@/services/stream.js";
 import type { User } from "@/models/entities/user.js";
 import type { UserList } from "@/models/entities/user-list.js";
-import { UserListJoinings, Users, Followings } from "@/models/index.js";
+import { UserListJoinings, Users } from "@/models/index.js";
 import type { UserListJoining } from "@/models/entities/user-list-joining.js";
 import { genId } from "@/misc/gen-id.js";
-import { fetchProxyAccount } from "@/misc/fetch-proxy-account.js";
-import createFollowing from "../following/create.js";
+import { ensureProxyFollowsListedUser } from "./ensure-proxy-follow.js";
 
 export async function pushUserToUserList(target: User, list: UserList) {
 	await UserListJoinings.insert({
@@ -17,17 +16,5 @@ export async function pushUserToUserList(target: User, list: UserList) {
 
 	publishUserListStream(list.id, "userAdded", await Users.pack(target));
 
-	const localFollowersCount = await Followings.createQueryBuilder("following")
-		.where("following.followeeId = :userId", { userId: target.id })
-		.andWhere("following.followerHost IS NULL")
-		.getCount();
-
-	// このインスタンス内にこのリモートユーザーをフォローしているユーザーがいなくても投稿を受け取るためにダミーのユーザーがフォローしたということにする
-	// 条件 : 対象のローカル内フォロワーが0人以下（ローカルからフォローされていない）
-	if (Users.isRemoteUser(target) && localFollowersCount <= 0) {
-		const proxy = await fetchProxyAccount();
-		if (proxy) {
-			createFollowing(proxy, target);
-		}
-	}
+        await ensureProxyFollowsListedUser(target);
 }


### PR DESCRIPTION
## 概要
- リスト対象ユーザーをproxyでフォローさせる共通処理を追加し、リスト追加やフォロー解除・ブロック時に呼び出すように更新
- cleanジョブにおけるproxyフォロー状態の確認をノート削除処理の後段に移し、ログ文言を調整
- ユーザーリストpullエンドポイントは元の挙動を維持するためproxyフォロー補助処理の呼び出しを外す

## テスト
- `pnpm --filter backend lint` （romeが未インストールのため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68d337b8b6808326bb58c6b39bb05730