### PR TITLE
詳細画面以外でのリアクション解除ボタン表示を修正

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -208,8 +208,8 @@
 						@click="toggleReference()"
 					>
 						<i class="ph-stack ph-bold ph-lg"></i>
-					</button>
-					<button
+                                        </button>
+                                        <button
 						v-if="
 							$i &&
 							defaultStore.state.toolbarAirReply &&
@@ -297,21 +297,20 @@
                                                        <p class="count">{{ totalReactions }}</p>
                                                </template>
                                        </button>
-					<button
-						v-if="
-							(enableEmojiReactions ||
-								detailedView ||
-								(showEmojiButton &&
-									favButtonReactionIsFavorite)) &&
-							appearNote.myReaction != null &&
-							!multiReaction
-						"
-						ref="reactButton"
-						class="button _button reacted"
-						@click="undoReact(appearNote)"
-					>
-						<i class="ph-minus ph-bold ph-lg"></i>
-					</button>
+                                        <button
+                                                v-if="
+                                                        (enableEmojiReactions ||
+                                                                detailedView ||
+                                                                showEmojiButton) &&
+                                                        appearNote.myReaction != null &&
+                                                        !multiReaction
+                                                "
+                                                ref="reactButton"
+                                                class="button _button reacted"
+                                                @click="undoReact(appearNote)"
+                                        >
+                                                <i class="ph-minus ph-bold ph-lg"></i>
+                                        </button>
 					<XQuoteButton
 						class="button"
 						:note="developerQuote ? note : appearNote"


### PR DESCRIPTION
## 概要
- 詳細画面以外でリアクションを非表示にする設定時でも、リアクション解除ボタンが表示されるよう条件を緩和

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68d9d479c174832688e93a8c6fa10e1f