### PR TITLE
リアクション解除ボタンでリアクション数を表示

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -208,8 +208,8 @@
 						@click="toggleReference()"
 					>
 						<i class="ph-stack ph-bold ph-lg"></i>
-					</button>
-					<button
+                                        </button>
+                                        <button
 						v-if="
 							$i &&
 							defaultStore.state.toolbarAirReply &&
@@ -293,25 +293,21 @@
                                                        class="ph-smiley-wink ph-bold ph-lg"
                                                ></i>
                                                <i v-else class="ph-smiley ph-bold ph-lg"></i>
-                                               <template v-if="showReactionPickerCount">
+                                               <template v-if="showReactionCount && showReactionPickerButton">
                                                        <p class="count">{{ totalReactions }}</p>
                                                </template>
                                        </button>
-					<button
-						v-if="
-							(enableEmojiReactions ||
-								detailedView ||
-								(showEmojiButton &&
-									favButtonReactionIsFavorite)) &&
-							appearNote.myReaction != null &&
-							!multiReaction
-						"
-						ref="reactButton"
-						class="button _button reacted"
-						@click="undoReact(appearNote)"
-					>
-						<i class="ph-minus ph-bold ph-lg"></i>
-					</button>
+                                       <button
+                                               v-if="showUndoReactionButton"
+                                               ref="reactButton"
+                                               class="button _button reacted"
+                                               @click="undoReact(appearNote)"
+                                       >
+                                               <i class="ph-minus ph-bold ph-lg"></i>
+                                               <template v-if="showReactionCount && showUndoReactionButton">
+                                                       <p class="count">{{ totalReactions }}</p>
+                                               </template>
+                                       </button>
 					<XQuoteButton
 						class="button"
 						:note="developerQuote ? note : appearNote"
@@ -579,13 +575,19 @@ const showReactionPickerButton = $computed(
                 !isMaxReacted &&
                 isCanAction
 );
-const showReactionPickerCount = $computed(
+const showUndoReactionButton = $computed(
+        () =>
+                (enableEmojiReactions || isDetailedView || showEmojiButton) &&
+                appearNote.myReaction != null &&
+                !multiReaction
+);
+const showReactionCount = $computed(
         () =>
                 totalReactions > 0 &&
                 !enableEmojiReactions &&
                 !isDetailedView &&
-                showReactionPickerButton &&
-                !showStarButtonNoEmoji
+                !showStarButtonNoEmoji &&
+                (showReactionPickerButton || showUndoReactionButton)
 );
 const favButtonReactionIsFavorite =
         defaultStore.state.favButtonReaction === "favorite";


### PR DESCRIPTION
## 概要
- 詳細画面以外でリアクションを非表示にする設定時でも、リアクション解除ボタンが表示されるよう条件を緩和
- リアクションピッカーの代わりに解除ボタンが表示される場合でもリアクション数を表示

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68d9d479c174832688e93a8c6fa10e1f