### PR TITLE
リモート絵文字取得の進行表示をqueueApiに切り替え

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1775,25 +1775,27 @@ function done(query?: any): boolean | void {
 	}
 }
 
-async function refetchEmoji(showToast = false) {
-        if (showToast) os.toast(i18n.ts.remoteEmojiRefetching);
+async function refetchEmoji(showQueue = false) {
+        const queueOptions = showQueue
+                ? { useQueue: true, comment: i18n.ts.remoteEmojiRefetching }
+                : undefined;
         let fetchModeMax = defaultStore.state.remoteEmojisFetch ?? "all";
         if (fetchModeMax === "always") {
                 await set("emojiFetchAttemptDate", Date.now());
-                await fetchAllEmojiNoCache();
+                await fetchAllEmojiNoCache(queueOptions);
         } else if (fetchModeMax === "all") {
                 await set("emojiFetchAttemptDate", Date.now());
-                await fetchAllEmoji().catch(() => {
+                await fetchAllEmoji(queueOptions).catch(() => {
                         // 保存に失敗した場合は軽量版リモート絵文字の取得を試行
-                        fetchPlusEmoji();
+                        fetchPlusEmoji(queueOptions);
                 });
         } else if (fetchModeMax === "plus") {
                 await set("emojiFetchAttemptDate", Date.now());
-                await fetchPlusEmoji();
+                await fetchPlusEmoji(queueOptions);
         }
         // 絵文字を読み込み直す
         await emojiLoad();
-        if (showToast) os.toast(i18n.ts.remoteEmojiRefetched);
+        if (showQueue) os.toast(i18n.ts.remoteEmojiRefetched);
 }
 
 onMounted(() => {

--- a/packages/client/src/instance.ts
+++ b/packages/client/src/instance.ts
@@ -1,5 +1,5 @@
 import { computed, reactive } from "vue";
-import { api } from "./os";
+import { api, queueApi } from "./os";
 import { stream } from "@/stream";
 import type * as Misskey from "calckey-js";
 import { get, set } from "./scripts/idb-proxy";
@@ -163,10 +163,35 @@ export async function fetchEmoji() {
 	}
 }
 
-export async function fetchPlusEmoji() {
-	const meta = await api("emojis", {
-		remoteEmojis: "mini",
-	});
+type EmojiFetchOptions = {
+        useQueue?: boolean;
+        comment?: string;
+};
+
+async function requestEmojis(
+        params: Record<string, any>,
+        options?: EmojiFetchOptions,
+) {
+        if (options?.useQueue) {
+                return await queueApi(
+                        "emojis",
+                        params,
+                        undefined,
+                        false,
+                        options.comment,
+                );
+        }
+
+        return await api("emojis", params);
+}
+
+export async function fetchPlusEmoji(options?: EmojiFetchOptions) {
+        const meta = await requestEmojis(
+                {
+                        remoteEmojis: "mini",
+                },
+                options,
+        );
 
 	const remoteEmojiData = {
 		emojiFetchDate: meta.emojiFetchDate,
@@ -182,10 +207,13 @@ export async function fetchPlusEmoji() {
 	}
 }
 
-export async function fetchAllEmoji() {
-	const meta = await api("emojis", {
-		remoteEmojis: "all",
-	});
+export async function fetchAllEmoji(options?: EmojiFetchOptions) {
+        const meta = await requestEmojis(
+                {
+                        remoteEmojis: "all",
+                },
+                options,
+        );
 
 	const remoteEmojiData = {
 		emojiFetchDate: meta.emojiFetchDate,
@@ -201,10 +229,13 @@ export async function fetchAllEmoji() {
 	}
 }
 
-export async function fetchAllEmojiNoCache() {
-	const meta = await api("emojis", {
-		remoteEmojis: "all",
-	});
+export async function fetchAllEmojiNoCache(options?: EmojiFetchOptions) {
+        const meta = await requestEmojis(
+                {
+                        remoteEmojis: "all",
+                },
+                options,
+        );
 
 	for (const [k, v] of Object.entries(meta)) {
 		instance[k] = v;


### PR DESCRIPTION
## 概要
* 絵文字ピッカーから他サーバー絵文字を再取得する際に queueApi を用いてキュー表示するよう変更しました
* リモート絵文字取得関連の関数でキュー表示オプションを扱えるよう共通化しました

## テスト
* テスト未実施（UI の表示挙動のみ変更）

------
https://chatgpt.com/codex/tasks/task_e_68d9ddf27f3483269d9a4c31e3afa07d