### PR TITLE
ログイン画面のアイコン取得失敗時にトーストを抑止

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -209,14 +209,19 @@ const props = defineProps({
 });
 
 function onUsernameChange() {
-	os.api("users/show", {
-		username: username,
-	}).then(
-		(userResponse) => {
-			user = userResponse;
-		},
-		() => {
-			user = null;
+        os.api(
+                "users/show",
+                {
+                        username: username,
+                },
+                undefined,
+                true,
+        ).then(
+                (userResponse) => {
+                        user = userResponse;
+                },
+                () => {
+                        user = null;
 		}
 	);
 }


### PR DESCRIPTION
## 概要
- ログイン画面でユーザーアイコン取得のAPI呼び出しにトースト抑止フラグを追加し、エラー時にトーストが表示されないようにしました

## テスト
- なし

------
https://chatgpt.com/codex/tasks/task_e_68d9de1be5d88326954e0d53519725b5