### PR TITLE
Amazon商品のURLプレビュー対応

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -1,10 +1,11 @@
 import type Koa from "koa";
 import summaly from "summaly";
+import { load } from "cheerio";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import Logger from "@/services/logger.js";
 import config from "@/config/index.js";
 import { query } from "@/prelude/url.js";
-import { getJson } from "@/misc/fetch.js";
+import { getHtml, getJson } from "@/misc/fetch.js";
 
 const logger = new Logger("url-preview");
 
@@ -32,6 +33,7 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
   // SteamのApp IDを取得
   const steamAppId = isSteamUrl(url);
   const VRCWorldId = isVRCUrl(url);
+  const amazonProduct = isAmazonProductUrl(url);
 
   if (steamAppId) {
     // Steamの場合の処理
@@ -154,6 +156,70 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
     }
   }
 
+  if (amazonProduct) {
+    try {
+      const localeInfo = getAmazonLocaleInfo(amazonProduct.hostname);
+      const normalizedLang = normalizeLang(lang ?? localeInfo.locale);
+      const html = await getHtml(url, "text/html, */*", 10000, {
+        "accept-language": normalizedLang,
+      });
+
+      const $ = load(html);
+      const productData = extractAmazonProductData($);
+
+      if (!productData) throw new Error("product data not found");
+
+      const description = sanitizeAmazonDescription(productData.description);
+      const image = selectAmazonImage(productData);
+      const offer = selectAmazonOffer(productData.offers);
+      const priceValue = extractPriceValue(offer);
+      const priceCurrency = extractPriceCurrency(offer) ?? localeInfo.currency;
+      const priceDisplay =
+        formatAmazonPrice(priceValue, priceCurrency, normalizedLang) ??
+        offer?.price ??
+        null;
+      const availability =
+        typeof offer?.availability === "string"
+          ? humanizeAvailability(offer.availability, normalizedLang)
+          : null;
+      const rating = normalizeAmazonRating(productData.aggregateRating);
+      const brand = extractBrand(productData.brand);
+      const primeEligible = Boolean(productData.isPrimeEligible);
+
+      const iconHost = amazonProduct.hostname.replace(/^smile\./, "");
+      const favicon = `https://${iconHost}/favicon.ico`;
+
+      const summary = {
+        url,
+        title: productData.name ?? productData.headline ?? "Amazon",
+        description,
+        thumbnail: wrap(image) ?? "",
+        icon: wrap(favicon) ?? favicon,
+        sitename: formatAmazonSitename(iconHost),
+        player: null as any,
+        amazon: {
+          asin: amazonProduct.asin,
+          price: {
+            value: priceValue,
+            currency: priceCurrency,
+            display: priceDisplay,
+          },
+          availability,
+          rating,
+          brand,
+          prime: primeEligible,
+        },
+      };
+
+      ctx.set("Cache-Control", "max-age=604800, immutable");
+      ctx.body = summary;
+      return;
+    } catch (err) {
+      logger.warn(`Failed to get Amazon data for ${url}: ${err}`);
+      // フォールバックとして通常のサマリーを取得する
+    }
+  }
+
   // 既存の処理
   try {
     const summary = meta.summalyProxy
@@ -222,6 +288,11 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
   }
 };
 
+function normalizeLang(lang?: string | null): string {
+  if (!lang) return "en-US";
+  return lang.replace("ja-KS", "ja-JP").replace("ja-KK", "ja-JP");
+}
+
 // SteamのURLを判定し、App IDを取得する関数
 function isSteamUrl(url: string): string | null {
   try {
@@ -241,6 +312,285 @@ function isSteamUrl(url: string): string | null {
     logger.warn("Invalid URL:", error);
     return null;
   }
+}
+
+
+function isAmazonProductUrl(url: string): { asin: string | null; hostname: string } | null {
+  try {
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname;
+    if (!/amazon\./i.test(hostname)) return null;
+
+    const segments = parsedUrl.pathname.split("/").filter(Boolean);
+    if (segments.length === 0) return { asin: null, hostname };
+
+    const dpIndex = segments.findIndex((segment) => segment.toLowerCase() === "dp");
+    if (dpIndex !== -1 && segments.length > dpIndex + 1) {
+      return { asin: sanitizeAsin(segments[dpIndex + 1]), hostname };
+    }
+
+    const gpIndex = segments.findIndex((segment) => segment.toLowerCase() === "product");
+    if (gpIndex > 0 && segments[gpIndex - 1].toLowerCase() === "gp") {
+      const asin = segments[gpIndex + 1];
+      if (asin) return { asin: sanitizeAsin(asin), hostname };
+    }
+
+    const awIndex = segments.findIndex((segment) => segment.toLowerCase() === "d");
+    if (awIndex > 0 && segments[awIndex - 1].toLowerCase() === "aw") {
+      const asin = segments[awIndex + 1];
+      if (asin) return { asin: sanitizeAsin(asin), hostname };
+    }
+
+    return { asin: null, hostname };
+  } catch (error) {
+    logger.warn("Invalid URL:", error);
+    return null;
+  }
+}
+
+function sanitizeAsin(segment: string): string {
+  return segment.replace(/[^A-Z0-9]/gi, "").slice(0, 10) || segment;
+}
+
+function extractAmazonProductData($: ReturnType<typeof load>): any | null {
+  const scripts = Array.from($('script[type="application/ld+json"]').toArray());
+
+  for (const script of scripts) {
+    const content = $(script).contents().text().trim();
+    if (!content) continue;
+
+    const candidates = buildJsonCandidates(content);
+    for (const candidate of candidates) {
+      try {
+        const json = JSON.parse(candidate);
+        const product = findProductNode(json);
+        if (product) return product;
+      } catch (err) {
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildJsonCandidates(content: string): string[] {
+  const trimmed = content
+    .replace(/<!--.*?-->/gs, "")
+    .replace(/\s*;\s*$/, "")
+    .trim();
+  const candidates = new Set<string>();
+  if (!trimmed) return [];
+
+  candidates.add(trimmed);
+
+  if (!trimmed.startsWith("[")) {
+    const arrayWrapped = `[${trimmed.replace(/}\s*{/g, "},{")}]`;
+    candidates.add(arrayWrapped);
+  }
+
+  return Array.from(candidates.values());
+}
+
+function findProductNode(node: any): any | null {
+  if (!node) return null;
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const found = findProductNode(item);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  if (typeof node === "object") {
+    const type = node["@type"];
+    const types = Array.isArray(type) ? type : type ? [type] : [];
+    if (types.some((t) => typeof t === "string" && t.toLowerCase() === "product")) {
+      return node;
+    }
+
+    if (node.mainEntity) {
+      const found = findProductNode(node.mainEntity);
+      if (found) return found;
+    }
+
+    if (node["@graph"]) {
+      const found = findProductNode(node["@graph"]);
+      if (found) return found;
+    }
+
+    if (node.itemListElement) {
+      const found = findProductNode(node.itemListElement);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+function selectAmazonImage(productData: any): string | null {
+  const image = productData?.image;
+  if (!image) return null;
+  if (typeof image === "string") return image;
+  if (Array.isArray(image)) {
+    for (const entry of image) {
+      if (typeof entry === "string") return entry;
+      if (entry && typeof entry === "object" && typeof entry.url === "string") {
+        return entry.url;
+      }
+    }
+  }
+  if (typeof image === "object" && typeof image.url === "string") return image.url;
+  return null;
+}
+
+function selectAmazonOffer(offers: any): any | null {
+  if (!offers) return null;
+  if (Array.isArray(offers)) {
+    for (const offer of offers) {
+      if (offer && typeof offer === "object") {
+        return offer;
+      }
+    }
+    return null;
+  }
+  return typeof offers === "object" ? offers : null;
+}
+
+function extractPriceValue(offer: any): number | null {
+  if (!offer) return null;
+  const candidates = [offer.price, offer.lowPrice, offer.priceSpecification?.price];
+  for (const candidate of candidates) {
+    if (candidate == null) continue;
+    const numeric = Number(
+      String(candidate)
+        .replace(/[^0-9.,-]/g, "")
+        .replace(/,(?=\d{3}(?:\D|$))/g, "")
+        .replace(/,/g, "")
+    );
+    if (!Number.isNaN(numeric) && Number.isFinite(numeric)) {
+      return numeric;
+    }
+  }
+  return null;
+}
+
+function extractPriceCurrency(offer: any): string | null {
+  if (!offer) return null;
+  return (
+    offer.priceCurrency ||
+    offer.priceSpecification?.priceCurrency ||
+    offer.priceSpecification?.currency ||
+    offer.currency
+  ) ?? null;
+}
+
+function formatAmazonPrice(
+  value: number | null,
+  currency: string | null,
+  lang: string
+): string | null {
+  if (value == null || !currency) return null;
+  try {
+    return new Intl.NumberFormat(lang, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(value);
+  } catch (err) {
+    return value.toString();
+  }
+}
+
+function humanizeAvailability(value: string, lang: string): string {
+  const key = value.split("/").pop()?.toLowerCase() ?? value.toLowerCase();
+  const isJapanese = lang.startsWith("ja");
+  switch (key) {
+    case "instock":
+      return isJapanese ? "在庫あり" : "In stock";
+    case "outofstock":
+      return isJapanese ? "在庫切れ" : "Out of stock";
+    case "presale":
+    case "preorder":
+      return isJapanese ? "予約受付中" : "Preorder";
+    case "preorderavailable":
+      return isJapanese ? "予約可能" : "Preorder available";
+    case "discontinued":
+      return isJapanese ? "販売終了" : "Discontinued";
+    case "limitedavailability":
+      return isJapanese ? "在庫僅少" : "Limited availability";
+    default:
+      return value;
+  }
+}
+
+function normalizeAmazonRating(rating: any): {
+  value: number | null;
+  best: number | null;
+  count: number | null;
+} {
+  if (!rating || typeof rating !== "object") {
+    return { value: null, best: null, count: null };
+  }
+  const value = rating.ratingValue ?? rating.rating ?? null;
+  const best = rating.bestRating ?? rating.best ?? null;
+  const count = rating.ratingCount ?? rating.reviewCount ?? null;
+
+  return {
+    value: value != null ? Number(value) : null,
+    best: best != null ? Number(best) : null,
+    count: count != null ? Number(count) : null,
+  };
+}
+
+function extractBrand(brand: any): string | null {
+  if (!brand) return null;
+  if (typeof brand === "string") return brand;
+  if (typeof brand === "object") {
+    if (typeof brand.name === "string") return brand.name;
+    if (typeof brand.brand === "string") return brand.brand;
+  }
+  return null;
+}
+
+function sanitizeAmazonDescription(description: unknown): string {
+  if (typeof description !== "string") return "";
+  return description.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function getAmazonLocaleInfo(hostname: string): { locale: string; currency: string } {
+  const normalizedHost = hostname.replace(/^smile\./, "").replace(/^www\./, "");
+  const mapping: Record<string, { locale: string; currency: string }> = {
+    "amazon.co.jp": { locale: "ja-JP", currency: "JPY" },
+    "amazon.com": { locale: "en-US", currency: "USD" },
+    "amazon.co.uk": { locale: "en-GB", currency: "GBP" },
+    "amazon.de": { locale: "de-DE", currency: "EUR" },
+    "amazon.fr": { locale: "fr-FR", currency: "EUR" },
+    "amazon.it": { locale: "it-IT", currency: "EUR" },
+    "amazon.es": { locale: "es-ES", currency: "EUR" },
+    "amazon.ca": { locale: "en-CA", currency: "CAD" },
+    "amazon.com.mx": { locale: "es-MX", currency: "MXN" },
+    "amazon.com.au": { locale: "en-AU", currency: "AUD" },
+    "amazon.in": { locale: "en-IN", currency: "INR" },
+    "amazon.com.br": { locale: "pt-BR", currency: "BRL" },
+    "amazon.ae": { locale: "ar-AE", currency: "AED" },
+    "amazon.sa": { locale: "ar-SA", currency: "SAR" },
+    "amazon.sg": { locale: "en-SG", currency: "SGD" },
+    "amazon.nl": { locale: "nl-NL", currency: "EUR" },
+    "amazon.se": { locale: "sv-SE", currency: "SEK" },
+    "amazon.pl": { locale: "pl-PL", currency: "PLN" },
+    "amazon.com.tr": { locale: "tr-TR", currency: "TRY" },
+    "amazon.com.be": { locale: "nl-BE", currency: "EUR" },
+    "amazon.eg": { locale: "ar-EG", currency: "EGP" },
+  };
+
+  return mapping[normalizedHost] ?? { locale: "en-US", currency: "USD" };
+}
+
+function formatAmazonSitename(hostname: string): string {
+  const normalizedHost = hostname.replace(/^smile\./, "").replace(/^www\./, "");
+  const suffix = normalizedHost.replace(/^amazon\./i, "");
+  return suffix ? `Amazon.${suffix}` : "Amazon";
 }
 
 

--- a/packages/client/src/components/MkUrlPreview.vue
+++ b/packages/client/src/components/MkUrlPreview.vue
@@ -27,11 +27,11 @@
 		allow="autoplay; encrypted-media"
 		allowfullscreen
 	  />
-	</div>
-  
-	<div
-	  v-else-if="isSteam"
-	  class="mk-url-preview steam"
+        </div>
+
+        <div
+          v-else-if="isSteam"
+          class="mk-url-preview steam"
 	  :class="{ legacyStyle: $store.state.compactGridUrl }"
 	  @click.stop
 	>
@@ -103,12 +103,93 @@
 		  </article>
 		</component>
 	  </transition>
-	</div>
-	<div
-	  v-else-if="tweetId && tweetExpanded"
-	  ref="twitter"
-	  class="twitter"
-	  @click.stop
+        </div>
+        <div
+          v-else-if="isAmazon"
+          class="mk-url-preview amazon"
+          :class="{ legacyStyle: $store.state.compactGridUrl }"
+          @click.stop
+        >
+          <MkButton
+                v-if="thumbnail && $store.state.enableDataSaverMode && !showThumbnail"
+                class="showThumbnail"
+                :small="true"
+                @click="showThumbnail = true"
+          >
+                <i class="ph-image ph-bold ph-lg"></i> {{ i18n.ts.showThumbnail }}
+          </MkButton>
+          <transition :name="$store.state.animation ? 'zoom' : ''" mode="out-in">
+                <component
+                  :is="self ? 'MkA' : 'a'"
+                  v-if="!fetching"
+                  class="link"
+                  :class="{ compact }"
+                  :[attr]="self ? url.substr(local.length) : url"
+                  rel="nofollow noopener"
+                  :target="target"
+                  :title="url"
+                >
+                  <div
+                        v-if="thumbnail && (showThumbnail || !$store.state.enableDataSaverMode)"
+                        class="thumbnail"
+                        :style="`background-image: url('${thumbnail}')`"
+                  >
+                        <button
+                          v-if="!playerEnabled && player.url"
+                          class="_button"
+                          :title="i18n.ts.enablePlayer"
+                          @click.prevent="playerEnabled = true"
+                        >
+                          <i class="ph-play-circle ph-bold ph-7x"></i>
+                        </button>
+                  </div>
+                  <article>
+                        <header>
+                          <h1 :title="title">
+                                <img v-if="icon" :src="icon" alt="Favicon" class="favicon" />
+                                {{ title }}
+                          </h1>
+                          <div class="amazon-brand" v-if="amazonBrand">{{ amazonBrand }}</div>
+                        </header>
+                        <p v-if="description" :title="description">
+                          {{
+                                description.length > 250
+                                  ? `${description.slice(0, 250)}…`
+                                  : description
+                          }}
+                        </p>
+                        <footer class="amazon-footer">
+                          <div class="amazon-price-row" v-if="amazonPriceText || amazonPrime">
+                                <span class="amazon-price" v-if="amazonPriceText">
+                                  {{ amazonPriceText }}
+                                </span>
+                                <span class="amazon-prime-badge" v-if="amazonPrime">Prime</span>
+                          </div>
+                          <div class="amazon-rating" v-if="amazonRatingValue !== null">
+                                <span class="amazon-star">★</span>
+                                <span class="amazon-rating-value">
+                                  {{ formatRatingValue(amazonRatingValue) }}
+                                </span>
+                                <span class="amazon-rating-best" v-if="amazonRatingBest">
+                                  / {{ amazonRatingBest }}
+                                </span>
+                                <span class="amazon-rating-count" v-if="amazonRatingCount !== null">
+                                  ({{ formatCountValue(amazonRatingCount) }})
+                                </span>
+                          </div>
+                          <div class="amazon-availability" v-if="amazonAvailability">
+                                {{ amazonAvailability }}
+                          </div>
+                        </footer>
+                  </article>
+                </component>
+          </transition>
+        </div>
+        <div
+          v-else-if="tweetId && tweetExpanded"
+          ref="twitter"
+          class="twitter"
+          @click.stop
 	>
 	  <iframe
 		ref="tweet"
@@ -217,9 +298,54 @@
 	}
   );
   
-  const self = props.url.startsWith(local);
-  const attr = self ? "to" : "href";
-  const target = self ? null : "_blank";
+const self = props.url.startsWith(local);
+const attr = self ? "to" : "href";
+const target = self ? null : "_blank";
+const normalizedLang = (lang || "ja-JP")
+  .replace("ja-KS", "ja-JP")
+  .replace("ja-KK", "ja-JP");
+
+function createNumberFormatter(
+  locale: string,
+  options?: Intl.NumberFormatOptions
+): Intl.NumberFormat {
+  try {
+    return new Intl.NumberFormat(locale, options);
+  } catch (error) {
+    console.warn("Failed to create Intl.NumberFormat", error);
+    return new Intl.NumberFormat("en-US", options);
+  }
+}
+
+const countFormatter = createNumberFormatter(normalizedLang);
+const ratingFormatter = createNumberFormatter(normalizedLang, {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const formatRatingValue = (value: number | null) =>
+  value == null ? "" : ratingFormatter.format(value).replace(/\.0$/, "");
+const formatCountValue = (value: number | null) =>
+  value == null ? "" : countFormatter.format(value);
+const formatCurrencyValue = (value: number | null, currency: string | null) => {
+  if (value == null || !currency) return null;
+  try {
+    return new Intl.NumberFormat(normalizedLang, {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch (error) {
+    console.warn("Failed to format currency", error);
+    try {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+      }).format(value);
+    } catch {
+      return value.toString();
+    }
+  }
+};
   let fetching = $ref(true);
   let title = $ref<string | null>(null);
   let description = $ref<string | null>(null);
@@ -238,58 +364,119 @@
   const embedId = `embed${Math.random().toString().replace(/\D/, "")}`;
   let tweetHeight = $ref(150);
   
-  // Steam専用のリアクティブ変数
-  let isSteam = $ref(false);
-  let steamAgeLimit = $ref<string | null>(null);
-  let steamGameName = $ref<string>("");
+// Steam専用のリアクティブ変数
+let isSteam = $ref(false);
+let steamAgeLimit = $ref<string | null>(null);
+let steamGameName = $ref<string>("");
   let steamDeveloper = $ref<string>("");
   let steamOnSale = $ref(false);
   let steamDiscount = $ref<number>(0);
   let steamOriginalPrice = $ref<string | null>(null);
   let steamCurrentPrice = $ref<string | null>(null);
-  let steamGenres = $ref<string>("");
-	let steamComingSoon = $ref(false);
-  let steamReleaseDate = $ref<string>("");
-  
-  // SteamファビコンのデフォルトURL（通常のfaviconを使用）
-  const defaultIcon = "https://store.steampowered.com/favicon.ico";
-  
-  // URL情報の取得
-  const fetchUrlData = async () => {
-	const requestLang = (lang || "ja-JP")
-	  .replace("ja-KS", "ja-JP")
-	  .replace("ja-KK", "ja-JP");
-  
-	try {
-	  const response = await fetch(
+let steamGenres = $ref<string>("");
+      let steamComingSoon = $ref(false);
+let steamReleaseDate = $ref<string>("");
+
+// Amazon専用のリアクティブ変数
+let isAmazon = $ref(false);
+let amazonAsin = $ref<string | null>(null);
+let amazonPriceText = $ref<string | null>(null);
+let amazonPriceValue = $ref<number | null>(null);
+let amazonPriceCurrency = $ref<string | null>(null);
+let amazonAvailability = $ref<string | null>(null);
+let amazonPrime = $ref(false);
+let amazonRatingValue = $ref<number | null>(null);
+let amazonRatingBest = $ref<number | null>(null);
+let amazonRatingCount = $ref<number | null>(null);
+let amazonBrand = $ref<string | null>(null);
+
+// SteamファビコンのデフォルトURL（通常のfaviconを使用）
+const defaultIcon = "https://store.steampowered.com/favicon.ico";
+
+// URL情報の取得
+const fetchUrlData = async () => {
+  const requestLang = normalizedLang;
+
+  // 状態の初期化
+  isSteam = false;
+  isAmazon = false;
+  steamAgeLimit = null;
+  steamGameName = "";
+  steamDeveloper = "";
+  steamOnSale = false;
+  steamDiscount = 0;
+  steamOriginalPrice = null;
+  steamCurrentPrice = null;
+  steamGenres = "";
+  steamComingSoon = false;
+  steamReleaseDate = "";
+  amazonAsin = null;
+  amazonPriceText = null;
+  amazonPriceValue = null;
+  amazonPriceCurrency = null;
+  amazonAvailability = null;
+  amazonPrime = false;
+  amazonRatingValue = null;
+  amazonRatingBest = null;
+  amazonRatingCount = null;
+  amazonBrand = null;
+  tweetId = null;
+  tweetExpanded = defaultStore.state.alwaysXExpand || props.detail;
+  playerEnabled = false;
+  showThumbnail = false;
+
+  try {
+    const response = await fetch(
 		`/url?url=${encodeURIComponent(props.url)}&lang=${requestLang}`
 	  );
 	  const info = await response.json();
 	  if (info.url == null) return;
   
 	  // Steamの場合の処理
-	  if (info.steam) {
-		isSteam = true;
-		steamGameName = info.title;
-		description = info.description;
-		icon = info.icon;
-		thumbnail = info.thumbnail;
-		steamAgeLimit = info.steam.ageLimit;
-		steamDeveloper = info.steam.developer;
-		steamOnSale = info.steam.onSale;
-		steamDiscount = info.steam.discountPercent;
-		steamOriginalPrice = info.steam.originalPrice;
-		steamCurrentPrice =
-		  info.steam.currentPrice ||
-		  (info.steam.isFree ? "無料プレイ" : "");
-		steamGenres = info.steam.genres;
-		steamComingSoon = !!info.steam.releaseDate.comingSoon;
-		steamReleaseDate = info.steam.releaseDate.date;
-	  } else {
-		// 既存の処理
-		title = info.title;
-		description = info.description;
-		thumbnail = info.thumbnail;
+        if (info.steam) {
+          isSteam = true;
+          steamGameName = info.title;
+          description = info.description;
+          icon = info.icon;
+          thumbnail = info.thumbnail;
+          steamAgeLimit = info.steam.ageLimit;
+          steamDeveloper = info.steam.developer;
+          steamOnSale = info.steam.onSale;
+          steamDiscount = info.steam.discountPercent;
+          steamOriginalPrice = info.steam.originalPrice;
+          steamCurrentPrice =
+            info.steam.currentPrice ||
+            (info.steam.isFree ? "無料プレイ" : "");
+          steamGenres = info.steam.genres;
+          steamComingSoon = !!info.steam.releaseDate.comingSoon;
+          steamReleaseDate = info.steam.releaseDate.date;
+        } else if (info.amazon) {
+          isAmazon = true;
+          title = info.title;
+          description = info.description;
+          thumbnail = info.thumbnail;
+          icon = info.icon;
+          sitename = info.sitename;
+          player = info.player;
+          amazonAsin = info.amazon.asin ?? null;
+          amazonPriceValue = info.amazon.price?.value ?? null;
+          amazonPriceCurrency = info.amazon.price?.currency ?? null;
+          amazonPriceText =
+            info.amazon.price?.display ??
+            (amazonPriceValue != null && amazonPriceCurrency
+              ? formatCurrencyValue(amazonPriceValue, amazonPriceCurrency)
+              : null);
+          amazonAvailability = info.amazon.availability ?? null;
+          amazonPrime = !!info.amazon.prime;
+          amazonRatingValue = info.amazon.rating?.value ?? null;
+          amazonRatingBest = info.amazon.rating?.best ?? null;
+          amazonRatingCount = info.amazon.rating?.count ?? null;
+          amazonBrand = info.amazon.brand ?? null;
+        } else {
+          // 既存の処理
+          title = info.title;
+          description = info.description;
+          thumbnail = info.thumbnail;
 		icon = info.icon;
 		sitename = info.sitename;
 		player = info.player;
@@ -318,17 +505,13 @@
 		  requestUrl.hostname = "www.youtube.com";
 		}
   
-		const requestLang = (lang || "ja-JP")
-		  .replace("ja-KS", "ja-JP")
-		  .replace("ja-KK", "ja-JP");
-  
-		requestUrl.hash = "";
-  
-		fetch(
-		  `/url?url=${encodeURIComponent(requestUrl.href)}&lang=${requestLang}`
-		).then((res) => {
-		  res.json().then((info) => {
-			if (info.url == null) return;
+                requestUrl.hash = "";
+
+                fetch(
+                  `/url?url=${encodeURIComponent(requestUrl.href)}&lang=${normalizedLang}`
+                ).then((res) => {
+                  res.json().then((info) => {
+                        if (info.url == null) return;
 			title = info.title;
 			description = info.description;
 			thumbnail = info.thumbnail;
@@ -671,11 +854,11 @@
 		}
 	  }
 	}
-	&.steam {
-	  .link {
-		pointer-events: none;
-		display: flex;
-		flex-direction: column;
+        &.steam {
+          .link {
+                pointer-events: none;
+                display: flex;
+                flex-direction: column;
   
 		.thumbnail {
 		  order: 1;
@@ -759,8 +942,117 @@
 			}
 		  }
 		}
-	  }
-	}
+          }
+        }
+        &.amazon {
+          .link {
+                pointer-events: none;
+                display: flex;
+                flex-direction: column;
+
+                .thumbnail {
+                  order: 1;
+                  pointer-events: none;
+                }
+
+                article {
+                  order: 2;
+                  pointer-events: auto;
+
+                  header {
+                        display: flex;
+                        flex-direction: column;
+                        align-items: flex-start;
+
+                        h1 {
+                          display: flex;
+                          align-items: center;
+                          margin: 0;
+                          font-size: 1em;
+                          overflow: visible;
+                          white-space: normal;
+                          word-break: normal;
+                          word-break: auto-phrase;
+
+                          .favicon {
+                                width: 24px;
+                                height: 24px;
+                                margin-right: 0.5rem;
+                          }
+                        }
+
+                        .amazon-brand {
+                          margin-top: 0.25rem;
+                          font-size: 0.9em;
+                          color: var(--fg);
+                          opacity: 0.8;
+                        }
+                  }
+
+                  p {
+                        overflow: visible;
+                        white-space: normal;
+                        word-break: normal;
+                        word-break: auto-phrase;
+                  }
+
+                  .amazon-footer {
+                        display: flex;
+                        flex-direction: column;
+                        gap: 0.35rem;
+                        font-size: 0.9em;
+
+                        .amazon-price-row {
+                          display: flex;
+                          align-items: center;
+                          gap: 0.5rem;
+
+                          .amazon-price {
+                                font-size: 1.15em;
+                                font-weight: 700;
+                                color: #c45500;
+                          }
+
+                          .amazon-prime-badge {
+                                display: inline-flex;
+                                align-items: center;
+                                gap: 0.2rem;
+                                padding: 0.1rem 0.35rem;
+                                border-radius: 0.25rem;
+                                font-size: 0.85em;
+                                font-weight: 700;
+                                background: linear-gradient(90deg, #00a8e1, #1f3b8f);
+                                color: #fff;
+                          }
+                        }
+
+                        .amazon-rating {
+                          display: flex;
+                          align-items: center;
+                          gap: 0.25rem;
+
+                          .amazon-star {
+                                color: #ffa41c;
+                                font-size: 1.1em;
+                          }
+
+                          .amazon-rating-value {
+                                font-weight: 600;
+                          }
+
+                          .amazon-rating-count {
+                                opacity: 0.8;
+                          }
+                        }
+
+                        .amazon-availability {
+                          color: var(--fg);
+                          opacity: 0.85;
+                        }
+                  }
+                }
+          }
+        }
   }
   </style>
-  
+


### PR DESCRIPTION
## 概要
- Amazon商品のURLを検出し、ページのJSON-LDから価格や在庫情報を抽出する処理を追加
- サムネイルやアイコンをプロキシ化した上でAmazon専用データを含むプレビューJSONを返すようURLプレビューAPIを拡張
- クライアントのURLプレビューにAmazon専用レイアウトを実装し、価格・Primeバッジ・評価・在庫状況などを表示

## テスト
- pnpm lint (依存関係不足のため packages/calckey-js サブパッケージで失敗)


------
https://chatgpt.com/codex/tasks/task_e_68d9e46ac540832692ce5565a134deab