### PR TITLE
アイコンジェネレーターで選択範囲をドラッグ可能にする

### DIFF
--- a/packages/client/src/pages/settings/profile.icon-generator.vue
+++ b/packages/client/src/pages/settings/profile.icon-generator.vue
@@ -738,7 +738,7 @@ function setupCropper() {
                 selection.aspectRatio = 1;
                 selection.initialAspectRatio = 1;
                 selection.initialCoverage = 1;
-                selection.movable = false;
+                selection.movable = true;
                 selection.resizable = true;
                 selection.keyboard = true;
                 selection.outlined = true;


### PR DESCRIPTION
## 概要
- アイコンジェネレーターのCropper設定を調整し、選択範囲をドラッグで移動できるようにしました

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68da3d3d6c98832686f90cfd640363c4