### PR TITLE
アイコンジェネレーターのcontain復元処理を改善

### DIFF
--- a/packages/client/src/pages/settings/profile.icon-generator.vue
+++ b/packages/client/src/pages/settings/profile.icon-generator.vue
@@ -26,7 +26,7 @@
                 <p class="description">{{ i18n.ts._profile.iconGeneratorDescription }}</p>
                 <div class="content">
                         <div class="cropper-area">
-                                <div class="cropper-panel">
+                                <div class="cropper-panel" :style="cropperPanelStyle">
                                         <div v-if="!selectedFile" class="empty">
                                                 <i class="ph-user-circle-plus ph-bold"></i>
                                                 <p>{{ i18n.ts._profile.iconGeneratorEmpty }}</p>
@@ -212,12 +212,20 @@ let pendingHistory: SelectionSnapshot | null = null;
 let historySuppressUntil = 0;
 let lastSelectionSnapshot: SelectionSnapshot | null = null;
 let pendingPreviewSnapshot: SelectionSnapshot | null = null;
+let imageAspectRatio = $ref(1);
 
 const canUndo = $computed(() => historyIndex > 0);
 const canRedo = $computed(
         () => historyIndex >= 0 && historyIndex < selectionHistory.length - 1,
 );
 type CropperHandleElement = HTMLElement & { action?: string };
+const cropperPanelStyle = $computed(() => {
+        const ratio = selectedFile ? imageAspectRatio : 1;
+        const safeRatio = Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
+        return {
+                "--cropper-panel-aspect": String(safeRatio),
+        };
+});
 
 let selectedFile = $ref<DriveFile | null>(null);
 let imgEl = $ref<HTMLImageElement | null>(null);
@@ -228,6 +236,8 @@ let cropperSelection: CropperSelection | null = null;
 let selectionChangeListener: ((event: Event) => void) | null = null;
 let canvasActionEndListener: ((event: Event) => void) | null = null;
 let imageTransformListener: ((event: Event) => void) | null = null;
+let containEnforcementFrame: number | null = null;
+let suppressContainEnforcement = false;
 let loading = $ref(false);
 let downloading = $ref(false);
 let previewUpdating = false;
@@ -256,6 +266,7 @@ function resetSelectionState() {
         cancelPendingHistory();
         lastSelectionSnapshot = null;
         pendingPreviewSnapshot = null;
+        imageAspectRatio = 1;
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -296,6 +307,65 @@ function getSelectionBounds(): SelectionBounds | null {
                 width: Math.round(canvasRect.width),
                 height: Math.round(canvasRect.height),
         };
+}
+
+function runWithContainSuppressed(callback: () => void) {
+        suppressContainEnforcement = true;
+        try {
+                callback();
+        } finally {
+                if (typeof window !== "undefined") {
+                        window.requestAnimationFrame(() => {
+                                suppressContainEnforcement = false;
+                        });
+                } else {
+                        suppressContainEnforcement = false;
+                }
+        }
+}
+
+function isImageOverflowing() {
+        if (!cropperCanvas || !cropperImage) return false;
+        const canvasRect = cropperCanvas.getBoundingClientRect();
+        const imageRect = cropperImage.getBoundingClientRect();
+        if (!canvasRect.width || !canvasRect.height) return false;
+        if (!imageRect.width || !imageRect.height) return false;
+
+        const epsilon = 0.5;
+        return (
+                imageRect.top < canvasRect.top - epsilon ||
+                imageRect.left < canvasRect.left - epsilon ||
+                imageRect.bottom > canvasRect.bottom + epsilon ||
+                imageRect.right > canvasRect.right + epsilon
+        );
+}
+
+function requestContainEnforcement() {
+        if (!cropperCanvas || !cropperImage) return;
+        if (typeof window === "undefined") return;
+        if (suppressContainEnforcement) return;
+        if (containEnforcementFrame != null) {
+                return;
+        }
+
+        containEnforcementFrame = window.requestAnimationFrame(() => {
+                containEnforcementFrame = null;
+                if (!cropperCanvas || !cropperImage) return;
+                if (suppressContainEnforcement) return;
+                if (!isImageOverflowing()) {
+                        return;
+                }
+                runWithContainSuppressed(() => {
+                        cropperImage?.$center("contain");
+                });
+        });
+}
+
+function cancelContainEnforcement() {
+        if (containEnforcementFrame != null && typeof window !== "undefined") {
+                window.cancelAnimationFrame(containEnforcementFrame);
+        }
+        containEnforcementFrame = null;
 }
 
 function clampSelectionSnapshot(snapshot: SelectionSnapshot): SelectionSnapshot {
@@ -641,6 +711,11 @@ async function pickImage(ev?: Event) {
 }
 
 function onImageLoad() {
+        if (imgEl?.naturalWidth && imgEl.naturalHeight) {
+                imageAspectRatio = imgEl.naturalWidth / imgEl.naturalHeight;
+        } else {
+                imageAspectRatio = 1;
+        }
         loading = false;
 }
 
@@ -702,7 +777,10 @@ function setupCropper() {
                         );
                 }
                 imageTransformListener = () => {
-                        if (!cropperSelection) return;
+                        requestContainEnforcement();
+                        if (!cropperSelection) {
+                                return;
+                        }
                         handleSelectionChange(false, {
                                 x: cropperSelection.x,
                                 y: cropperSelection.y,
@@ -756,7 +834,9 @@ function setupCropper() {
                         if (!cropperSelection || cropperSelection !== selection) {
                                 return;
                         }
-                        cropperImage?.$center("contain");
+                        runWithContainSuppressed(() => {
+                                cropperImage?.$center("contain");
+                        });
                         const bounds = getSelectionBounds();
                         if (bounds) {
                                 const size = Math.min(bounds.width, bounds.height);
@@ -792,6 +872,8 @@ function setupCropper() {
 }
 
 function destroyCropper() {
+        cancelContainEnforcement();
+        suppressContainEnforcement = false;
         if (cropperSelection && selectionChangeListener) {
                 cropperSelection.removeEventListener(
                         "change",
@@ -1048,8 +1130,13 @@ definePageMetadata({
 }
 
 .cropper-panel {
+        --cropper-panel-aspect: 1;
         position: relative;
-        min-height: 22rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        min-height: min(22rem, 70vh);
+        max-height: min(70vh, 40rem);
         min-width: 0;
         width: 100%;
         max-width: 100%;
@@ -1058,21 +1145,32 @@ definePageMetadata({
         border-radius: var(--radius);
         background: var(--panel);
         overflow: hidden;
+        aspect-ratio: var(--cropper-panel-aspect, 1);
 }
 
 .cropper-wrapper {
         position: relative;
+        display: flex;
+        flex: 1 1 auto;
         min-width: 0;
+        min-height: 0;
         max-width: 100%;
         width: 100%;
         height: 100%;
 
         > ::v-deep(.cropper-container) {
+                flex: 1 1 auto;
+                min-height: 0;
                 width: 100% !important;
                 max-width: 100%;
                 height: 100% !important;
         }
 
+}
+
+.cropper-panel > .empty {
+        flex: 1 1 auto;
+        width: 100%;
 }
 
 .cropper-container {


### PR DESCRIPTION
## Summary
- 画像変形監視でrequestAnimationFrameを利用してはみ出し検知後にcontain再センタリングを行うよう変更
- contain強制時に再帰呼び出しが発生しないよう抑止フラグとリスナー解放処理を追加

## Testing
- 未実施（テスト環境未整備のため）

------
https://chatgpt.com/codex/tasks/task_e_68da3bdf0f7c83268544b569dc1175a2