### PR TITLE
アイコンジェネレーターのcontain制御を修正

### DIFF
--- a/packages/client/src/pages/settings/profile.icon-generator.vue
+++ b/packages/client/src/pages/settings/profile.icon-generator.vue
@@ -243,6 +243,51 @@ let downloading = $ref(false);
 let previewUpdating = false;
 let previewPending = false;
 
+function ensureContainEnforcement() {
+        if (containEnforcementFrame != null) {
+                return;
+        }
+
+        const step = () => {
+                if (!cropperImage) {
+                        containEnforcementFrame = null;
+                        return;
+                }
+
+                if (!suppressContainEnforcement) {
+                        try {
+                                cropperImage?.$center("contain");
+                        } catch (err) {
+                                // noop - guard against unexpected runtime issues
+                        }
+                }
+
+                containEnforcementFrame = window.requestAnimationFrame(step);
+        };
+
+        containEnforcementFrame = window.requestAnimationFrame(step);
+}
+
+function cancelContainEnforcement() {
+        if (containEnforcementFrame != null) {
+                window.cancelAnimationFrame(containEnforcementFrame);
+                containEnforcementFrame = null;
+        }
+}
+
+function runWithContainSuppressed(callback: () => void) {
+        const previous = suppressContainEnforcement;
+        suppressContainEnforcement = true;
+        try {
+                callback();
+        } finally {
+                suppressContainEnforcement = previous;
+                if (!previous) {
+                        ensureContainEnforcement();
+                }
+        }
+}
+
 const imgUrl = $computed(() =>
         selectedFile
                 ? `${url}/proxy/image.webp?${query({ url: selectedFile.url })}`
@@ -718,6 +763,7 @@ function setupCropper() {
                         cropperImage.rotatable = false;
                         cropperImage.scalable = true;
                 }
+                ensureContainEnforcement();
                 cropperSelection = selection;
 
                 if (selectionChangeListener) {


### PR DESCRIPTION
## 概要
- Cropper画像のcontain維持を行うためのrequestAnimationFrameループを追加
- 抑制用のヘルパー関数とクリーンアップ処理を実装

## テスト
- なし


------
https://chatgpt.com/codex/tasks/task_e_68da4a5b95b08326b3cd8ff4d80d816c