### PR TITLE
fix: アイコンジェネレーターの操作とプレビューを調整

### DIFF
--- a/packages/client/src/pages/settings/profile.icon-generator.vue
+++ b/packages/client/src/pages/settings/profile.icon-generator.vue
@@ -847,9 +847,6 @@ function setupCropper() {
                         canvas.querySelector('cropper-handle[action="select"]'),
                         "none",
                 );
-                selection
-                        .querySelectorAll('cropper-handle[action="move"]')
-                        .forEach((handle) => setHandleAction(handle, "none"));
 
                 const initializeSelection = () => {
                         if (!cropperSelection || cropperSelection !== selection) {
@@ -1399,7 +1396,6 @@ definePageMetadata({
                 width: 100%;
                 height: 100%;
                 object-fit: cover;
-                image-rendering: pixelated;
         }
 
         > span {


### PR DESCRIPTION
## 概要
- アイコンジェネレーターの選択範囲ハンドル設定を見直し、ドラッグで移動できるように修正
- プレビュー画像の image-rendering を既存アイコンに合わせて自然な描画に変更

## テスト
- [ ] 未実施（開発環境の依存関係不足により起動失敗）

------
https://chatgpt.com/codex/tasks/task_e_68da4fbdf4708326991727226cfa8375