### PR TITLE
アイコンジェネレーターの追加プレビューを92pxに変更

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1934,7 +1934,7 @@ _profile:
   iconGenerator: "アイコンジェネレーター"
   iconGeneratorDescription: "画像を正方形に切り抜き、プレビューをリアルタイムで確認できます。"
   iconGeneratorEmpty: "まずは画像を選択してアイコン作りを始めましょう。"
-  iconGeneratorPreviewNote: "四角と丸の両方で、184・64・32ピクセルの表示をリアルタイムに確認できます。"
+  iconGeneratorPreviewNote: "四角と丸の両方で、184・92・64・32ピクセルの表示をリアルタイムに確認できます。"
   selectImage: "画像を選択"
   replaceImage: "別の画像を選ぶ"
   previewSquare: "四角"

--- a/packages/client/src/pages/settings/profile.icon-generator.vue
+++ b/packages/client/src/pages/settings/profile.icon-generator.vue
@@ -173,9 +173,10 @@ import * as os from "@/os";
 
 const router = useRouter();
 
-const previewSizes = [184, 64, 32] as const;
+const previewSizes = [184, 92, 64, 32] as const;
 const previewSources = reactive<Record<number, string | null>>({
         184: null,
+        92: null,
         64: null,
         32: null,
 });


### PR DESCRIPTION
## 概要
- アイコンジェネレーターの追加プレビューサイズを100pxから92pxに変更しました
- 日本語文言を新しいプレビューサイズに合わせて更新しました

## テスト
- 未実行

------
https://chatgpt.com/codex/tasks/task_e_68da539d5abc8326897ce9ed3a96d51a