### PR TITLE
他サーバー絵文字再取得の多重実行防止と再検索対応

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1306,6 +1306,7 @@ let singleTapEl = undefined;
 
 let waitingFlg = ref(false);
 let searchingFlg = ref(false);
+const refetchingRemoteEmojis = ref(false);
 let debounceTimer;
 
 watch(q, (nQ, oQ) => {
@@ -1776,26 +1777,39 @@ function done(query?: any): boolean | void {
 }
 
 async function refetchEmoji(showQueue = false) {
+        if (refetchingRemoteEmojis.value) return;
+
+        refetchingRemoteEmojis.value = true;
         const queueOptions = showQueue
                 ? { useQueue: true, comment: i18n.ts.remoteEmojiRefetching }
                 : undefined;
         let fetchModeMax = defaultStore.state.remoteEmojisFetch ?? "all";
-        if (fetchModeMax === "always") {
-                await set("emojiFetchAttemptDate", Date.now());
-                await fetchAllEmojiNoCache(queueOptions);
-        } else if (fetchModeMax === "all") {
-                await set("emojiFetchAttemptDate", Date.now());
-                await fetchAllEmoji(queueOptions).catch(() => {
-                        // 保存に失敗した場合は軽量版リモート絵文字の取得を試行
-                        fetchPlusEmoji(queueOptions);
-                });
-        } else if (fetchModeMax === "plus") {
-                await set("emojiFetchAttemptDate", Date.now());
-                await fetchPlusEmoji(queueOptions);
+        try {
+                if (fetchModeMax === "always") {
+                        await set("emojiFetchAttemptDate", Date.now());
+                        await fetchAllEmojiNoCache(queueOptions);
+                } else if (fetchModeMax === "all") {
+                        await set("emojiFetchAttemptDate", Date.now());
+                        await fetchAllEmoji(queueOptions).catch(() => {
+                                // 保存に失敗した場合は軽量版リモート絵文字の取得を試行
+                                fetchPlusEmoji(queueOptions);
+                        });
+                } else if (fetchModeMax === "plus") {
+                        await set("emojiFetchAttemptDate", Date.now());
+                        await fetchPlusEmoji(queueOptions);
+                }
+                // 絵文字を読み込み直す
+                await emojiLoad();
+
+                if (emojis.value?.isConnected && q.value != null) {
+                        const currentQuery = q.value;
+                        emojiSearch(currentQuery, currentQuery);
+                }
+
+                if (showQueue) os.toast(i18n.ts.remoteEmojiRefetched);
+        } finally {
+                refetchingRemoteEmojis.value = false;
         }
-        // 絵文字を読み込み直す
-        await emojiLoad();
-        if (showQueue) os.toast(i18n.ts.remoteEmojiRefetched);
 }
 
 onMounted(() => {


### PR DESCRIPTION
## 概要
- 他サーバー絵文字の手動取得中は再実行されないよう制御フラグを追加しました
- 絵文字再取得完了後にピッカーが表示されている場合は現在の検索語で再検索するようにしました

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68df1551eb4c832689287a9c09a58df7