### PR TITLE
他サーバー絵文字取得の自動再取得条件を修正

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -1203,19 +1203,20 @@ const search = ref<HTMLInputElement>();
 const emojis = ref<HTMLDivElement>();
 
 const {
-	reactions: pinned,
-	reactions2: pinned2,
-	reactions3: pinned3,
-	reactions4: pinned4,
-	reactions5: pinned5,
-	reactionPickerSize,
-	reactionPickerWidth,
-	reactionPickerHeight,
-	reactionPickerVAlign,
-	reactionPickerAllWidth,
-	disableShowingAnimatedImages,
-	recentlyUsedEmojis,
+        reactions: pinned,
+        reactions2: pinned2,
+        reactions3: pinned3,
+        reactions4: pinned4,
+        reactions5: pinned5,
+        reactionPickerSize,
+        reactionPickerWidth,
+        reactionPickerHeight,
+        reactionPickerVAlign,
+        reactionPickerAllWidth,
+        disableShowingAnimatedImages,
+        recentlyUsedEmojis,
 } = defaultStore.reactiveState;
+const defaultRemoteEmojisFetchMode = defaultStore.def.remoteEmojisFetch.default;
 
 const size = computed(() =>
 	props.asReactionPicker || defaultStore.state.usePickerSizePostForm
@@ -1278,10 +1279,10 @@ const randomSubset = computed(() => {
 	return result;
 });
 const recentlyMostUsed = computed(() => {
-	if (!instance.emojiStats) return [];
+        if (!instance.emojiStats) return [];
 
-	const pinnedValues = [
-		...pinned.value,
+        const pinnedValues = [
+                ...pinned.value,
 		...pinned2.value,
 		...pinned3.value,
 		...pinned4.value,
@@ -1310,13 +1311,20 @@ const refetchingRemoteEmojis = ref(false);
 let debounceTimer;
 
 watch(q, (nQ, oQ) => {
-	clearTimeout(debounceTimer);
+        clearTimeout(debounceTimer);
 
-	waitingFlg.value = true;
+        if (nQ?.includes("@") && defaultStore.isDefault("remoteEmojisFetch")) {
+                void (async () => {
+                        await defaultStore.set("remoteEmojisFetch", "all");
+                        await refetchEmoji();
+                })();
+        }
 
-	let searchInstant = false;
-	if (q.value.includes("*")) {
-		q.value = oQ;
+        waitingFlg.value = true;
+
+        let searchInstant = false;
+        if (q.value.includes("*")) {
+                q.value = oQ;
 	}
 	if (oQ?.includes("*")) {
 		searchInstant = true;
@@ -1783,7 +1791,8 @@ async function refetchEmoji(showQueue = false) {
         const queueOptions = showQueue
                 ? { useQueue: true, comment: i18n.ts.remoteEmojiRefetching }
                 : undefined;
-        let fetchModeMax = defaultStore.state.remoteEmojisFetch ?? "all";
+        let fetchModeMax =
+                defaultStore.state.remoteEmojisFetch ?? defaultRemoteEmojisFetchMode ?? "all";
         try {
                 if (fetchModeMax === "always") {
                         await set("emojiFetchAttemptDate", Date.now());

--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -606,7 +606,9 @@ const initializeEmoji = async () => {
 			? Number.parseInt(await get("emojiFetchAttemptDate"), 10)
 			: 0,
 	);
-	let fetchModeMax = defaultStore.state.remoteEmojisFetch ?? "all";
+	const defaultRemoteEmojisFetchMode = defaultStore.def.remoteEmojisFetch.default;
+	let fetchModeMax =
+		defaultStore.state.remoteEmojisFetch ?? defaultRemoteEmojisFetchMode ?? "all";
 	// 更新間隔 : データセーバーなら、24時間 そうでないなら、6時間
 	const fetchTimeBorder = defaultStore.state.enableDataSaverMode
 		? 1000 * 60 * 60 * 24

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -1151,7 +1151,7 @@ export const defaultStore = markRaw(
                 },
                 remoteEmojisFetch: {
                         where: "device",
-                        default: "all" as "all" | "plus" | "keep" | "none" | "always" | "once",
+                        default: "none" as "all" | "plus" | "keep" | "none" | "always" | "once",
                         createdAt: "2023/7/10",
                         page: "reaction",
 		},


### PR DESCRIPTION
## 概要
* 他サーバー絵文字取得設定のデフォルト値をオフに変更しました
* 絵文字ピッカーで初めて@を入力した際に設定が既定値のままなら全取得へ切り替えて再取得するようにし、その判定をdefaultStore.isDefault("remoteEmojisFetch")で行うよう修正しました
* 起動時のリモート絵文字取得処理で新しいデフォルト値を参照するようにしました


------
https://chatgpt.com/codex/tasks/task_e_68df172ab67083268a294c9b01bc6493