### PR TITLE
URLプレビューの通常表示でタイトルと概要を2行に制限

### DIFF
--- a/packages/client/src/components/MkUrlPreview.vue
+++ b/packages/client/src/components/MkUrlPreview.vue
@@ -746,16 +746,26 @@ const fetchUrlData = async () => {
 		> header {
 		  margin-bottom: 0.5rem;
   
-		  > h1 {
-			margin: 0;
-			font-size: 1em;
-		  }
-		}
-  
-		> p {
-		  margin: 0;
-		  font-size: 0.8em;
-		}
+                  > h1 {
+                        margin: 0;
+                        font-size: 1em;
+                        overflow: hidden;
+                        display: -webkit-box;
+                        -webkit-line-clamp: 2;
+                        -webkit-box-orient: vertical;
+                        word-break: break-word;
+                  }
+                }
+
+                > p {
+                  margin: 0;
+                  font-size: 0.8em;
+                  overflow: hidden;
+                  display: -webkit-box;
+                  -webkit-line-clamp: 2;
+                  -webkit-box-orient: vertical;
+                  word-break: break-word;
+                }
   
 		> footer {
 		  margin-top: 0.5rem;


### PR DESCRIPTION
## 概要
- 通常のURLプレビューで表示されるタイトルに2行のラインクランプを適用
- 同プレビューで表示される概要文も2行に収めるようスタイルを調整

## テスト
- なし


------
https://chatgpt.com/codex/tasks/task_e_68df4fb1c0dc83268d4bddc6a652fea2