### PR TITLE
SteamプレビューのDeepL翻訳対応

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/translate.ts
+++ b/packages/backend/src/server/api/endpoints/notes/translate.ts
@@ -1,9 +1,8 @@
-import { URLSearchParams } from "node:url";
 import fetch from "node-fetch";
-import config from "@/config/index.js";
-import { getAgentByUrl } from "@/misc/fetch.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
+import { getAgentByUrl } from "@/misc/fetch.js";
 import { Notes } from "@/models/index.js";
+import { translateWithDeepl } from "@/services/translation/deepl.js";
 import { ApiError } from "../../error.js";
 import { getNote } from "../../common/getters.js";
 import define from "../../define.js";
@@ -97,37 +96,18 @@ export default define(meta, paramDef, async (ps, user) => {
 		};
 	}
 
-	const params = new URLSearchParams();
-	params.append("auth_key", instance.deeplAuthKey ?? "");
-	params.append("text", note.text);
-	params.append("target_lang", targetLang);
+        const translation = await translateWithDeepl(
+                note.text,
+                targetLang.toUpperCase(),
+                instance,
+        );
 
-	const endpoint = instance.deeplIsPro
-		? "https://api.deepl.com/v2/translate"
-		: "https://api-free.deepl.com/v2/translate";
+        if (!translation) {
+                return 204;
+        }
 
-	const res = await fetch(endpoint, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-			"User-Agent": config.userAgent,
-			Accept: "application/json, */*",
-		},
-		body: params,
-		// TODO
-		//timeout: 10000,
-		agent: getAgentByUrl,
-	});
-
-	const json = (await res.json()) as {
-		translations: {
-			detected_source_language: string;
-			text: string;
-		}[];
-	};
-
-	return {
-		sourceLang: json.translations[0].detected_source_language,
-		text: json.translations[0].text,
-	};
+        return {
+                sourceLang: translation.sourceLang ?? undefined,
+                text: translation.text,
+        };
 });

--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -6,6 +6,13 @@ import Logger from "@/services/logger.js";
 import config from "@/config/index.js";
 import { query } from "@/prelude/url.js";
 import { getHtml, getJson } from "@/misc/fetch.js";
+import { translateWithDeepl } from "@/services/translation/deepl.js";
+
+const JAPANESE_CHAR_REGEX = /[\u3000-\u303f\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9faf\uf900-\ufa6d\uff66-\uff9f]/u;
+
+function containsJapanese(text: string): boolean {
+  return JAPANESE_CHAR_REGEX.test(text);
+}
 
 const logger = new Logger("url-preview");
 
@@ -117,7 +124,22 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
           },
         };
 
-		/*
+        if (
+          summary.description &&
+          meta.deeplAuthKey &&
+          !containsJapanese(summary.description)
+        ) {
+          const translated = await translateWithDeepl(
+            summary.description,
+            "JA",
+            meta,
+          );
+          if (translated?.text) {
+            summary.description = translated.text;
+          }
+        }
+
+                /*
         // 動画情報をplayerにセット
         if (appData.movies && Array.isArray(appData.movies)) {
           const highlightedMovies = appData.movies.filter(
@@ -238,6 +260,21 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
 			}
           },
         };
+        if (
+          summary.description &&
+          meta.deeplAuthKey &&
+          !containsJapanese(summary.description)
+        ) {
+          const translated = await translateWithDeepl(
+            summary.description,
+            "JA",
+            meta,
+          );
+          if (translated?.text) {
+            summary.description = translated.text;
+          }
+        }
+
 
         // サムネイルとアイコンをラップ
         summary.icon = wrap(_summary.icon) ?? "";

--- a/packages/backend/src/services/translation/deepl.ts
+++ b/packages/backend/src/services/translation/deepl.ts
@@ -1,0 +1,66 @@
+import { URLSearchParams } from "node:url";
+import fetch from "node-fetch";
+
+import config from "@/config/index.js";
+import { getAgentByUrl } from "@/misc/fetch.js";
+import { fetchMeta } from "@/misc/fetch-meta.js";
+import type { Meta } from "@/models/entities/meta.js";
+
+export interface DeeplTranslationResult {
+  text: string;
+  sourceLang: string | null;
+}
+
+export async function translateWithDeepl(
+  text: string,
+  targetLang: string,
+  instance?: Meta,
+): Promise<DeeplTranslationResult | null> {
+  const meta = instance ?? (await fetchMeta());
+
+  if (!meta.deeplAuthKey) {
+    return null;
+  }
+
+  const normalizedTarget = targetLang.toUpperCase();
+
+  const params = new URLSearchParams();
+  params.append("auth_key", meta.deeplAuthKey ?? "");
+  params.append("text", text);
+  params.append("target_lang", normalizedTarget);
+
+  const endpoint = meta.deeplIsPro
+    ? "https://api.deepl.com/v2/translate"
+    : "https://api-free.deepl.com/v2/translate";
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": config.userAgent,
+      Accept: "application/json, */*",
+    },
+    body: params,
+    agent: getAgentByUrl,
+  });
+
+  if (!res.ok) {
+    return null;
+  }
+
+  const json = (await res.json()) as {
+    translations: {
+      detected_source_language: string;
+      text: string;
+    }[];
+  };
+
+  if (!json.translations?.length) {
+    return null;
+  }
+
+  return {
+    sourceLang: json.translations[0].detected_source_language,
+    text: json.translations[0].text,
+  };
+}


### PR DESCRIPTION
## 概要
- Steam向けURLプレビューで日本語が含まれない概要文をDeepLで自動翻訳するようにしました
- DeepL翻訳処理をサービスとして切り出し、ノート翻訳APIでも共通利用するようにしました

## テスト
- `pnpm lint --filter backend`（依存関係未インストールのため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68df93bafa348326b3a2946260bd053e