### PR TITLE
DeepL翻訳プレフィックスを言語コード表記に変更

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/translate.ts
+++ b/packages/backend/src/server/api/endpoints/notes/translate.ts
@@ -1,9 +1,11 @@
-import { URLSearchParams } from "node:url";
 import fetch from "node-fetch";
-import config from "@/config/index.js";
-import { getAgentByUrl } from "@/misc/fetch.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
+import { getAgentByUrl } from "@/misc/fetch.js";
 import { Notes } from "@/models/index.js";
+import {
+        translateWithDeepl,
+        formatDeeplTranslationPrefix,
+} from "@/services/translation/deepl.js";
 import { ApiError } from "../../error.js";
 import { getNote } from "../../common/getters.js";
 import define from "../../define.js";
@@ -97,37 +99,18 @@ export default define(meta, paramDef, async (ps, user) => {
 		};
 	}
 
-	const params = new URLSearchParams();
-	params.append("auth_key", instance.deeplAuthKey ?? "");
-	params.append("text", note.text);
-	params.append("target_lang", targetLang);
+        const translation = await translateWithDeepl(
+                note.text,
+                targetLang.toUpperCase(),
+                instance,
+        );
 
-	const endpoint = instance.deeplIsPro
-		? "https://api.deepl.com/v2/translate"
-		: "https://api-free.deepl.com/v2/translate";
+        if (!translation) {
+                return 204;
+        }
 
-	const res = await fetch(endpoint, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-			"User-Agent": config.userAgent,
-			Accept: "application/json, */*",
-		},
-		body: params,
-		// TODO
-		//timeout: 10000,
-		agent: getAgentByUrl,
-	});
-
-	const json = (await res.json()) as {
-		translations: {
-			detected_source_language: string;
-			text: string;
-		}[];
-	};
-
-	return {
-		sourceLang: json.translations[0].detected_source_language,
-		text: json.translations[0].text,
-	};
+        return {
+                sourceLang: translation.sourceLang ?? undefined,
+                text: `${formatDeeplTranslationPrefix(translation.sourceLang)} ${translation.text}`,
+        };
 });

--- a/packages/backend/src/server/api/endpoints/notes/translate.ts
+++ b/packages/backend/src/server/api/endpoints/notes/translate.ts
@@ -1,7 +1,6 @@
 import fetch from "node-fetch";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import { getAgentByUrl } from "@/misc/fetch.js";
-import { Notes } from "@/models/index.js";
 import {
         translateWithDeepl,
         formatDeeplTranslationPrefix,
@@ -93,10 +92,12 @@ export default define(meta, paramDef, async (ps, user) => {
 			translatedText: string;
 		};
 
-		return {
-			sourceLang: json.detectedLanguage?.language,
-			text: json.translatedText,
-		};
+                const sourceLang = json.detectedLanguage?.language ?? null;
+
+                return {
+                        sourceLang: sourceLang ?? undefined,
+                        text: `${formatDeeplTranslationPrefix(sourceLang)} ${json.translatedText}`,
+                };
 	}
 
         const translation = await translateWithDeepl(

--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -6,6 +6,16 @@ import Logger from "@/services/logger.js";
 import config from "@/config/index.js";
 import { query } from "@/prelude/url.js";
 import { getHtml, getJson } from "@/misc/fetch.js";
+import {
+  translateWithDeepl,
+  formatDeeplTranslationPrefix,
+} from "@/services/translation/deepl.js";
+
+const JAPANESE_CHAR_REGEX = /[\u3000-\u303f\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9faf\uf900-\ufa6d\uff66-\uff9f]/u;
+
+function containsJapanese(text: string): boolean {
+  return JAPANESE_CHAR_REGEX.test(text);
+}
 
 const logger = new Logger("url-preview");
 
@@ -117,7 +127,23 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
           },
         };
 
-		/*
+        if (
+          summary.description &&
+          meta.deeplAuthKey &&
+          !containsJapanese(summary.description)
+        ) {
+          const translated = await translateWithDeepl(
+            summary.description,
+            "JA",
+            meta,
+          );
+          if (translated?.text) {
+            const prefix = formatDeeplTranslationPrefix(translated.sourceLang);
+            summary.description = `${prefix} ${translated.text}`;
+          }
+        }
+
+                /*
         // 動画情報をplayerにセット
         if (appData.movies && Array.isArray(appData.movies)) {
           const highlightedMovies = appData.movies.filter(
@@ -238,6 +264,22 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
 			}
           },
         };
+        if (
+          summary.description &&
+          meta.deeplAuthKey &&
+          !containsJapanese(summary.description)
+        ) {
+          const translated = await translateWithDeepl(
+            summary.description,
+            "JA",
+            meta,
+          );
+          if (translated?.text) {
+            const prefix = formatDeeplTranslationPrefix(translated.sourceLang);
+            summary.description = `${prefix} ${translated.text}`;
+          }
+        }
+
 
         // サムネイルとアイコンをラップ
         summary.icon = wrap(_summary.icon) ?? "";

--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -10,11 +10,34 @@ import {
   translateWithDeepl,
   formatDeeplTranslationPrefix,
 } from "@/services/translation/deepl.js";
+import type { Meta } from "@/models/entities/meta.js";
 
 const JAPANESE_CHAR_REGEX = /[\u3000-\u303f\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9faf\uf900-\ufa6d\uff66-\uff9f]/u;
 
 function containsJapanese(text: string): boolean {
   return JAPANESE_CHAR_REGEX.test(text);
+}
+
+async function translateDescriptionToJapaneseIfNeeded(
+  description: string | null | undefined,
+  meta: Meta,
+): Promise<string | null | undefined> {
+  if (description == null || description === "") {
+    return description;
+  }
+
+  if (!meta.deeplAuthKey || containsJapanese(description)) {
+    return description;
+  }
+
+  const translated = await translateWithDeepl(description, "JA", meta);
+
+  if (!translated?.text) {
+    return description;
+  }
+
+  const prefix = formatDeeplTranslationPrefix(translated.sourceLang);
+  return `${prefix} ${translated.text}`;
 }
 
 const logger = new Logger("url-preview");
@@ -127,21 +150,10 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
           },
         };
 
-        if (
-          summary.description &&
-          meta.deeplAuthKey &&
-          !containsJapanese(summary.description)
-        ) {
-          const translated = await translateWithDeepl(
-            summary.description,
-            "JA",
-            meta,
-          );
-          if (translated?.text) {
-            const prefix = formatDeeplTranslationPrefix(translated.sourceLang);
-            summary.description = `${prefix} ${translated.text}`;
-          }
-        }
+        summary.description = await translateDescriptionToJapaneseIfNeeded(
+          summary.description,
+          meta,
+        );
 
                 /*
         // 動画情報をplayerにセット
@@ -264,21 +276,10 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
 			}
           },
         };
-        if (
-          summary.description &&
-          meta.deeplAuthKey &&
-          !containsJapanese(summary.description)
-        ) {
-          const translated = await translateWithDeepl(
-            summary.description,
-            "JA",
-            meta,
-          );
-          if (translated?.text) {
-            const prefix = formatDeeplTranslationPrefix(translated.sourceLang);
-            summary.description = `${prefix} ${translated.text}`;
-          }
-        }
+        summary.description = await translateDescriptionToJapaneseIfNeeded(
+          summary.description,
+          meta,
+        );
 
 
         // サムネイルとアイコンをラップ

--- a/packages/backend/src/services/translation/deepl.ts
+++ b/packages/backend/src/services/translation/deepl.ts
@@ -1,0 +1,77 @@
+import { URLSearchParams } from "node:url";
+import fetch from "node-fetch";
+
+import config from "@/config/index.js";
+import { getAgentByUrl } from "@/misc/fetch.js";
+import { fetchMeta } from "@/misc/fetch-meta.js";
+import type { Meta } from "@/models/entities/meta.js";
+
+export interface DeeplTranslationResult {
+  text: string;
+  sourceLang: string | null;
+}
+
+export function formatDeeplTranslationPrefix(sourceLang: string | null): string {
+  if (!sourceLang) {
+    return "??から翻訳:";
+  }
+
+  const normalized = sourceLang.toUpperCase();
+  const base = normalized.split("-")[0] || normalized;
+
+  return `${base}から翻訳:`;
+}
+
+export async function translateWithDeepl(
+  text: string,
+  targetLang: string,
+  instance?: Meta,
+): Promise<DeeplTranslationResult | null> {
+  const meta = instance ?? (await fetchMeta());
+
+  if (!meta.deeplAuthKey) {
+    return null;
+  }
+
+  const normalizedTarget = targetLang.toUpperCase();
+
+  const params = new URLSearchParams();
+  params.append("auth_key", meta.deeplAuthKey ?? "");
+  params.append("text", text);
+  params.append("target_lang", normalizedTarget);
+
+  const endpoint = meta.deeplIsPro
+    ? "https://api.deepl.com/v2/translate"
+    : "https://api-free.deepl.com/v2/translate";
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": config.userAgent,
+      Accept: "application/json, */*",
+    },
+    body: params,
+    agent: getAgentByUrl,
+  });
+
+  if (!res.ok) {
+    return null;
+  }
+
+  const json = (await res.json()) as {
+    translations: {
+      detected_source_language: string;
+      text: string;
+    }[];
+  };
+
+  if (!json.translations?.length) {
+    return null;
+  }
+
+  return {
+    sourceLang: json.translations[0].detected_source_language,
+    text: json.translations[0].text,
+  };
+}

--- a/packages/backend/src/services/translation/deepl.ts
+++ b/packages/backend/src/services/translation/deepl.ts
@@ -16,10 +16,15 @@ export function formatDeeplTranslationPrefix(sourceLang: string | null): string 
     return "??から翻訳:";
   }
 
-  const normalized = sourceLang.toUpperCase();
+  const normalized = sourceLang.trim().toLowerCase();
   const base = normalized.split("-")[0] || normalized;
+  const short = base.length > 2 ? base.slice(0, 2) : base;
 
-  return `${base}から翻訳:`;
+  if (!short) {
+    return "??から翻訳:";
+  }
+
+  return `${short}から翻訳:`;
 }
 
 export async function translateWithDeepl(


### PR DESCRIPTION
## 概要
- DeepL翻訳結果から言語名を取得して日本語プレフィックスを付ける共通処理を追加しました
- Steam向けURLプレビューとノート翻訳APIでDeepL翻訳文の先頭にプレフィックスを付与しました
- DeepL翻訳プレフィックスの表記を日本語名ではなく言語コード（2文字）に変更しました

## テスト
- なし


------
https://chatgpt.com/codex/tasks/task_e_68df93bafa348326b3a2946260bd053e