### PR TITLE
リアクション検索の計算量を線形に最適化

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -435,24 +435,26 @@ export const NoteRepository = db.getRepository(Note).extend({
 		if (notes.length === 0) return [];
 
 		const meId = me ? me.id : null;
-		const myReactionsMap = new Map<Note["id"], NoteReaction | null>();
-		if (meId) {
-			const renoteIds = notes
-				.filter((n) => n.renoteId != null)
-				.map((n) => n.renoteId!);
-			const targets = [...notes.map((n) => n.id), ...renoteIds];
-			const myReactions = await NoteReactions.findBy({
-				userId: meId,
-				noteId: In(targets),
-			});
+                const myReactionsMap = new Map<Note["id"], NoteReaction | null>();
+                if (meId) {
+                        const renoteIds = notes
+                                .filter((n) => n.renoteId != null)
+                                .map((n) => n.renoteId!);
+                        const targets = [...notes.map((n) => n.id), ...renoteIds];
+                        const myReactions = await NoteReactions.findBy({
+                                userId: meId,
+                                noteId: In(targets),
+                        });
 
-			for (const target of targets) {
-				myReactionsMap.set(
-					target,
-					myReactions.find((reaction) => reaction.noteId === target) || null,
-				);
-			}
-		}
+                        const myReactionsByNoteId = new Map<Note["id"], NoteReaction>();
+                        for (const reaction of myReactions) {
+                                myReactionsByNoteId.set(reaction.noteId, reaction);
+                        }
+
+                        for (const target of targets) {
+                                myReactionsMap.set(target, myReactionsByNoteId.get(target) ?? null);
+                        }
+                }
 
 		await prefetchEmojis(aggregateNoteEmojis(notes));
 


### PR DESCRIPTION
## 概要
- packMany 内で取得した myReactions を一度だけ走査して noteId をキーにした Map を構築
- targets のループでは Map.get を利用し、存在しない場合は null を設定することで計算量を O(n) に改善

## テスト
- 未実施（ロジック変更のみ）

------
https://chatgpt.com/codex/tasks/task_e_68e3767410e083268c8e00612b61ac7f