### PR TITLE
通知配信時のミュート取得を事前バッチ化

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -112,25 +112,39 @@ class NotificationManager {
 		}
 	}
 
-	public async deliver() {
-		for (const x of this.queue) {
-			// ミュート情報を取得
-			const mentioneeMutes = await Mutings.findBy({
-				muterId: x.target,
-			});
+        public async deliver() {
+                const targets = [...new Set(this.queue.map((x) => x.target))];
 
-			const mentioneesMutedUserIds = mentioneeMutes.map((m) => m.muteeId);
+                const mentioneeMutes =
+                        targets.length === 0
+                                ? []
+                                : await Mutings.findBy({
+                                          muterId: In(targets),
+                                  });
 
-			// 通知される側のユーザーが通知する側のユーザーをミュートしていない限りは通知する
-			if (!mentioneesMutedUserIds.includes(this.notifier.id)) {
-				createNotification(x.target, x.reason, {
-					notifierId: this.notifier.id,
-					noteId: this.note.id,
-					note: this.note,
-				});
-			}
-		}
-	}
+                const mentioneeMutesMap = new Map<ILocalUser["id"], User["id"][]>();
+
+                for (const mute of mentioneeMutes) {
+                        if (!mentioneeMutesMap.has(mute.muterId)) {
+                                mentioneeMutesMap.set(mute.muterId, []);
+                        }
+
+                        mentioneeMutesMap.get(mute.muterId)!.push(mute.muteeId);
+                }
+
+                for (const x of this.queue) {
+                        const mentioneesMutedUserIds = mentioneeMutesMap.get(x.target) ?? [];
+
+                        // 通知される側のユーザーが通知する側のユーザーをミュートしていない限りは通知する
+                        if (!mentioneesMutedUserIds.includes(this.notifier.id)) {
+                                createNotification(x.target, x.reason, {
+                                        notifierId: this.notifier.id,
+                                        noteId: this.note.id,
+                                        note: this.note,
+                                });
+                        }
+                }
+        }
 }
 
 type MinimumUser = {


### PR DESCRIPTION
## 概要
- 通知キュー内の対象ユーザーをまとめて抽出し、ミュート情報を一括取得するように変更
- 取得したミュート情報を target ごとの Map に変換して通知送信時の判定に利用
- ループ内での不要な await を排除し逐次実行を防止

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68e378793e7c8326bee10eef6aa069e5