### PR TITLE
generateAlts内でのthumbnail初期化順序を修正

### DIFF
--- a/packages/backend/src/services/drive/add-file.ts
+++ b/packages/backend/src/services/drive/add-file.ts
@@ -312,7 +312,8 @@ export async function generateAlts(
 	}
 
 	// #region webpublic
-	let webpublic: IImage | null = null;
+        let webpublic: IImage | null = null;
+        let thumbnail: IImage | null = null;
 
         const needWebpublic = generateWeb && !satisfyWebpublic;
         const needThumbnail =
@@ -411,8 +412,6 @@ export async function generateAlts(
 	// #endregion webpublic
 
 	// #region thumbnail
-	let thumbnail: IImage | null = null;
-
         if (!(needWebpublic && needThumbnail)) {
                 try {
                         if (needThumbnail) {


### PR DESCRIPTION
## 概要
- generateAlts内でthumbnail変数を先に初期化するように修正し、初期化前参照エラーを防止

## テスト
- テストは未実施（コード修正のみ）

------
https://chatgpt.com/codex/tasks/task_e_68e37eb897cc8326b45f61bdb33641cf