### PR TITLE
リモートユーザーのピン留め更新時の重複挿入を防ぐ

### DIFF
--- a/packages/backend/src/remote/activitypub/models/person.ts
+++ b/packages/backend/src/remote/activitypub/models/person.ts
@@ -996,23 +996,27 @@ export async function updateFeatured(userId: User["id"], resolver?: Resolver) {
 			.map((item) => limit(() => resolveNote(item, resolver))),
 	);
 
-	await db.transaction(async (transactionalEntityManager) => {
-		await transactionalEntityManager.delete(UserNotePining, {
-			userId: user.id,
-		});
+        await db.transaction(async (transactionalEntityManager) => {
+                await transactionalEntityManager.delete(UserNotePining, {
+                        userId: user.id,
+                });
 
-		// For now, generate the id at a different time and maintain the order.
-		let td = 0;
-		for (const note of featuredNotes.filter((note) => note != null)) {
-			td -= 1000;
-			transactionalEntityManager.insert(UserNotePining, {
-				id: genId(new Date(Date.now() + td)),
-				createdAt: new Date(),
-				userId: user.id,
-				noteId: note!.id,
-			});
-		}
-	});
+                // For now, generate the id at a different time and maintain the order.
+                let td = 0;
+                const insertedNoteIds = new Set<string>();
+                for (const note of featuredNotes.filter((note) => note != null)) {
+                        if (insertedNoteIds.has(note!.id)) continue;
+                        insertedNoteIds.add(note!.id);
+
+                        td -= 1000;
+                        await transactionalEntityManager.insert(UserNotePining, {
+                                id: genId(new Date(Date.now() + td)),
+                                createdAt: new Date(),
+                                userId: user.id,
+                                noteId: note!.id,
+                        });
+                }
+        });
 }
 
 function getSkebGenreIcon(genre: string) {


### PR DESCRIPTION
## 概要
- ActivityPub の featured ノート更新時に重複するノート ID をスキップ
- ピン留めレコード挿入を await してトランザクション内での順序と整合性を保証

## テスト
- テスト未実行（ローカル環境なし）

------
https://chatgpt.com/codex/tasks/task_e_68e38fb6d0188326a7e85e23908fafe3