### PR TITLE
リモートユーザのピン更新競合を回避

### DIFF
--- a/packages/backend/src/remote/activitypub/models/person.ts
+++ b/packages/backend/src/remote/activitypub/models/person.ts
@@ -1009,12 +1009,33 @@ export async function updateFeatured(userId: User["id"], resolver?: Resolver) {
                         insertedNoteIds.add(note!.id);
 
                         td -= 1000;
-                        await transactionalEntityManager.insert(UserNotePining, {
-                                id: genId(new Date(Date.now() + td)),
-                                createdAt: new Date(),
-                                userId: user.id,
-                                noteId: note!.id,
-                        });
+                        const id = genId(new Date(Date.now() + td));
+                        const createdAt = new Date();
+
+                        try {
+                                await transactionalEntityManager.insert(UserNotePining, {
+                                        id,
+                                        createdAt,
+                                        userId: user.id,
+                                        noteId: note!.id,
+                                });
+                        } catch (err) {
+                                if (isDuplicateKeyValueError(err)) {
+                                        await transactionalEntityManager.update(
+                                                UserNotePining,
+                                                {
+                                                        userId: user.id,
+                                                        noteId: note!.id,
+                                                },
+                                                {
+                                                        id,
+                                                        createdAt,
+                                                },
+                                        );
+                                } else {
+                                        throw err;
+                                }
+                        }
                 }
         });
 }

--- a/packages/backend/src/services/i/pin.ts
+++ b/packages/backend/src/services/i/pin.ts
@@ -67,10 +67,11 @@ export async function addPinned(
                                 noteId: note.id,
                         } as UserNotePining);
                 } catch (err) {
-                        if (
-                                err instanceof QueryFailedError &&
-                                err.driverError?.code === "23505"
-                        ) {
+                        const driverErrorCode =
+                                (err as QueryFailedError)?.driverError?.code ??
+                                (err as { code?: string }).code;
+
+                        if (driverErrorCode === "23505") {
                                 // 挿入競合時は既存レコードを更新
                                 await updateExisting();
                         } else {


### PR DESCRIPTION
## 概要
- リモートユーザのfeatured更新処理でピン挿入が重複した際に既存レコードを更新するように変更
- リモートユーザ情報の更新時に発生していた一意制約エラーを防止

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68e3911e11408326b1c7652f5528321d