### PR TITLE
ハッシュタグトレンド集計のuserId参照修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/hashtags/trend.ts
+++ b/packages/backend/src/server/api/endpoints/hashtags/trend.ts
@@ -156,7 +156,7 @@ export default define(meta, paramDef, async () => {
         const bucketCountsRaw = await Notes.createQueryBuilder()
                 .select("tag", "tag")
                 .addSelect("bucket", "bucket")
-                .addSelect("COUNT(DISTINCT userId)", "count")
+                .addSelect("COUNT(DISTINCT \"tagged_notes\".\"userId\")", "count")
                 .from(`(${bucketizedNotesQb.getQuery()})`, "tagged_notes")
                 .where("tag = ANY(:hots)", { hots })
                 .groupBy("tag")
@@ -198,7 +198,7 @@ export default define(meta, paramDef, async () => {
 
         const totalCountsRaw = await Notes.createQueryBuilder()
                 .select("tag", "tag")
-                .addSelect("COUNT(DISTINCT userId)", "count")
+                .addSelect("COUNT(DISTINCT \"recent_tagged\".\"userId\")", "count")
                 .from(`(${totalsSubQuery.getQuery()})`, "recent_tagged")
                 .where("tag = ANY(:hots)", { hots })
                 .groupBy("tag")


### PR DESCRIPTION
## 概要
- ハッシュタグトレンド集計クエリでサブクエリのuserId列を明示的に引用し、存在しない列エラーを防止

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68e3926850788326be58c9077d766339