### PR TITLE
リモートユーザ画像のmediaproxyフォールバック

### DIFF
--- a/packages/client/src/components/MkUserInfo.vue
+++ b/packages/client/src/components/MkUserInfo.vue
@@ -1,11 +1,6 @@
 <template>
 	<div class="_panel vjnjpkug">
-		<div
-			class="banner"
-			:style="
-				user.bannerUrl ? `background-image: url(${user.bannerUrl})` : ''
-			"
-		></div>
+                <div class="banner" :style="bannerStyle"></div>
 		<MkAvatar
 			class="avatar"
 			:user="user"
@@ -61,15 +56,28 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from "vue";
 import * as misskey from "calckey-js";
 import MkFollowButton from "@/components/MkFollowButton.vue";
 import MkNumber from "@/components/MkNumber.vue";
 import { userPage } from "@/filters/user";
 import { i18n } from "@/i18n";
+import { useRemoteImageWithProxy } from "@/scripts/use-remote-image-with-proxy";
 
-defineProps<{
-	user: misskey.entities.UserDetailed;
+const props = defineProps<{
+        user: misskey.entities.UserDetailed;
 }>();
+
+const bannerImageUrl = useRemoteImageWithProxy(
+        () => props.user.bannerUrl ?? null,
+        () => props.user.host != null,
+);
+
+const bannerStyle = computed(() =>
+        bannerImageUrl.value ? `background-image: url(${bannerImageUrl.value})` : "",
+);
+
+const user = computed(() => props.user);
 </script>
 
 <style lang="scss" scoped>

--- a/packages/client/src/components/MkUserPreview.vue
+++ b/packages/client/src/components/MkUserPreview.vue
@@ -20,14 +20,7 @@
 			"
 		>
 			<div v-if="user != null" class="info">
-				<div
-					class="banner"
-					:style="
-						user.bannerUrl
-							? `background-image: url(${user.bannerUrl})`
-							: ''
-					"
-				>
+                                <div class="banner" :style="bannerStyle">
 					<span
 						v-if="$i && $i.id != user.id && user.isFollowed"
 						class="followed"
@@ -125,7 +118,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import * as Acct from "calckey-js/built/acct";
 import type * as misskey from "calckey-js";
 import MkFollowButton from "@/components/MkFollowButton.vue";
@@ -134,6 +127,7 @@ import XShowMoreButton from "@/components/MkShowMoreButton.vue";
 import * as os from "@/os";
 import { $i } from "@/account";
 import { i18n } from "@/i18n";
+import { useRemoteImageWithProxy } from "@/scripts/use-remote-image-with-proxy";
 
 const props = defineProps<{
 	showing: boolean;
@@ -154,6 +148,15 @@ let left = $ref(0);
 
 let isLong = $ref(false);
 let collapsed = $ref(!isLong);
+
+const bannerImageUrl = useRemoteImageWithProxy(
+        () => user?.bannerUrl ?? null,
+        () => Boolean(user?.host),
+);
+
+const bannerStyle = computed(() =>
+        bannerImageUrl.value ? `background-image: url(${bannerImageUrl.value})` : "",
+);
 
 onMounted(() => {
 	if (typeof props.q === "object") {

--- a/packages/client/src/components/global/MkAvatar.vue
+++ b/packages/client/src/components/global/MkAvatar.vue
@@ -11,15 +11,15 @@
 		:title="acct(user)"
 		@click="onClick"
 	>
-		<img
-			v-if="
-				!errorIcon
-			"
-			class="inner"
-			:src="defaultStore.state.hiddenIconUserIds?.includes(user.id) ? `${config.url}/avatar-alt/@${acct(user)}` : url"
-			@error="errorIcon = true"
-			decoding="async"
-		/>
+                <img
+                        v-if="
+                                !errorIcon
+                        "
+                        class="inner"
+                        :src="hiddenIconUrl ?? displayUrl ?? undefined"
+                        @error="handleAvatarError"
+                        decoding="async"
+                />
 		<img
 			v-else
 			class="inner"
@@ -46,15 +46,15 @@
 		:target="target"
 		@click.stop="showAvatar"
 	>
-		<img
-			v-if="
-				!errorIcon
-			"
-			class="inner"
-			:src="defaultStore.state.hiddenIconUserIds?.includes(user.id) ? `${config.url}/avatar-alt/@${acct(user)}` : url"
-			@error="errorIcon = true"
-			decoding="async"
-		/>
+                <img
+                        v-if="
+                                !errorIcon
+                        "
+                        class="inner"
+                        :src="hiddenIconUrl ?? displayUrl ?? undefined"
+                        @error="handleAvatarError"
+                        decoding="async"
+                />
 		<img
 			v-else-if="!errorAltIcon"
 			class="inner"
@@ -80,6 +80,7 @@
 import { watch } from "vue";
 import * as misskey from "calckey-js";
 import { getStaticImageUrl } from "@/scripts/get-static-image-url";
+import { getProxiedImageUrl } from "@/scripts/media-proxy";
 import { extractAvgColorFromBlurhash } from "@/scripts/extract-avg-color-from-blurhash";
 import { acct, userPage } from "@/filters/user";
 import MkUserOnlineIndicator from "@/components/MkUserOnlineIndicator.vue";
@@ -111,14 +112,26 @@ const emit = defineEmits<{
 }>();
 
 const url = $computed(() =>
-	defaultStore.state.disableShowingAnimatedImages
-		? getStaticImageUrl(props.user.avatarUrl)
-		: props.user.avatarUrl
+        defaultStore.state.disableShowingAnimatedImages
+                ? getStaticImageUrl(props.user.avatarUrl)
+                : props.user.avatarUrl
+);
+const proxiedUrl = $computed(() =>
+        props.user.host ? getProxiedImageUrl(props.user.avatarUrl) : null,
+);
+const hiddenIconUrl = $computed(() =>
+        defaultStore.state.hiddenIconUserIds?.includes(props.user.id)
+                ? `${config.url}/avatar-alt/@${acct(props.user)}`
+                : null,
 );
 
+let displayUrl = $ref<string | null>(null);
+let triedProxy = $ref(false);
+
 async function openAvatarImage() {
+        const targetUrl = displayUrl ?? url;
         if (defaultStore.state.imageNewTab) {
-                window.open(url);
+                if (targetUrl) window.open(targetUrl);
                 return;
         }
 
@@ -133,7 +146,7 @@ async function openAvatarImage() {
                 const lightbox = new pswpLightbox.default({
                         dataSource: [
                                 {
-                                        src: url,
+                                        src: targetUrl,
                                         w: img.naturalWidth,
                                         h: img.naturalHeight,
                                 },
@@ -149,7 +162,9 @@ async function openAvatarImage() {
                 lightbox.init();
                 lightbox.loadAndOpen(0);
         };
-        img.src = url;
+        if (targetUrl) {
+                img.src = targetUrl;
+        }
 }
 
 function onClick(ev: MouseEvent) {
@@ -164,6 +179,33 @@ function showAvatar(ev: MouseEvent) {
 let color = $ref();
 let errorIcon = $ref(false);
 let errorAltIcon = $ref(false);
+
+watch(
+        () => url,
+        (newUrl) => {
+                displayUrl = newUrl;
+                triedProxy = false;
+                errorIcon = false;
+                errorAltIcon = false;
+        },
+        { immediate: true },
+);
+
+function handleAvatarError() {
+        if (
+                !triedProxy &&
+                props.user.host != null &&
+                hiddenIconUrl == null &&
+                proxiedUrl != null &&
+                displayUrl !== proxiedUrl
+        ) {
+                triedProxy = true;
+                displayUrl = proxiedUrl;
+                return;
+        }
+
+        errorIcon = true;
+}
 
 watch(
 	() => props.user.avatarBlurhash,

--- a/packages/client/src/pages/user/home.vue
+++ b/packages/client/src/pages/user/home.vue
@@ -569,6 +569,7 @@ import * as os from "@/os";
 import { useRouter } from "@/router";
 import { i18n } from "@/i18n";
 import { $i } from "@/account";
+import { useRemoteImageWithProxy } from "@/scripts/use-remote-image-with-proxy";
 
 const XPhotos = defineAsyncComponent(() => import("./index.photos.vue"));
 const XActivity = defineAsyncComponent(() => import("./index.activity.vue"));
@@ -594,6 +595,10 @@ let rootEl = $ref<null | HTMLElement>(null);
 let bannerEl = $ref<null | HTMLElement>(null);
 const pinFull = $ref(false);
 const mkBadge = $ref(props.user.badges || []);
+const bannerImageUrl = useRemoteImageWithProxy(
+        () => props.user.bannerUrl ?? null,
+        () => props.user.host != null,
+);
 const visiblePinnedNotes = $computed(() => {
 	return pinFull
 		? props.user.pinnedNotes
@@ -675,15 +680,20 @@ const birthday = $computed(() => {
 });
 
 const style = $computed(() => {
-	if (
-		props.user.bannerUrl == null ||
-		(defaultStore.state.enableDataSaverMode &&
-			defaultStore.state.dataSaverDisabledBanner)
-	)
-		return {};
-	return {
-		backgroundImage: `url(${props.user.bannerUrl})`,
-	};
+        if (
+                props.user.bannerUrl == null ||
+                (defaultStore.state.enableDataSaverMode &&
+                        defaultStore.state.dataSaverDisabledBanner)
+        )
+                return {};
+
+        const resolvedUrl = bannerImageUrl.value ?? props.user.bannerUrl;
+
+        if (!resolvedUrl) return {};
+
+        return {
+                backgroundImage: `url(${resolvedUrl})`,
+        };
 });
 
 const age = $computed(() => {

--- a/packages/client/src/scripts/use-remote-image-with-proxy.ts
+++ b/packages/client/src/scripts/use-remote-image-with-proxy.ts
@@ -1,0 +1,57 @@
+import { ref, watch } from "vue";
+import { getProxiedImageUrl } from "@/scripts/media-proxy";
+
+export function useRemoteImageWithProxy(
+        sourceGetter: () => string | null | undefined,
+        shouldTryProxy: () => boolean,
+) {
+        const resolvedUrl = ref<string | null>(null);
+        let triedProxy = false;
+
+        const load = (url: string | null | undefined, allowProxyRetry: boolean) => {
+                if (!url) {
+                        resolvedUrl.value = null;
+                        return;
+                }
+
+                resolvedUrl.value = url;
+
+                if (typeof window === "undefined" || !shouldTryProxy()) {
+                        return;
+                }
+
+                const img = new Image();
+
+                img.onload = () => {
+                        if (resolvedUrl.value !== url) {
+                                resolvedUrl.value = url;
+                        }
+                };
+
+                img.onerror = () => {
+                        if (!allowProxyRetry || triedProxy) return;
+
+                        triedProxy = true;
+
+                        const proxiedUrl = getProxiedImageUrl(url);
+                        if (proxiedUrl === url) {
+                                return;
+                        }
+
+                        load(proxiedUrl, false);
+                };
+
+                img.src = url;
+        };
+
+        watch(
+                sourceGetter,
+                (newUrl) => {
+                        triedProxy = false;
+                        load(newUrl, true);
+                },
+                { immediate: true },
+        );
+
+        return resolvedUrl;
+}


### PR DESCRIPTION
## 概要
- リモートユーザのアイコン読み込み失敗時にmediaproxyを自動再試行するよう更新
- ユーザバナー画像にmediaproxyフォールバックを適用する共通フックを実装し、各表示コンポーネントへ適用
- プロフィール画面などでバナー画像の取得失敗時にmediaproxy経由の取得を試みるよう調整

## テスト
- `pnpm --filter client lint` (rome未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68e473724a9c8326b0c354aab2d9e6dc