### PR TITLE
p-limit を使ってインスタンス検査処理を並列化

### DIFF
--- a/packages/backend/src/queue/processors/system/check-suspended-instances.ts
+++ b/packages/backend/src/queue/processors/system/check-suspended-instances.ts
@@ -1,6 +1,7 @@
 import type Bull from "bull";
 import { Instances } from "@/models/index.js";
 import { fetchInstanceMetadata } from "@/services/fetch-instance-metadata.js";
+import pLimit from "p-limit";
 import { LessThan, Not } from "typeorm";
 import { queueLogger } from "../../logger.js";
 
@@ -14,6 +15,7 @@ export async function checkSuspendedInstances(
         job.log("info - Checking suspended instances...");
 
         const twoWeeksAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 14);
+        const limit = pLimit(5);
 
         const notSuspended = await Instances.find({
                 where: {
@@ -26,38 +28,42 @@ export async function checkSuspendedInstances(
                 },
         });
 
-        for (const inst of notSuspended) {
-                try {
-                        const ok = await fetchInstanceMetadata(inst, true);
+        await Promise.allSettled(
+                notSuspended.map((inst) =>
+                        limit(async () => {
+                                try {
+                                        const ok = await fetchInstanceMetadata(inst, true);
 
-                        const update: Record<string, any> = {
-                                latestRequestSentAt: new Date(),
-                        };
-                        if (ok) {
-                                update.isNotResponding = false;
-                                update.lastCommunicatedAt = new Date();
-                        } else {
-                                update.isSuspended = true;
-                        }
+                                        const update: Record<string, any> = {
+                                                latestRequestSentAt: new Date(),
+                                        };
+                                        if (ok) {
+                                                update.isNotResponding = false;
+                                                update.lastCommunicatedAt = new Date();
+                                        } else {
+                                                update.isSuspended = true;
+                                        }
 
-                        await Instances.update(inst.id, update);
+                                        await Instances.update(inst.id, update);
 
-                        if (ok) {
-                                logger.succ(`recovered ${inst.host}`);
-                                job.log(`succ - recovered ${inst.host}`);
-                        } else {
-                                logger.warn(`suspend ${inst.host}`);
-                                job.log(`warn - suspend ${inst.host}`);
-                        }
-                } catch (err) {
-                        await Instances.update(inst.id, {
-                                latestRequestSentAt: new Date(),
-                                isSuspended: true,
-                        });
-                        logger.warn(`check failed for ${inst.host}: ${err}`);
-                        job.log(`warn - check failed for ${inst.host}: ${err}`);
-                }
-        }
+                                        if (ok) {
+                                                logger.succ(`recovered ${inst.host}`);
+                                                job.log(`succ - recovered ${inst.host}`);
+                                        } else {
+                                                logger.warn(`suspend ${inst.host}`);
+                                                job.log(`warn - suspend ${inst.host}`);
+                                        }
+                                } catch (err) {
+                                        await Instances.update(inst.id, {
+                                                latestRequestSentAt: new Date(),
+                                                isSuspended: true,
+                                        });
+                                        logger.warn(`check failed for ${inst.host}: ${err}`);
+                                        job.log(`warn - check failed for ${inst.host}: ${err}`);
+                                }
+                        }),
+                ),
+        );
 
         const goneServers = await Instances.find({
                 where: {
@@ -66,14 +72,18 @@ export async function checkSuspendedInstances(
                 },
         });
 
-        for (const inst of goneServers) {
-                await Instances.update(inst.id, {
-                        latestRequestSentAt: new Date(),
-                        isSuspended: true,
-                });
-                logger.warn(`suspend ${inst.host} by 410`);
-                job.log(`warn - suspend ${inst.host} by 410`);
-        }
+        await Promise.allSettled(
+                goneServers.map((inst) =>
+                        limit(async () => {
+                                await Instances.update(inst.id, {
+                                        latestRequestSentAt: new Date(),
+                                        isSuspended: true,
+                                });
+                                logger.warn(`suspend ${inst.host} by 410`);
+                                job.log(`warn - suspend ${inst.host} by 410`);
+                        }),
+                ),
+        );
 
         const targets = await Instances.find({
                 where: {
@@ -82,37 +92,42 @@ export async function checkSuspendedInstances(
                 },
         });
 
-        for (const inst of targets) {
-                if (
-                        inst.latestStatus === 410 ||
-                        (inst.latestStatus == null && inst.isNotResponding)
-                )
-                        continue;
+        await Promise.allSettled(
+                targets.map((inst) =>
+                        limit(async () => {
+                                if (
+                                        inst.latestStatus === 410 ||
+                                        (inst.latestStatus == null && inst.isNotResponding)
+                                ) {
+                                        return;
+                                }
 
-                try {
-                        const ok = await fetchInstanceMetadata(inst, true);
+                                try {
+                                        const ok = await fetchInstanceMetadata(inst, true);
 
-                        const update: Record<string, any> = {
-                                latestRequestSentAt: new Date(),
-                        };
+                                        const update: Record<string, any> = {
+                                                latestRequestSentAt: new Date(),
+                                        };
 
-                        if (ok) {
-                                update.isSuspended = false;
-                                update.isNotResponding = false;
-                                update.lastCommunicatedAt = new Date();
-                                logger.succ(`unsuspended ${inst.host}`);
-                                job.log(`succ - unsuspended ${inst.host}`);
-                        }
+                                        if (ok) {
+                                                update.isSuspended = false;
+                                                update.isNotResponding = false;
+                                                update.lastCommunicatedAt = new Date();
+                                                logger.succ(`unsuspended ${inst.host}`);
+                                                job.log(`succ - unsuspended ${inst.host}`);
+                                        }
 
-                        await Instances.update(inst.id, update);
-                } catch (err) {
-                        await Instances.update(inst.id, {
-                                latestRequestSentAt: new Date(),
-                        });
-                        logger.warn(`check failed for ${inst.host}: ${err}`);
-                        job.log(`warn - check failed for ${inst.host}: ${err}`);
-                }
-        }
+                                        await Instances.update(inst.id, update);
+                                } catch (err) {
+                                        await Instances.update(inst.id, {
+                                                latestRequestSentAt: new Date(),
+                                        });
+                                        logger.warn(`check failed for ${inst.host}: ${err}`);
+                                        job.log(`warn - check failed for ${inst.host}: ${err}`);
+                                }
+                        }),
+                ),
+        );
 
         logger.succ("Check finished.");
         job.log("succ - Check finished.");


### PR DESCRIPTION
## 概要
- インスタンス状態の再確認・停止判定処理を Promise.allSettled で並列実行できるように変更
- p-limit で同時実行数を制御しつつ、従来のログ出力と Instances.update 呼び出しを維持
- エラーハンドリングを並列処理に合わせて調整

## テスト
- pnpm lint（依存モジュール不足により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68e475d9ac2c8326a56fdc1efd434978