### PR TITLE
ユーザーリスト削除処理の非同期化

### DIFF
--- a/packages/backend/src/services/blocking/create.ts
+++ b/packages/backend/src/services/blocking/create.ts
@@ -160,14 +160,16 @@ async function unFollow(follower: User, followee: User) {
 }
 
 async function removeFromList(listOwner: User, user: User) {
-	const userLists = await UserLists.findBy({
-		userId: listOwner.id,
-	});
+        const userLists = await UserLists.findBy({
+                userId: listOwner.id,
+        });
 
-	for (const userList of userLists) {
-		await UserListJoinings.delete({
-			userListId: userList.id,
-			userId: user.id,
-		});
-	}
+        const deletePromises = userLists.map((userList) =>
+                UserListJoinings.delete({
+                        userListId: userList.id,
+                        userId: user.id,
+                }),
+        );
+
+        await Promise.all(deletePromises);
 }


### PR DESCRIPTION
## 概要
- ブロック処理時のリスト退避削除を Promise.all でまとめて実行するよう変更

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68e477bbe96c8326b13def9d47898bf1