### PR TITLE
アナウンス一覧APIの読了数取得を並列化

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/announcements/list.ts
+++ b/packages/backend/src/server/api/endpoints/admin/announcements/list.ts
@@ -81,24 +81,25 @@ export default define(meta, paramDef, async (ps) => {
 
 	const announcements = await query.take(ps.limit).getMany();
 
-	const reads = new Map<Announcement, number>();
+        const readCounts = await Promise.all(
+                announcements.map((announcement) =>
+                        AnnouncementReads.countBy({
+                                announcementId: announcement.id,
+                        }),
+                ),
+        );
 
-	for (const announcement of announcements) {
-		reads.set(
-			announcement,
-			await AnnouncementReads.countBy({
-				announcementId: announcement.id,
-			}),
-		);
-	}
+        const reads = new Map<Announcement["id"], number>(
+                announcements.map((announcement, index) => [announcement.id, readCounts[index]]),
+        );
 
-	return announcements.map((announcement) => ({
-		id: announcement.id,
-		createdAt: announcement.createdAt.toISOString(),
-		updatedAt: announcement.updatedAt?.toISOString() ?? null,
-		title: announcement.title,
-		text: announcement.text,
-		imageUrl: announcement.imageUrl,
-		reads: reads.get(announcement)!,
-	}));
+        return announcements.map((announcement) => ({
+                id: announcement.id,
+                createdAt: announcement.createdAt.toISOString(),
+                updatedAt: announcement.updatedAt?.toISOString() ?? null,
+                title: announcement.title,
+                text: announcement.text,
+                imageUrl: announcement.imageUrl,
+                reads: reads.get(announcement.id)!,
+        }));
 });


### PR DESCRIPTION
## 概要
- 管理者向けアナウンス一覧APIでの読了数取得を逐次処理から並列実行へ変更
- Promise.allで得た結果をマップ化し、レスポンス生成時に参照するよう調整
- レスポンス順序や件数制限を維持したまま効率化

## テスト
- なし（コード変更のみ）

------
https://chatgpt.com/codex/tasks/task_e_68e47a38a6288326a79b3c341a94186e