### PR TITLE
修飾キー押下時にMkAをバイパスしてブラウザ動作を許可

### DIFF
--- a/packages/client/src/components/global/MkA.vue
+++ b/packages/client/src/components/global/MkA.vue
@@ -1,11 +1,10 @@
 <template>
-	<a
-		:href="to"
-		:class="active ? activeClass : null"
-		@click="nav"
-		@contextmenu.prevent.stop="onContextmenu"
-		@click.stop
-	>
+        <a
+                :href="to"
+                :class="active ? activeClass : null"
+                @click="nav"
+                @contextmenu.prevent.stop="onContextmenu"
+        >
 		<slot></slot>
 	</a>
 </template>
@@ -99,27 +98,32 @@ function popout() {
 }
 
 function nav(ev: MouseEvent) {
-	if (!ev.ctrlKey) {
-		ev.preventDefault();
+        if (ev.button !== 0) return;
 
-		if (props.behavior === "browser") {
-			location.href = props.to;
-			return;
-		}
+        if (ev.ctrlKey || ev.altKey || ev.metaKey) {
+                return;
+        }
 
-		if (props.behavior) {
-			if (props.behavior === "window") {
-				return openWindow();
-			} else if (props.behavior === "modalWindow") {
-				return modalWindow();
-			}
-		}
+        ev.preventDefault();
+        ev.stopPropagation();
 
-		if (ev.shiftKey) {
-			return openWindow();
-		}
+        if (props.behavior === "browser") {
+                location.href = props.to;
+                return;
+        }
 
-		router.push(props.to, ev.ctrlKey ? "forcePage" : null);
-	}
+        if (props.behavior) {
+                if (props.behavior === "window") {
+                        return openWindow();
+                } else if (props.behavior === "modalWindow") {
+                        return modalWindow();
+                }
+        }
+
+        if (ev.shiftKey) {
+                return openWindow();
+        }
+
+        router.push(props.to);
 }
 </script>


### PR DESCRIPTION
## 概要
- ctrl / alt / meta いずれかの修飾キーを押したクリックでは MkA のナビゲーション処理をスキップしてブラウザ標準の挙動を維持
- 左クリック時のみ MkA の処理を実行し、イベント伝播の制御を関数内で行うように変更

## テスト
- テストなし（未実行）

------
https://chatgpt.com/codex/tasks/task_e_68e47d7457c8832691170dd5c575b8f1