### PR TITLE
Users.getRelationの招待判定改善とテスト追加

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -289,7 +289,11 @@ export const NoteRepository = db.getRepository(Note).extend({
 		}
 
 		if (opts.blockCheck && meId) {
-			const relation = await Users.getRelation(meId, note.userId);
+                        const relation = await Users.getRelation(
+                                meId,
+                                note.userId,
+                                note.user ?? undefined,
+                        );
 			if (relation.isMuted || relation.isBlocked) {
 				throw new IdentifiableError(
 					"281827eb-bd11-3625-ac9d-336a0d80fac2",

--- a/packages/backend/src/models/repositories/user.ts
+++ b/packages/backend/src/models/repositories/user.ts
@@ -158,8 +158,16 @@ export const UserRepository = db.getRepository(User).extend({
 	validateBirthday: ajv.compile(birthdaySchema),
 	//#endregion
 
-        async getRelation(me: User["id"], target: User["id"]): Promise<UserRelation> {
-                const relations = await this.getRelationsBulk(me, [target]);
+        async getRelation(
+                me: User["id"],
+                target: User["id"],
+                targetUser?: Pick<User, "id" | "inviteUserId"> | null,
+        ): Promise<UserRelation> {
+                const relations = await this.getRelationsBulk(
+                        me,
+                        [target],
+                        targetUser ? [targetUser] : undefined,
+                );
                 const relation = relations.get(target);
                 if (relation == null) {
                         return {
@@ -183,12 +191,26 @@ export const UserRepository = db.getRepository(User).extend({
         async getRelationsBulk(
                 meId: User["id"],
                 targetIds: User["id"][],
+                targetUsers?: (Pick<User, "id" | "inviteUserId"> | null | undefined)[],
         ): Promise<Map<User["id"], UserRelation>> {
                 const uniqueTargetIds = Array.from(
                         new Set(targetIds.filter((id) => id !== meId)),
                 );
 
                 const relationsMap = new Map<User["id"], UserRelation>();
+
+                const targetUserMap = new Map<
+                        User["id"],
+                        Pick<User, "id" | "inviteUserId">
+                >();
+
+                if (targetUsers) {
+                        for (const info of targetUsers) {
+                                if (info) {
+                                        targetUserMap.set(info.id, info);
+                                }
+                        }
+                }
 
                 if (uniqueTargetIds.length === 0) {
                         return relationsMap;
@@ -258,13 +280,24 @@ export const UserRepository = db.getRepository(User).extend({
                                 blockerId: meId,
                                 blockeeId: In(uniqueTargetIds),
                         }),
-                        this.find({
-                                select: { id: true, inviteUserId: true },
-                                where: {
-                                        id: In(uniqueTargetIds),
-                                        inviteUserId: meId,
-                                },
-                        }),
+                        (async () => {
+                                const idsToFetch = uniqueTargetIds.filter((id) => {
+                                        const info = targetUserMap.get(id);
+                                        return !(info && info.inviteUserId === meId);
+                                });
+
+                                if (idsToFetch.length === 0) {
+                                        return [] as Pick<User, "id" | "inviteUserId">[];
+                                }
+
+                                return this.find({
+                                        select: { id: true, inviteUserId: true },
+                                        where: {
+                                                id: In(idsToFetch),
+                                                inviteUserId: meId,
+                                        },
+                                });
+                        })(),
                 ]);
 
                 for (const following of followings) {
@@ -310,6 +343,13 @@ export const UserRepository = db.getRepository(User).extend({
                 for (const followBlocking of followBlockings) {
                         const relation = relationsMap.get(followBlocking.blockeeId);
                         if (relation) relation.isFollowBlocking = true;
+                }
+
+                for (const info of targetUserMap.values()) {
+                        if (info.inviteUserId === meId) {
+                                const relation = relationsMap.get(info.id);
+                                if (relation) relation.isInviter = true;
+                        }
                 }
 
                 for (const invitee of invitees) {
@@ -481,7 +521,9 @@ export const UserRepository = db.getRepository(User).extend({
                         let isFollowed = relationHint?.isFollowed;
 
                         if (isFollowed == null) {
-                                isFollowed = (await this.getRelation(meId, user.id)).isFollowed;
+                                isFollowed = (
+                                        await this.getRelation(meId, user.id, user)
+                                ).isFollowed;
                         }
 
                         if (!isFollowed) {
@@ -605,7 +647,7 @@ export const UserRepository = db.getRepository(User).extend({
                 const relation = relationHintProvided
                         ? hints?.relation ?? null
                         : meId && !isMe && (opts.detail || opts.relation)
-                        ? await this.getRelation(meId, user.id)
+                        ? await this.getRelation(meId, user.id, user)
                         : null;
 		const pins = opts.detail
 			? await UserNotePinings.createQueryBuilder("pin")
@@ -1085,9 +1127,13 @@ export const UserRepository = db.getRepository(User).extend({
                         .filter((id): id is User["id"] => id != null);
                 const uniqueIds = Array.from(new Set(ids));
 
+                const targetUsers = users.map((u) =>
+                        typeof u === "object" ? (u as Pick<User, "id" | "inviteUserId">) : undefined,
+                );
+
                 const relationsMap =
                         meId && uniqueIds.length > 0 && (opts.detail || opts.relation)
-                                ? await this.getRelationsBulk(meId, uniqueIds)
+                                ? await this.getRelationsBulk(meId, uniqueIds, targetUsers)
                                 : null;
 
                 const memoMap =

--- a/packages/backend/src/server/activitypub.ts
+++ b/packages/backend/src/server/activitypub.ts
@@ -239,7 +239,11 @@ router.get("/notes/:note", async (ctx, next) => {
 			return;
 		}
 
-		const relation = await Users.getRelation(remoteUser.user.id, note.userId);
+                const relation = await Users.getRelation(
+                        remoteUser.user.id,
+                        note.userId,
+                        note.user ?? undefined,
+                );
 		serverLogger.debug("Relation:");
 		serverLogger.debug(JSON.stringify(relation, null, 2));
 
@@ -351,7 +355,11 @@ router.get("/notes/:note/references", async (ctx, next) => {
 			return;
 		}
 
-		const relation = await Users.getRelation(remoteUser.user.id, note.userId);
+            const relation = await Users.getRelation(
+                    remoteUser.user.id,
+                    note.userId,
+                    note.user ?? undefined,
+            );
 		serverLogger.debug("Relation:");
 		serverLogger.debug(JSON.stringify(relation, null, 2));
 

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -748,7 +748,14 @@ export default async (
 				const localRelation = await mentionedUsers
 					.filter((x) => !x.host || x.host === config.host)
 					.every(
-						async (x) => !(await Users.getRelation(user.id, x.id)).isFollowed,
+                                            async (x) =>
+                                                    !(
+                                                            await Users.getRelation(
+                                                                    user.id,
+                                                                    x.id,
+                                                                    x,
+                                                            )
+                                                    ).isFollowed,
 					);
 				console.log(`localRelation: ${!localRelation}`);
                                 if (localRelation)
@@ -777,7 +784,14 @@ export default async (
 			const localRelation = await mentionedUsers
 				.filter((x) => !x.host || x.host === config.host)
 				.every(
-					async (x) => !(await Users.getRelation(user.id, x.id)).isFollowed,
+                                    async (x) =>
+                                            !(
+                                                    await Users.getRelation(
+                                                            user.id,
+                                                            x.id,
+                                                            x,
+                                                    )
+                                            ).isFollowed,
 				);
 			console.log(`localRelation: ${!localRelation}`);
                         if (localRelation)
@@ -832,7 +846,15 @@ export default async (
 			const relation = user.isSilenced
 				? await Promise.all(
 						data.visibleUsers.map(
-							async (x) => (await Users.getRelation(user.id, x.id)).isFollowed || (await Users.findOneByOrFail({ id: x.id })).isAdmin,
+                                                    async (x) =>
+                                                            (
+                                                                    await Users.getRelation(
+                                                                            user.id,
+                                                                            x.id,
+                                                                            x,
+                                                                    )
+                                                            ).isFollowed ||
+                                                            (await Users.findOneByOrFail({ id: x.id })).isAdmin,
 						),
 				  )
 				: undefined;

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -75,7 +75,11 @@ export default async (
 
 	const relationPromise = (async () => {
 		if (user.isSilenced && note.userId !== user.id) {
-			const relation = await Users.getRelation(user.id, note.userId);
+                        const relation = await Users.getRelation(
+                                user.id,
+                                note.userId,
+                                note.user ?? undefined,
+                        );
 			if (relation && !relation.isFollowed) {
 				throw new IdentifiableError(
 					"5ab2b45b-c2b5-0560-793d-2a670084cc92",

--- a/packages/backend/test/user-relation.ts
+++ b/packages/backend/test/user-relation.ts
@@ -1,0 +1,59 @@
+process.env.NODE_ENV = "test";
+
+import * as assert from "assert";
+import type * as childProcess from "child_process";
+import { Repository } from "typeorm";
+import { User } from "@/models/entities/user.js";
+import { Users } from "@/models/index.js";
+import {
+        async as asyncHelper,
+        initTestDb,
+        signup,
+        startServer,
+        shutdownServer,
+} from "./utils.js";
+
+describe("User relation", () => {
+        let p: childProcess.ChildProcess;
+        let userRepo: Repository<User>;
+
+        before(async () => {
+                p = await startServer();
+                const connection = await initTestDb(true);
+                userRepo = connection.getRepository(User);
+        });
+
+        after(async () => {
+                await shutdownServer(p);
+        });
+
+        it(
+                "target user hint keeps inviter flag",
+                asyncHelper(async () => {
+                        const inviter = await signup({ username: "inviter" });
+                        const invitee = await signup({ username: "invitee" });
+                        const other = await signup({ username: "other" });
+
+                        await userRepo.update({ id: invitee.id }, { inviteUserId: inviter.id });
+
+                        const inviteeEntity = await userRepo.findOneByOrFail({ id: invitee.id });
+                        const otherEntity = await userRepo.findOneByOrFail({ id: other.id });
+
+                        const relationWithHint = await Users.getRelation(
+                                inviter.id,
+                                invitee.id,
+                                inviteeEntity,
+                        );
+                        const relationWithoutHint = await Users.getRelation(inviter.id, invitee.id);
+                        const relationForOther = await Users.getRelation(
+                                inviter.id,
+                                other.id,
+                                otherEntity,
+                        );
+
+                        assert.strictEqual(relationWithHint.isInviter, true);
+                        assert.strictEqual(relationWithoutHint.isInviter, true);
+                        assert.strictEqual(relationForOther.isInviter, false);
+                }),
+        );
+});


### PR DESCRIPTION
## 概要
- Users.getRelationにtargetUserヒントを渡せるようにし、inviter判定のための追加クエリを省略
- Users.packなど関係取得の呼び出し元で可能な限りユーザー情報を渡すように更新
- 招待フラグの維持を確認するテストを追加

## テスト
- pnpm --filter backend test -- user-relation.ts (依存ライブラリ未導入のため cross-env が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68e47c4da6348326a626be090f9c7c90