### PR TITLE
フォロー関連のパック処理を最適化

### DIFF
--- a/packages/backend/src/models/repositories/following.ts
+++ b/packages/backend/src/models/repositories/following.ts
@@ -1,9 +1,11 @@
+import { In } from "typeorm";
 import { db } from "@/db/postgre.js";
-import { Users } from "../index.js";
+import { UserMemos, Users } from "../index.js";
 import { Following } from "@/models/entities/following.js";
 import { awaitAll } from "@/prelude/await-all.js";
 import type { Packed } from "@/misc/schema.js";
 import type { User } from "@/models/entities/user.js";
+import type { UserRelation } from "./user.js";
 
 type LocalFollowerFollowing = Following & {
 	followerHost: null;
@@ -46,45 +48,201 @@ export const FollowingRepository = db.getRepository(Following).extend({
 		return following.followeeHost != null;
 	},
 
-	async pack(
-		src: Following["id"] | Following,
-		me?: { id: User["id"] } | null | undefined,
-		opts?: {
-			populateFollowee?: boolean;
-			populateFollower?: boolean;
-		},
-	): Promise<Packed<"Following">> {
-		const following =
-			typeof src === "object" ? src : await this.findOneByOrFail({ id: src });
+        async pack(
+                src: Following["id"] | Following,
+                me?: { id: User["id"] } | null | undefined,
+                opts?: {
+                        populateFollowee?: boolean;
+                        populateFollower?: boolean;
+                },
+                hints?: {
+                        followee?: {
+                                relation?: UserRelation | null;
+                                memo?: Awaited<ReturnType<typeof UserMemos.findOneBy>> | null;
+                        };
+                        follower?: {
+                                relation?: UserRelation | null;
+                                memo?: Awaited<ReturnType<typeof UserMemos.findOneBy>> | null;
+                        };
+                },
+        ): Promise<Packed<"Following">> {
+                const following =
+                        typeof src === "object" ? src : await this.findOneByOrFail({ id: src });
 
-		if (opts == null) opts = {};
+                if (opts == null) opts = {};
 
 		return await awaitAll({
 			id: following.id,
 			createdAt: following.createdAt.toISOString(),
-			followeeId: following.followeeId,
-			followerId: following.followerId,
-			followee: opts.populateFollowee
-				? Users.pack(following.followee || following.followeeId, me, {
-						detail: true,
-				  })
-				: undefined,
-			follower: opts.populateFollower
-				? Users.pack(following.follower || following.followerId, me, {
-						detail: true,
-				  })
-				: undefined,
-		});
-	},
+                        followeeId: following.followeeId,
+                        followerId: following.followerId,
+                        followee: opts.populateFollowee
+                                ? Users.pack(following.followee || following.followeeId, me, {
+                                                detail: true,
+                                  }, hints?.followee)
+                                : undefined,
+                        follower: opts.populateFollower
+                                ? Users.pack(following.follower || following.followerId, me, {
+                                                detail: true,
+                                  }, hints?.follower)
+                                : undefined,
+                });
+        },
 
-	packMany(
-		followings: any[],
-		me?: { id: User["id"] } | null | undefined,
-		opts?: {
-			populateFollowee?: boolean;
-			populateFollower?: boolean;
-		},
-	) {
-		return Promise.all(followings.map((x) => this.pack(x, me, opts)));
-	},
+        async packMany(
+                followings: any[],
+                me?: { id: User["id"] } | null | undefined,
+                opts?: {
+                        populateFollowee?: boolean;
+                        populateFollower?: boolean;
+                },
+        ) {
+                if (opts == null) opts = {};
+
+                const populateFollowee = Boolean(opts.populateFollowee);
+                const populateFollower = Boolean(opts.populateFollower);
+
+                const extractUserId = (
+                        user: User | null | undefined,
+                        fallbackId: User["id"] | undefined,
+                ): User["id"] | undefined => {
+                        if (user && typeof user === "object") {
+                                return user.id;
+                        }
+
+                        return fallbackId;
+                };
+
+                const extractFolloweeId = (following: Following): User["id"] | undefined =>
+                        extractUserId(following.followee ?? undefined, following.followeeId);
+
+                const extractFollowerId = (following: Following): User["id"] | undefined =>
+                        extractUserId(following.follower ?? undefined, following.followerId);
+
+                const ids = new Set<User["id"]>();
+
+                if (populateFollowee || populateFollower) {
+                        for (const following of followings) {
+                                if (typeof following !== "object" || following == null) continue;
+
+                                const entity = following as Following;
+
+                                if (populateFollowee) {
+                                        const followeeId = extractFolloweeId(entity);
+                                        if (followeeId) ids.add(followeeId);
+                                }
+
+                                if (populateFollower) {
+                                        const followerId = extractFollowerId(entity);
+                                        if (followerId) ids.add(followerId);
+                                }
+                        }
+                }
+
+                const meId = me?.id ?? null;
+
+                let relationsMap: Map<User["id"], UserRelation> | null = null;
+                let memoMap:
+                        | Map<
+                                  User["id"],
+                                  Awaited<ReturnType<typeof UserMemos.findOneBy>>
+                          >
+                        | null = null;
+
+                if (meId && ids.size > 0) {
+                        const targetIds = Array.from(ids);
+
+                        relationsMap = await Users.getRelationsBulk(meId, targetIds);
+
+                        memoMap = new Map(
+                                (
+                                        await UserMemos.findBy({
+                                                userId: meId,
+                                                targetUserId: In(targetIds),
+                                        })
+                                ).map((row) => [row.targetUserId, row]),
+                        );
+                }
+
+                const createUserHints = (
+                        id: User["id"] | null | undefined,
+                ):
+                        | {
+                                  relation?: UserRelation | null;
+                                  memo?: Awaited<ReturnType<typeof UserMemos.findOneBy>> | null;
+                          }
+                        | undefined => {
+                        if (!id) return undefined;
+
+                        let hints:
+                                | {
+                                          relation?: UserRelation | null;
+                                          memo?: Awaited<ReturnType<typeof UserMemos.findOneBy>> | null;
+                                  }
+                                | undefined;
+
+                        if (relationsMap) {
+                                hints = hints ?? {};
+                                hints.relation = relationsMap.get(id) ?? null;
+                        }
+
+                        if (memoMap) {
+                                hints = hints ?? {};
+                                hints.memo = memoMap.has(id)
+                                        ? memoMap.get(id) ?? null
+                                        : null;
+                        }
+
+                        return hints;
+                };
+
+                return Promise.all(
+                        followings.map((following) => {
+                                if (typeof following !== "object" || following == null) {
+                                        return this.pack(following, me, opts);
+                                }
+
+                                const entity = following as Following;
+
+                                const followeeId = populateFollowee
+                                        ? extractFolloweeId(entity)
+                                        : undefined;
+                                const followerId = populateFollower
+                                        ? extractFollowerId(entity)
+                                        : undefined;
+
+                                const followeeHints = populateFollowee
+                                        ? createUserHints(followeeId)
+                                        : undefined;
+                                const followerHints = populateFollower
+                                        ? createUserHints(followerId)
+                                        : undefined;
+
+                                let hints:
+                                        | {
+                                                  followee?: {
+                                                          relation?: UserRelation | null;
+                                                          memo?: Awaited<ReturnType<
+                                                                  typeof UserMemos.findOneBy
+                                                          >> | null;
+                                                  };
+                                                  follower?: {
+                                                          relation?: UserRelation | null;
+                                                          memo?: Awaited<ReturnType<
+                                                                  typeof UserMemos.findOneBy
+                                                          >> | null;
+                                                  };
+                                          }
+                                        | undefined;
+
+                                if (followeeHints || followerHints) {
+                                        hints = {};
+                                        if (followeeHints) hints.followee = followeeHints;
+                                        if (followerHints) hints.follower = followerHints;
+                                }
+
+                                return this.pack(entity, me, opts, hints);
+                        }),
+                );
+        },
 });


### PR DESCRIPTION
## 概要
- Followings.packMany で populate 対象のユーザー ID を集約し、閲覧者が存在する場合にリレーションとメモを一括取得
- Users.pack 呼び出しへヒントを渡すことで、フォロー/フォロワー API からのユーザー読み込み時のクエリ数を削減

## テスト
- 未実施（環境未整備のため）

------
https://chatgpt.com/codex/tasks/task_e_68e47f1c435083269d997080f07efcbb