### PR TITLE
フォローリクエスト承認処理のユーザー取得最適化

### DIFF
--- a/packages/backend/src/services/following/requests/accept-all.ts
+++ b/packages/backend/src/services/following/requests/accept-all.ts
@@ -1,6 +1,7 @@
 import accept from "./accept.js";
 import type { User } from "@/models/entities/user.js";
 import { FollowRequests, Users } from "@/models/index.js";
+import { In } from "typeorm";
 
 /**
  * Approve all follow requests for the specified user
@@ -17,8 +18,18 @@ export default async function (user: {
 		followeeId: user.id,
 	});
 
-	for (const request of requests) {
-		const follower = await Users.findOneByOrFail({ id: request.followerId });
-		accept(user, follower);
-	}
+        const followerIds = Array.from(new Set(requests.map((request) => request.followerId)));
+
+        if (followerIds.length === 0) return;
+
+        const followers = await Users.findBy({ id: In(followerIds) });
+        const followerMap = new Map(followers.map((follower) => [follower.id, follower]));
+
+        for (const request of requests) {
+                const follower =
+                        followerMap.get(request.followerId) ??
+                        (await Users.findOneByOrFail({ id: request.followerId }));
+
+                accept(user, follower);
+        }
 }


### PR DESCRIPTION
## 概要
- フォローリクエストのフォロワーIDをまとめて取得し、一括でユーザー情報を取得するように変更
- 取得できなかったユーザーは従来同様 `findOneByOrFail` で補完し、`accept` の呼び出し方法を維持

## テスト
- テストは未実施（コード変更のみ）

------
https://chatgpt.com/codex/tasks/task_e_68e481dc27588326855a60ea72c15d15