### PR TITLE
Twemojiに存在しないUnicodeリアクションの保存対応

### DIFF
--- a/packages/backend/src/misc/emoji-regex.ts
+++ b/packages/backend/src/misc/emoji-regex.ts
@@ -1,5 +1,13 @@
 import twemoji from "twemoji-parser/dist/lib/regex.js";
+import emojiRegexFactory from "emoji-regex";
+
 const twemojiRegex = twemoji.default;
+const generalEmojiRegex = emojiRegexFactory();
 
 export const emojiRegex = new RegExp(`(${twemojiRegex.source})`);
 export const emojiRegexAtStartToEnd = new RegExp(`^(${twemojiRegex.source})$`);
+export const unicodeEmojiRegex = new RegExp(`(${generalEmojiRegex.source})`, "u");
+export const unicodeEmojiRegexAtStartToEnd = new RegExp(
+        `^(${generalEmojiRegex.source})$`,
+        "u",
+);

--- a/packages/backend/src/misc/reaction-lib.ts
+++ b/packages/backend/src/misc/reaction-lib.ts
@@ -1,4 +1,7 @@
-import { emojiRegex } from "./emoji-regex.js";
+import {
+        emojiRegex,
+        unicodeEmojiRegexAtStartToEnd,
+} from "./emoji-regex.js";
 import { fetchMeta } from "./fetch-meta.js";
 import { Emojis } from "@/models/index.js";
 import { toPunyNullable } from "./convert-host.js";
@@ -76,11 +79,17 @@ export async function toDbReaction(
 	if (emoji) return emoji;
 
 	// Allow unicode reactions
-	const match = emojiRegex.exec(reaction);
-	if (match) {
-		const unicode = match[0];
-		return unicode;
-	}
+        const match = emojiRegex.exec(reaction);
+        if (match) {
+                const unicode = match[0];
+                return unicode;
+        }
+
+        const unicodeMatch = unicodeEmojiRegexAtStartToEnd.exec(reaction);
+        if (unicodeMatch) {
+                const unicode = unicodeMatch[1] ?? unicodeMatch[0];
+                return unicode;
+        }
 
 	const custom = reaction.match(/^:([\w+-]+)(?:@([\w.-]+))?:$/);
 


### PR DESCRIPTION
## 概要
- Twemojiベースの絵文字検出に加えて emoji-regex を導入し、Twemojiに無いUnicode絵文字も判定できるようにしました
- リアクション保存時に新しい判定を使い、Unicode絵文字であれば拒否せず保存するようにしました

## テスト
- 未実施（ローカルでの動作確認が困難なため）

------
https://chatgpt.com/codex/tasks/task_e_68e49c3813e4832696c805c84df9f542