### PR TITLE
プレーンテキストの改行表示をノートに限定

### DIFF
--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -190,22 +190,18 @@ export default defineComponent({
 								}
 							}
 
-                                                        if (!this.plain) {
+                                                        const lines = text.split("\n");
+
+                                                        if (!this.plain || isNote) {
                                                                 const res = [];
-                                                                for (const t of text.split("\n")) {
-                                                                        res.push(h("br"));
-                                                                        res.push(t);
-                                                                }
-                                                                res.shift();
-                                                                return res;
-                                                        } else {
-                                                                const res = [];
-                                                                text.split("\n").forEach((line, index) => {
+                                                                lines.forEach((line, index) => {
                                                                         if (index > 0) res.push(h("br"));
                                                                         res.push(line);
                                                                 });
                                                                 return res;
                                                         }
+
+                                                        return [text];
                                                 }
 
 						case "bold": {


### PR DESCRIPTION
## 概要
- プレーンテキスト表示で改行を反映する条件を Note の場合に限定
- Note 以外のプレーンテキスト表示では改行が反映されないよう調整

## テスト
- `pnpm --filter client lint` (依存関係不足により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68e4a97a34148326a1c967098f3ab6b1