### PR TITLE
SQLインジェクション検知の正規表現を修正

### DIFF
--- a/packages/backend/src/misc/safe-for-sql.ts
+++ b/packages/backend/src/misc/safe-for-sql.ts
@@ -1,3 +1,5 @@
+const UNSAFE_SQL_PATTERN = /[\0\x08\x09\x1a\n\r"'\\%]/;
+
 export function safeForSql(text: string): boolean {
-	return !/[\0\x08\x09\x1a\n\r"'\\\%]/g.test(text);
+        return !UNSAFE_SQL_PATTERN.test(text);
 }


### PR DESCRIPTION
## 概要
- SQL安全判定で利用している正規表現からグローバルフラグを取り除き、複数回の呼び出しでも安定して検知できるように修正

## テスト
- `pnpm test` (依存パッケージの取得に失敗したため未完了)


------
https://chatgpt.com/codex/tasks/task_e_68e779ce28608326a1437104ea5199ad