### PR TITLE
fix: Cheerioの読み込み方法を修正

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -1,6 +1,6 @@
 import type Koa from "koa";
 import summaly from "summaly";
-import { load } from "cheerio";
+import * as cheerio from "cheerio";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import Logger from "@/services/logger.js";
 import config from "@/config/index.js";
@@ -820,7 +820,7 @@ type AmazonFallbackData = {
 };
 
 function extractAmazonFallbackData(html: string): AmazonFallbackData | null {
-  const $ = load(html);
+  const $ = cheerio.load(html);
 
   const title = cleanAmazonText(
     $("#title").text() ||


### PR DESCRIPTION
## 概要
- cheerioを名前付きインポートではなく名前空間インポートに切り替え、ESM環境での読み込みエラーを解消
- HTML解析処理でcheerio.loadを利用するように調整

## テスト
- `pnpm --filter backend build` ※napiコマンドが環境に存在しないため失敗

------
https://chatgpt.com/codex/tasks/task_e_68edad8ea09083268bc47125f4227eee