### PR TITLE
ソフトミュートされたリアクションを総数表示から除外

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -474,6 +474,7 @@ import { deepClone } from "@/scripts/clone";
 import { getNoteSummary } from "@/scripts/get-note-summary";
 import copyToClipboard from "@/scripts/copy-to-clipboard";
 import * as sound from "@/scripts/sound.js";
+import { getVisibleReactionsTotal } from "@/scripts/reaction-utils";
 
 const router = useRouter();
 
@@ -557,10 +558,7 @@ const enableEmojiReactions = defaultStore.state.enableEmojiReactions;
 const showEmojiButton = defaultStore.state.showEmojiButton;
 const isDetailedView = $computed(() => props.detailedView ?? false);
 const totalReactions = $computed(() =>
-        Object.values(appearNote.reactions ?? {}).reduce(
-                (sum, val) => sum + val,
-                0
-        )
+        getVisibleReactionsTotal(appearNote as misskey.entities.Note)
 );
 const showStarButtonNoEmoji = $computed(() => {
         const canShow =

--- a/packages/client/src/components/MkNoteSub.vue
+++ b/packages/client/src/components/MkNoteSub.vue
@@ -139,18 +139,13 @@
 						:note="appearNote"
 						:count="appearNote.renoteCount"
 					/>
-					<XStarButtonNoEmoji
-						v-if="!enableEmojiReactions || !showContent"
-						class="button"
-						:note="appearNote"
-						:count="
-							Object.values(appearNote.reactions).reduce(
-								(partialSum, val) => partialSum + val,
-								0
-							)
-						"
-						:reacted="appearNote.myReaction != null"
-					/>
+                                        <XStarButtonNoEmoji
+                                                v-if="!enableEmojiReactions || !showContent"
+                                                class="button"
+                                                :note="appearNote"
+                                                :count="totalReactions"
+                                                :reacted="appearNote.myReaction != null"
+                                        />
 					<XStarButton
 						v-if="
 							enableEmojiReactions &&
@@ -301,6 +296,7 @@ import { defaultStore } from "@/store";
 import { deepClone } from "@/scripts/clone";
 import copyToClipboard from "@/scripts/copy-to-clipboard";
 import * as sound from "@/scripts/sound.js";
+import { getVisibleReactionsTotal } from "@/scripts/reaction-utils";
 
 const router = useRouter();
 
@@ -383,6 +379,9 @@ const replies: misskey.entities.Note[] =
 		)
 		.reverse() ?? [];
 const enableEmojiReactions = defaultStore.state.enableEmojiReactions;
+const totalReactions = $computed(() =>
+        getVisibleReactionsTotal(appearNote as misskey.entities.Note)
+);
 
 useNoteCapture({
 	rootEl: el,

--- a/packages/client/src/components/MkReactionsViewer.vue
+++ b/packages/client/src/components/MkReactionsViewer.vue
@@ -15,93 +15,16 @@
 <script lang="ts" setup>
 import { computed, unref } from "vue";
 import * as misskey from "calckey-js";
-import * as config from "@/config";
 import { $i } from "@/account";
 import XReaction from "@/components/MkReactionsViewer.reaction.vue";
-import { defaultStore } from "@/store";
-import { i18n } from "@/i18n";
+import { getVisibleReactions } from "@/scripts/reaction-utils";
 
 const props = defineProps<{
 	note: misskey.entities.Note;
 	multi?: boolean;
 }>();
 
-const reactions = computed(() => {
-	let _reactions = { ...props.note.reactions };
-
-	if (
-		props.note.tags &&
-		props.note.text?.includes("#ゴルベーザ百天王バトル")
-	) {
-		if (_reactions["🅰️"] == null) {
-			_reactions["🅰️"] = 0;
-		}
-		if (_reactions["🅱️"] == null) {
-			_reactions["🅱️"] = 0;
-		}
-	}
-
-	const localReactions = Object.keys(_reactions).filter((x) =>
-		x.includes("@")
-	);
-	const mergeReactions = {};
-	const reactionMuted = defaultStore.state.reactionMutedWords.map((x) => {
-		return {
-			name: x.replaceAll(":", "").replace("@", ""),
-			exact: /^:@?\w+:$/.test(x),
-			hostmute: /^:?@[\w.-]/.test(x),
-		};
-	});
-
-	localReactions.forEach((localReaction) => {
-		if (!_reactions || _reactions.length === 0) return;
-		const targetReactions = Object.keys(_reactions).filter((x) =>
-			x.startsWith(localReaction.replace(/@[\w:\.\-]+:$/, "@"))
-		);
-		if (targetReactions?.length === 0) return;
-		let totalCount = 0;
-		let maxReaction = {
-			reaction: localReaction,
-			count: _reactions[localReaction],
-		};
-		targetReactions.forEach((x) => {
-			if (
-				!localReaction.endsWith("@.:") &&
-				maxReaction.count < _reactions[x]
-			) {
-				maxReaction = { reaction: x, count: _reactions[x] };
-			}
-			totalCount += _reactions[x];
-			delete _reactions[x];
-		});
-
-		//ミュートリアクション判定
-		if (
-			reactionMuted.some((x) => {
-				const emojiName = localReaction
-					.replace(":", "")
-					.replace(/@[\w:\.\-]+:$/, "");
-				const emojiHost = localReaction
-					.replace(/^:[\w:\.\-]+@/, "")
-					.replace(":", "");
-				return (
-					(defaultStore.state.remoteReactionMute &&
-						emojiHost &&
-						emojiHost !== "." &&
-						emojiHost !== config.host) ||
-					(!x.hostmute && !x.exact && emojiName.includes(x.name)) ||
-					(!x.hostmute && x.name === emojiName) ||
-					(x.hostmute && !x.exact && emojiHost.includes(x.name)) ||
-					(x.hostmute && x.name === emojiHost)
-				);
-			})
-		)
-			totalCount = 0;
-
-		mergeReactions[maxReaction.reaction] = totalCount;
-	});
-	return { ...mergeReactions, ..._reactions };
-});
+const reactions = computed(() => getVisibleReactions(props.note));
 
 let lastSortedReactions = ["🅰️", "🅱️"];
 

--- a/packages/client/src/scripts/reaction-utils.ts
+++ b/packages/client/src/scripts/reaction-utils.ts
@@ -1,0 +1,119 @@
+import * as misskey from "calckey-js";
+import * as config from "@/config";
+import { defaultStore } from "@/store";
+
+type ReactionCountMap = Record<string, number>;
+
+function createReactionMuteMatchers() {
+        return defaultStore.state.reactionMutedWords.map((word) => ({
+                name: word.replaceAll(":", "").replace("@", ""),
+                exact: /^:@?\w+:$/.test(word),
+                hostmute: /^:?@[\w.-]/.test(word),
+        }));
+}
+
+function isMutedReaction(
+        reaction: string,
+        muteMatchers: ReturnType<typeof createReactionMuteMatchers>,
+) {
+        const emojiName = reaction
+                .replace(":", "")
+                .replace(/@[\w:\.\-]+:$/, "");
+        const emojiHost = reaction
+                .replace(/^:[\w:\.\-]+@/, "")
+                .replace(":", "");
+
+        if (
+                defaultStore.state.remoteReactionMute &&
+                emojiHost &&
+                emojiHost !== "." &&
+                emojiHost !== config.host
+        ) {
+                return true;
+        }
+
+        return muteMatchers.some((matcher) => {
+                if (matcher.exact) {
+                        if (matcher.hostmute) {
+                                return matcher.name === emojiHost;
+                        }
+                        return matcher.name === emojiName;
+                }
+
+                if (matcher.hostmute) {
+                        return emojiHost.includes(matcher.name);
+                }
+
+                return emojiName.includes(matcher.name);
+        });
+}
+
+export function getVisibleReactions(
+        note: misskey.entities.Note,
+): ReactionCountMap {
+        const muteMatchers = createReactionMuteMatchers();
+        let reactions: ReactionCountMap = { ...(note.reactions ?? {}) };
+
+        if (note.tags && note.text?.includes("#ゴルベーザ百天王バトル")) {
+                if (reactions["🅰️"] == null) {
+                        reactions["🅰️"] = 0;
+                }
+                if (reactions["🅱️"] == null) {
+                        reactions["🅱️"] = 0;
+                }
+        }
+
+        const localReactions = Object.keys(reactions).filter((x) =>
+                x.includes("@"),
+        );
+        const mergedReactions: ReactionCountMap = {};
+
+        localReactions.forEach((localReaction) => {
+                const targetReactions = Object.keys(reactions).filter((name) =>
+                        name.startsWith(localReaction.replace(/@[\w:\.\-]+:$/, "@")),
+                );
+                if (targetReactions.length === 0) return;
+
+                let totalCount = 0;
+                let maxReaction = {
+                        reaction: localReaction,
+                        count: reactions[localReaction] ?? 0,
+                };
+
+                targetReactions.forEach((name) => {
+                        const reactionCount = reactions[name] ?? 0;
+                        if (
+                                !localReaction.endsWith("@.:") &&
+                                maxReaction.count < reactionCount
+                        ) {
+                                maxReaction = { reaction: name, count: reactionCount };
+                        }
+                        totalCount += reactionCount;
+                        delete reactions[name];
+                });
+
+                if (isMutedReaction(maxReaction.reaction, muteMatchers)) {
+                        totalCount = 0;
+                }
+
+                mergedReactions[maxReaction.reaction] = totalCount;
+        });
+
+        const visibleReactions: ReactionCountMap = {
+                ...mergedReactions,
+                ...reactions,
+        };
+
+        Object.keys(visibleReactions).forEach((name) => {
+                if (isMutedReaction(name, muteMatchers)) {
+                        visibleReactions[name] = 0;
+                }
+        });
+
+        return visibleReactions;
+}
+
+export function getVisibleReactionsTotal(note: misskey.entities.Note): number {
+        const reactions = getVisibleReactions(note);
+        return Object.values(reactions).reduce((sum, count) => sum + count, 0);
+}


### PR DESCRIPTION
## 概要
- リアクションの集計・表示処理を共通化するユーティリティを追加
- ソフトミュートされた絵文字を総リアクション数から除外するようノート表示を調整
- サブノートやリアクションビューアでもユーティリティを利用し表示数を同期

## テスト
- pnpm --filter client lint （romｅ が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68edd67689ac832684d2b98299df4ab9