### PR TITLE
引用折りたたみ時のリアクション数表示の調整

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -582,8 +582,7 @@ const showUndoReactionButton = $computed(
 const showReactionCount = $computed(
         () =>
                 totalReactions > 0 &&
-                !enableEmojiReactions &&
-                !isDetailedView &&
+                ((!enableEmojiReactions && !isDetailedView) || !showContent.value) &&
                 !showStarButtonNoEmoji &&
                 (showReactionPickerButton || showUndoReactionButton)
 );


### PR DESCRIPTION
## 概要
- 引用を折りたたみ中でもリアクションピッカーボタン横に総数が表示されるよう条件を調整

## テスト
- 未実行（UI表示条件の調整のみ）

------
https://chatgpt.com/codex/tasks/task_e_68eddb196aec83269a3840d881b8bd61