### PR TITLE
preprocess.tsにunique処理を追加

### DIFF
--- a/packages/client/src/scripts/preprocess.ts
+++ b/packages/client/src/scripts/preprocess.ts
@@ -125,6 +125,11 @@ export function preprocess(text: string): string {
                                 node.props.text = sortByCharCode(mfm.toString(node.children));
                                 node.children = undefined;
                         }
+                        if (node.type === "fn" && node.props.name === "unique") {
+                                node.type = "text";
+                                node.props.text = uniqueText(mfm.toString(node.children));
+                                node.children = undefined;
+                        }
                         if (
                                 node.type === "fn" &&
                                 (node.props.name === "search" || node.props.name === "f")
@@ -203,6 +208,25 @@ function sortByCharCode(text: string): string {
                         node.props.text = arr.join("");
                 }
         });
-  
+
+        return mfm.toString(nodes);
+}
+
+function uniqueText(text: string): string {
+        const nodes = mfm.parse(text);
+
+        mfm.inspect(nodes, node => {
+                if (node.type === "text" && node.props.text) {
+                        const seen = new Set<string>();
+                        node.props.text = [...node.props.text]
+                                .filter((ch) => {
+                                        if (seen.has(ch)) return false;
+                                        seen.add(ch);
+                                        return true;
+                                })
+                                .join("");
+                }
+        });
+
         return mfm.toString(nodes);
 }


### PR DESCRIPTION
## 概要
- unique関数を追加し、テキストノード内で2回目以降の文字を除去
- preprocess内で`unique`関数呼び出し時にテキストノードへ変換

## テスト
- なし

------
https://chatgpt.com/codex/tasks/task_e_690be563b154832685544233d1760794