### PR TITLE
uniqueTextにおける重複除去ロジックの改善

### DIFF
--- a/packages/client/src/scripts/preprocess.ts
+++ b/packages/client/src/scripts/preprocess.ts
@@ -214,12 +214,16 @@ function sortByCharCode(text: string): string {
 
 function uniqueText(text: string): string {
         const nodes = mfm.parse(text);
+        const seen = new Set<string>();
 
         mfm.inspect(nodes, node => {
                 if (node.type === "text" && node.props.text) {
-                        const seen = new Set<string>();
                         node.props.text = [...node.props.text]
                                 .filter((ch) => {
+                                        if (/\s/.test(ch) || ch === "　") {
+                                                return true;
+                                        }
+
                                         if (seen.has(ch)) return false;
                                         seen.add(ch);
                                         return true;


### PR DESCRIPTION
## 概要
- uniqueText関数でノード全体を通した重複文字の削除を行うよう修正
- 空白文字(正規表現の\sに該当する文字と全角スペース)は重複しても削除しないよう調整

## テスト
- なし

------
https://chatgpt.com/codex/tasks/task_e_690c22678a688326b74ceb6fdef0266e