### PR TITLE
driveファイル取得APIのdate-timeフォーマット警告を解消

### DIFF
--- a/packages/backend/src/server/api/endpoints/drive/files.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files.ts
@@ -41,12 +41,10 @@ export const paramDef = {
                 },
                 fromDate: {
                         type: "string",
-                        format: "date-time",
                         nullable: true,
                 },
                 untilDate: {
                         type: "string",
-                        format: "date-time",
                         nullable: true,
                 },
         },


### PR DESCRIPTION
## 概要
- drive/filesエンドポイントのfromDateおよびuntilDateに指定されていた`date-time`フォーマットを削除し、未知フォーマット警告を回避

## テスト
- 未実施（該当なし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691160d50c70832690c78e2f7ea58ece)