### PR TITLE
ドライブ自動フォルダの年月・種別表示を修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/drive/auto-folders.ts
+++ b/packages/backend/src/server/api/endpoints/drive/auto-folders.ts
@@ -99,28 +99,23 @@ export default define(meta, paramDef, async (ps, user) => {
 
         const typesRaw = await applyTypeFilter(
                 DriveFiles.createQueryBuilder("file")
-                        .select("split_part(file.type, '/', 1)", "major")
+                        .select("file.type", "type")
+                        .addSelect("split_part(file.type, '/', 1)", "major")
                         .addSelect("COUNT(*)", "count")
                         .where("file.userId = :userId", { userId: user.id })
         )
-                .groupBy("major")
+                .groupBy("type")
+                .addGroupBy("major")
                 .orderBy("count", "DESC")
                 .getRawMany();
 
         const types = typesRaw
-                .filter((row: { major: string | null }) => row.major)
-                .map((row: { major: string; count: string }) => {
-                        const majorType = row.major;
-                        const type =
-                                ps.type && !ps.type.endsWith("/*")
-                                        ? ps.type
-                                        : `${majorType}/*`;
-                        return {
-                                majorType,
-                                type,
-                                count: Number(row.count),
-                        };
-                });
+                .filter((row: { type: string | null }) => row.type)
+                .map((row: { type: string; major: string | null; count: string }) => ({
+                        majorType: row.major ?? row.type.split("/")[0],
+                        type: row.type,
+                        count: Number(row.count),
+                }));
 
         return {
                 months,

--- a/packages/backend/src/server/api/endpoints/drive/files.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files.ts
@@ -59,10 +59,10 @@ export default define(meta, paramDef, async (ps, user) => {
 	).andWhere("file.userId = :userId", { userId: user.id });
 	query.orderBy("file.userId", "ASC");
 
-	if (ps.folderId) {
-		query.andWhere("file.folderId = :folderId", { folderId: ps.folderId });
-	} else {
-		query.andWhere("file.folderId IS NULL");
+        if (ps.folderId) {
+                query.andWhere("file.folderId = :folderId", { folderId: ps.folderId });
+        } else if (!ps.type && !ps.fromDate && !ps.untilDate) {
+                query.andWhere("file.folderId IS NULL");
         }
         query.addOrderBy("file.folderId", "ASC");
 

--- a/packages/client/src/components/MkDrive.vue
+++ b/packages/client/src/components/MkDrive.vue
@@ -217,8 +217,8 @@ type AutoFoldersData = {
                 count: number;
         }[];
         types: {
-                majorType: string;
-                type: string | null;
+                majorType: string | null;
+                type: string;
                 count: number;
         }[];
 };
@@ -291,7 +291,20 @@ function formatYearMonthLabel(year: number, month: number): string {
         });
 }
 
-function getFileTypeLabel(majorType: string): string {
+function formatMimeType(type: string): string {
+        const [major, minor] = type.split("/");
+        if (!major || !minor) return type;
+
+        const formattedMajor = `${major.charAt(0).toUpperCase()}${major.slice(1)}`;
+        return `${formattedMajor}/${minor.toUpperCase()}`;
+}
+
+function getFileTypeLabel(entry: AutoFoldersData["types"][number]): string {
+        if (entry.type) {
+                return formatMimeType(entry.type);
+        }
+
+        const majorType = entry.majorType;
         switch (majorType) {
                 case "image":
                         return i18n.ts.driveFileTypeImage;
@@ -306,7 +319,9 @@ function getFileTypeLabel(majorType: string): string {
                 case "model":
                         return i18n.ts.driveFileTypeModel;
                 default:
-                        return i18n.t("driveFileTypeOther", { type: majorType });
+                        return majorType
+                                ? i18n.t("driveFileTypeOther", { type: majorType })
+                                : i18n.ts.unknown;
         }
 }
 
@@ -360,8 +375,8 @@ function createFileTypeFolder(
         parent: VirtualDriveFolder,
 ): VirtualDriveFolder {
         return {
-                id: `${AUTO_FILE_TYPE_ROOT_ID}:${entry.majorType}`,
-                name: getFileTypeLabel(entry.majorType),
+                id: `${AUTO_FILE_TYPE_ROOT_ID}:${encodeURIComponent(entry.type)}`,
+                name: getFileTypeLabel(entry),
                 parentId: parent.id,
                 parent,
                 isVirtual: true,
@@ -371,6 +386,7 @@ function createFileTypeFolder(
                 },
                 meta: {
                         majorType: entry.majorType,
+                        type: entry.type,
                         count: entry.count,
                 },
         };


### PR DESCRIPTION
## 概要
- ドライブファイル一覧 API がフィルタ条件付きの場合に全フォルダを対象に取得するよう調整しました
- 自動フォルダの種別集計を MIME Type 単位で行うよう変更しました
- 自動フォルダの種別ラベルを MIME Type ベースの表示に更新しました

## テスト
- 未実施


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691169894230832688889a550cb1cfa7)