### PR TITLE
MIMEタイプの自動フォルダ検証を修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/drive/auto-folders.ts
+++ b/packages/backend/src/server/api/endpoints/drive/auto-folders.ts
@@ -50,7 +50,7 @@ export const paramDef = {
                 type: {
                         type: "string",
                         nullable: true,
-                        pattern: /^[a-zA-Z\/\-*]+$/.toString().slice(1, -1),
+                        pattern: /^[0-9a-zA-Z!#$&^_.+\/\-*]+$/.toString().slice(1, -1),
                 },
         },
         required: [],


### PR DESCRIPTION
## 概要
- drive/auto-foldersエンドポイントのMIME typeパラメータで数字や記号を許可するようにバリデーションを拡張

## テスト
- 未実施

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116c5eec808326996ffa810af40e21)