### PR TITLE
ドライブファイルの使用回数フィールドをAPIレスポンスから除外

### DIFF
--- a/packages/backend/src/models/repositories/drive-file.ts
+++ b/packages/backend/src/models/repositories/drive-file.ts
@@ -173,7 +173,6 @@ export const DriveFileRepository = db.getRepository(DriveFile).extend({
                         originalUrl: this.getPublicUrl(file, false, true),
                         comment: file.comment,
                         folderId: file.folderId,
-                        usageCount: file.usageCount,
                         folder:
                                 opts.detail && file.folderId
                                         ? DriveFolders.pack(file.folderId, {
@@ -216,7 +215,6 @@ export const DriveFileRepository = db.getRepository(DriveFile).extend({
                         originalUrl: this.getPublicUrl(file, false, true),
                         comment: file.comment,
                         folderId: file.folderId,
-                        usageCount: file.usageCount,
                         folder:
                                 opts.detail && file.folderId
                                         ? DriveFolders.pack(file.folderId, {

--- a/packages/backend/src/models/schema/drive-file.ts
+++ b/packages/backend/src/models/schema/drive-file.ts
@@ -110,11 +110,6 @@ export const packedDriveFileSchema = {
                         format: "id",
                         example: "xxxxxxxxxx",
                 },
-                usageCount: {
-                        type: "number",
-                        optional: false,
-                        nullable: false,
-                },
                 folder: {
                         type: "object",
                         optional: true,

--- a/packages/calckey-js/etc/calckey-js.api.md
+++ b/packages/calckey-js/etc/calckey-js.api.md
@@ -288,7 +288,6 @@ type DriveFile = {
     name: string;
     thumbnailUrl: string;
     url: string;
-    usageCount: number;
     type: string;
     size: number;
     md5: string;

--- a/packages/calckey-js/etc/misskey-js.api.md
+++ b/packages/calckey-js/etc/misskey-js.api.md
@@ -288,7 +288,6 @@ type DriveFile = {
     name: string;
     thumbnailUrl: string;
     url: string;
-    usageCount: number;
     type: string;
     size: number;
     md5: string;

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -134,7 +134,6 @@ export type DriveFile = {
         md5: string;
         blurhash: string;
         comment: string | null;
-        usageCount: number;
         properties: Record<string, any>;
 };
 

--- a/packages/client/src/components/MkDrive.vue
+++ b/packages/client/src/components/MkDrive.vue
@@ -462,7 +462,12 @@ function matchesCurrentFolder(file: Misskey.entities.DriveFile): boolean {
 
                 if (!matchesTypeFilter(effectiveType, file.type)) return false;
 
-                if (query.frequentlyUsed && (file.usageCount ?? 0) < 2) return false;
+                if (query.frequentlyUsed) {
+                        const alreadyListed = files.value.some(
+                                (existing) => existing.id === file.id,
+                        );
+                        if (!alreadyListed) return false;
+                }
 
                 if (query.fromDate) {
                         const from = new Date(query.fromDate);


### PR DESCRIPTION
## Summary
- ドライブファイルのパック処理とスキーマからusageCountを取り除き、外部APIに含めないようにしました
- TypeScriptの型定義と生成ドキュメントからusageCountを削除しました
- フロントエンドのドライブ画面でusageCountに依存していた判定を既存のファイル一覧を参照する形に調整しました

## Testing
- 未実施（テストが必要な場合はご指示ください）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117f550f488326b180242d5e200883)