### PR TITLE
force指定の送信を任意化

### DIFF
--- a/packages/client/src/components/MkDrive.vue
+++ b/packages/client/src/components/MkDrive.vue
@@ -150,6 +150,7 @@ import { stream } from "@/stream";
 import { defaultStore } from "@/store";
 import { i18n } from "@/i18n";
 import { uploadFile, uploads } from "@/scripts/upload";
+import type { UploadFileOptions } from "@/scripts/upload";
 import {
         isVirtualDriveFolder,
         type DriveFolderLike,
@@ -740,7 +741,11 @@ function onChangeFileInput() {
 	}
 }
 
-function upload(file: File, folderToUpload?: DriveFolderLike | null) {
+function upload(
+        file: File,
+        folderToUpload?: DriveFolderLike | null,
+        options?: UploadFileOptions,
+) {
         const targetFolderId =
                 folderToUpload && !isVirtualDriveFolder(folderToUpload)
                         ? folderToUpload.id
@@ -750,10 +755,12 @@ function upload(file: File, folderToUpload?: DriveFolderLike | null) {
                 targetFolderId,
                 undefined,
                 keepOriginal.value,
-                keepFileName.value
+                keepFileName.value,
+                undefined,
+                options
         ).then((res) => {
                 addFile(res, true);
-	});
+        });
 }
 
 function chooseFile(file: Misskey.entities.DriveFile) {

--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -789,6 +789,7 @@ import {
 	openAccountMenu as openAccountMenu_,
 } from "@/account";
 import { uploads, uploadFile } from "@/scripts/upload";
+import type { UploadFileOptions } from "@/scripts/upload";
 import { deepClone } from "@/scripts/clone";
 import XDraft from "@/components/MkDraftDialog.vue";
 import XCheatSheet from "@/components/MkCheatSheetDialog.vue";
@@ -1473,7 +1474,7 @@ function updateFileName(file, name) {
 	files[files.findIndex((x) => x.id === file.id)].name = name;
 }
 
-function upload(file: File, name?: string) {
+function upload(file: File, name?: string, options?: UploadFileOptions) {
     fileError = false;
 
     const promise = uploadFile(
@@ -1482,7 +1483,8 @@ function upload(file: File, name?: string) {
         name,
         undefined,
         undefined,
-        requiredFilename
+        requiredFilename,
+        options
     )
     .then((res) => {
         files.push(res);

--- a/packages/client/src/pages/messaging/messaging-room.form.vue
+++ b/packages/client/src/pages/messaging/messaging-room.form.vue
@@ -69,6 +69,7 @@ import { stream } from "@/stream";
 import { defaultStore } from "@/store";
 import { i18n } from "@/i18n";
 import { uploadFile } from "@/scripts/upload";
+import type { UploadFileOptions } from "@/scripts/upload";
 
 const props = defineProps<{
 	user?: Misskey.entities.UserDetailed | null;
@@ -205,12 +206,20 @@ function onChangeFile() {
 	if (fileEl.files![0]) upload(fileEl.files[0]);
 }
 
-function upload(fileToUpload: File, name?: string) {
-	uploadFile(fileToUpload, defaultStore.state.uploadFolder, name).then(
-		(res) => {
-			file = res;
-		}
-	);
+function upload(fileToUpload: File, name?: string, options?: UploadFileOptions) {
+        uploadFile(
+                fileToUpload,
+                defaultStore.state.uploadFolder,
+                name,
+                undefined,
+                undefined,
+                undefined,
+                options,
+        ).then(
+                (res) => {
+                        file = res;
+                }
+        );
 }
 
 function send() {

--- a/packages/client/src/scripts/select-file.ts
+++ b/packages/client/src/scripts/select-file.ts
@@ -5,14 +5,16 @@ import { stream } from "@/stream";
 import { i18n } from "@/i18n";
 import { defaultStore } from "@/store";
 import { uploadFile } from "@/scripts/upload";
+import type { UploadFileOptions } from "@/scripts/upload";
 
 function select(
-	src: any,
-	label: string | null,
-	multiple: boolean,
-	requiredFilename?: boolean,
-	keepFilename?: boolean,
-	to?: string,
+        src: any,
+        label: string | null,
+        multiple: boolean,
+        requiredFilename?: boolean,
+        keepFilename?: boolean,
+        to?: string,
+        options?: UploadFileOptions,
 ): Promise<DriveFile | DriveFile[]> {
 	return new Promise((res, rej) => {
 		const keepOriginal = ref(
@@ -35,16 +37,17 @@ function select(
 			input.type = "file";
 			input.multiple = multiple;
 			input.onchange = () => {
-				const promises = Array.from(input.files).map((file) =>
-					uploadFile(
-						file,
-						folderId,
-						undefined,
-						keepOriginal.value,
-						keepFileName.value,
-						requiredFilename,
-					),
-				);
+                                const promises = Array.from(input.files).map((file) =>
+                                        uploadFile(
+                                                file,
+                                                folderId,
+                                                undefined,
+                                                keepOriginal.value,
+                                                keepFileName.value,
+                                                requiredFilename,
+                                                options,
+                                        ),
+                                );
 
 				Promise.all(promises)
 					.then((driveFiles) => {
@@ -169,35 +172,39 @@ function select(
 }
 
 export function selectFile(
-	src: any,
-	label: string | null = null,
-	requiredFilename?: boolean,
-	keepFilename?: boolean,
-	to?: string,
+        src: any,
+        label: string | null = null,
+        requiredFilename?: boolean,
+        keepFilename?: boolean,
+        to?: string,
+        options?: UploadFileOptions,
 ): Promise<DriveFile> {
-	return select(
-		src,
-		label,
-		false,
-		requiredFilename,
-		keepFilename,
-		to,
-	) as Promise<DriveFile>;
+        return select(
+                src,
+                label,
+                false,
+                requiredFilename,
+                keepFilename,
+                to,
+                options,
+        ) as Promise<DriveFile>;
 }
 
 export function selectFiles(
-	src: any,
-	label: string | null = null,
-	requiredFilename?: boolean,
-	keepFilename?: boolean,
-	to?: string,
+        src: any,
+        label: string | null = null,
+        requiredFilename?: boolean,
+        keepFilename?: boolean,
+        to?: string,
+        options?: UploadFileOptions,
 ): Promise<DriveFile[]> {
-	return select(
-		src,
-		label,
-		true,
-		requiredFilename,
-		keepFilename,
-		to,
-	) as Promise<DriveFile[]>;
+        return select(
+                src,
+                label,
+                true,
+                requiredFilename,
+                keepFilename,
+                to,
+                options,
+        ) as Promise<DriveFile[]>;
 }

--- a/packages/client/src/scripts/upload.ts
+++ b/packages/client/src/scripts/upload.ts
@@ -31,13 +31,18 @@ const mimeTypeMap = {
 	"image/avif": "avif",
 } as const;
 
+export type UploadFileOptions = {
+        force?: boolean;
+};
+
 export function uploadFile(
-	file: File,
-	folder?: any,
-	name?: string,
-	keepOriginal: boolean = defaultStore.state.keepOriginalUploading,
-	keepFileName: boolean = defaultStore.state.keepFileName,
-	requiredFilename: boolean = false,
+        file: File,
+        folder?: any,
+        name?: string,
+        keepOriginal: boolean = defaultStore.state.keepOriginalUploading,
+        keepFileName: boolean = defaultStore.state.keepFileName,
+        requiredFilename: boolean = false,
+        options?: UploadFileOptions,
 ): Promise<Misskey.entities.DriveFile> {
 	if (folder && typeof folder === "object") folder = folder.id;
 
@@ -134,8 +139,10 @@ export function uploadFile(
 					}
 				}
 
-				const formData = new FormData();
-				formData.append("force", "true");
+                                const formData = new FormData();
+                                if (options?.force) {
+                                        formData.append("force", "true");
+                                }
 				formData.append("file", resizedImage || file);
 				formData.append("name", ctx.name);
 				if (folder) formData.append("folderId", folder);


### PR DESCRIPTION
## 概要
- uploadFileにforceオプションを追加し、必要時のみ付与するように変更
- ファイル選択ユーティリティからforceを指定できるよう引数を拡張
- アップロードを利用するフォームで新しいオプション引数を受け付けるよう対応

## テスト
- pnpm --filter client lint（romeが未インストールのため失敗）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911825e58e08326821021fc7c6f03a8)