### PR TITLE
アンテナメンバーキャッシュの無効化処理を追加

### DIFF
--- a/packages/backend/src/misc/antenna-members-cache.ts
+++ b/packages/backend/src/misc/antenna-members-cache.ts
@@ -1,0 +1,30 @@
+import { Cache } from "./cache.js";
+import type { User } from "@/models/entities/user.js";
+import { UserGroupJoinings, UserListJoinings } from "@/models/index.js";
+
+const listMembersCache = new Cache<User["id"][]>(1000 * 60 * 5);
+const groupMembersCache = new Cache<User["id"][]>(1000 * 60 * 5);
+
+export async function fetchListMembers(listId: string): Promise<User["id"][]> {
+        return listMembersCache.fetch(listId, () =>
+                UserListJoinings.findBy({
+                        userListId: listId,
+                }).then((res) => res.map((x) => x.userId)),
+        );
+}
+
+export async function fetchGroupMembers(userGroupId: string): Promise<User["id"][]> {
+        return groupMembersCache.fetch(userGroupId, () =>
+                UserGroupJoinings.findBy({
+                        userGroupId,
+                }).then((res) => res.map((x) => x.userId)),
+        );
+}
+
+export function invalidateListMembersCache(listId: string): void {
+        listMembersCache.delete(listId);
+}
+
+export function invalidateGroupMembersCache(userGroupId: string): void {
+        groupMembersCache.delete(userGroupId);
+}

--- a/packages/backend/src/misc/check-hit-antenna.ts
+++ b/packages/backend/src/misc/check-hit-antenna.ts
@@ -1,16 +1,13 @@
 import type { Antenna } from "@/models/entities/antenna.js";
 import type { Note } from "@/models/entities/note.js";
 import type { User } from "@/models/entities/user.js";
-import {
-	UserListJoinings,
-	UserGroupJoinings,
-	Blockings,
-} from "@/models/index.js";
+import { Blockings, UserGroupJoinings } from "@/models/index.js";
 import { getFullApAccount } from "./convert-host.js";
 import * as Acct from "@/misc/acct.js";
 import type { Packed } from "./schema.js";
 import { Cache } from "./cache.js";
 import config from "@/config/index.js";
+import { fetchGroupMembers, fetchListMembers } from "./antenna-members-cache.js";
 
 const blockingCache = new Cache<User["id"][]>(1000 * 60 * 5);
 
@@ -45,32 +42,28 @@ export async function checkHitAntenna(
 
 	if (!antenna.withReplies && note.replyId != null) return false;
 
-	if (antenna.src === "home") {
-		if (noteUserFollowers && !noteUserFollowers.includes(antenna.userId))
-			return false;
-		if (antennaUserFollowing && !antennaUserFollowing.includes(note.userId))
-			return false;
-	} else if (antenna.src === "list") {
-		const listUsers = (
-			await UserListJoinings.findBy({
-				userListId: antenna.userListId!,
-			})
-		).map((x) => x.userId);
+        if (antenna.src === "home") {
+                if (noteUserFollowers && !noteUserFollowers.includes(antenna.userId))
+                        return false;
+                if (antennaUserFollowing && !antennaUserFollowing.includes(note.userId))
+                        return false;
+        } else if (antenna.src === "list") {
+                const listUsers = await fetchListMembers(antenna.userListId!);
 
-		if (!listUsers.includes(note.userId)) return false;
-	} else if (antenna.src === "group") {
-		const joining = await UserGroupJoinings.findOneByOrFail({
-			id: antenna.userGroupJoiningId!,
-		});
+                const listUserSet = new Set(listUsers);
 
-		const groupUsers = (
-			await UserGroupJoinings.findBy({
-				userGroupId: joining.userGroupId,
-			})
-		).map((x) => x.userId);
+                if (!listUserSet.has(note.userId)) return false;
+        } else if (antenna.src === "group") {
+                const joining = await UserGroupJoinings.findOneByOrFail({
+                        id: antenna.userGroupJoiningId!,
+                });
 
-		if (!groupUsers.includes(note.userId)) return false;
-	} else if (antenna.src === "users") {
+                const groupUsers = await fetchGroupMembers(joining.userGroupId);
+
+                const groupUserSet = new Set(groupUsers);
+
+                if (!groupUserSet.has(note.userId)) return false;
+        } else if (antenna.src === "users") {
 		const accts = antenna.users.map((x) => {
 			const { username, host } = Acct.parse(x);
 			return getFullApAccount(username, host).toLowerCase();

--- a/packages/backend/src/server/api/endpoints/users/groups/create.ts
+++ b/packages/backend/src/server/api/endpoints/users/groups/create.ts
@@ -1,5 +1,6 @@
 import { UserGroups, UserGroupJoinings } from "@/models/index.js";
 import { genId } from "@/misc/gen-id.js";
+import { invalidateGroupMembersCache } from "@/misc/antenna-members-cache.js";
 import type { UserGroup } from "@/models/entities/user-group.js";
 import type { UserGroupJoining } from "@/models/entities/user-group-joining.js";
 import define from "../../../define.js";
@@ -38,12 +39,14 @@ export default define(meta, paramDef, async (ps, user) => {
 	} as UserGroup).then((x) => UserGroups.findOneByOrFail(x.identifiers[0]));
 
 	// Push the owner
-	await UserGroupJoinings.insert({
-		id: genId(),
-		createdAt: new Date(),
-		userId: user.id,
-		userGroupId: userGroup.id,
-	} as UserGroupJoining);
+        await UserGroupJoinings.insert({
+                id: genId(),
+                createdAt: new Date(),
+                userId: user.id,
+                userGroupId: userGroup.id,
+        } as UserGroupJoining);
 
-	return await UserGroups.pack(userGroup);
+        invalidateGroupMembersCache(userGroup.id);
+
+        return await UserGroups.pack(userGroup);
 });

--- a/packages/backend/src/server/api/endpoints/users/groups/invitations/accept.ts
+++ b/packages/backend/src/server/api/endpoints/users/groups/invitations/accept.ts
@@ -1,5 +1,6 @@
 import { UserGroupJoinings, UserGroupInvitations } from "@/models/index.js";
 import { genId } from "@/misc/gen-id.js";
+import { invalidateGroupMembersCache } from "@/misc/antenna-members-cache.js";
 import type { UserGroupJoining } from "@/models/entities/user-group-joining.js";
 import { ApiError } from "../../../../error.js";
 import define from "../../../../define.js";
@@ -45,12 +46,14 @@ export default define(meta, paramDef, async (ps, user) => {
 	}
 
 	// Push the user
-	await UserGroupJoinings.insert({
-		id: genId(),
-		createdAt: new Date(),
-		userId: user.id,
-		userGroupId: invitation.userGroupId,
-	} as UserGroupJoining);
+        await UserGroupJoinings.insert({
+                id: genId(),
+                createdAt: new Date(),
+                userId: user.id,
+                userGroupId: invitation.userGroupId,
+        } as UserGroupJoining);
 
-	UserGroupInvitations.delete(invitation.id);
+        invalidateGroupMembersCache(invitation.userGroupId);
+
+        UserGroupInvitations.delete(invitation.id);
 });

--- a/packages/backend/src/server/api/endpoints/users/groups/leave.ts
+++ b/packages/backend/src/server/api/endpoints/users/groups/leave.ts
@@ -1,4 +1,5 @@
 import { UserGroups, UserGroupJoinings } from "@/models/index.js";
+import { invalidateGroupMembersCache } from "@/misc/antenna-members-cache.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
 
@@ -49,5 +50,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		throw new ApiError(meta.errors.youAreOwner);
 	}
 
-	await UserGroupJoinings.delete({ userGroupId: userGroup.id, userId: me.id });
+        await UserGroupJoinings.delete({ userGroupId: userGroup.id, userId: me.id });
+
+        invalidateGroupMembersCache(userGroup.id);
 });

--- a/packages/backend/src/server/api/endpoints/users/groups/pull.ts
+++ b/packages/backend/src/server/api/endpoints/users/groups/pull.ts
@@ -1,4 +1,5 @@
 import { UserGroups, UserGroupJoinings } from "@/models/index.js";
+import { invalidateGroupMembersCache } from "@/misc/antenna-members-cache.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
 import { getUser } from "../../../common/getters.js";
@@ -66,8 +67,10 @@ export default define(meta, paramDef, async (ps, me) => {
 	}
 
 	// Pull the user
-	await UserGroupJoinings.delete({
-		userGroupId: userGroup.id,
-		userId: user.id,
-	});
+        await UserGroupJoinings.delete({
+                userGroupId: userGroup.id,
+                userId: user.id,
+        });
+
+        invalidateGroupMembersCache(userGroup.id);
 });

--- a/packages/backend/src/server/api/endpoints/users/lists/pull.ts
+++ b/packages/backend/src/server/api/endpoints/users/lists/pull.ts
@@ -1,5 +1,6 @@
 import { publishUserListStream } from "@/services/stream.js";
 import { UserLists, UserListJoinings, Users } from "@/models/index.js";
+import { invalidateListMembersCache } from "@/misc/antenna-members-cache.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
 import { getUser } from "../../../common/getters.js";
@@ -56,7 +57,9 @@ export default define(meta, paramDef, async (ps, me) => {
 	});
 
 	// Pull the user
-	await UserListJoinings.delete({ userListId: userList.id, userId: user.id });
+        await UserListJoinings.delete({ userListId: userList.id, userId: user.id });
 
-	publishUserListStream(userList.id, "userRemoved", await Users.pack(user));
+        invalidateListMembersCache(userList.id);
+
+        publishUserListStream(userList.id, "userRemoved", await Users.pack(user));
 });

--- a/packages/backend/src/services/blocking/create.ts
+++ b/packages/backend/src/services/blocking/create.ts
@@ -19,6 +19,7 @@ import { perUserFollowingChart } from "@/services/chart/index.js";
 import { genId } from "@/misc/gen-id.js";
 import { IdentifiableError } from "@/misc/identifiable-error.js";
 import { getActiveWebhooks } from "@/misc/webhook-cache.js";
+import { invalidateListMembersCache } from "@/misc/antenna-members-cache.js";
 import { webhookDeliver } from "@/queue/index.js";
 import { ensureProxyFollowsListedUser } from "../user-list/ensure-proxy-follow.js";
 
@@ -172,4 +173,8 @@ async function removeFromList(listOwner: User, user: User) {
         );
 
         await Promise.all(deletePromises);
+
+        for (const userList of userLists) {
+                invalidateListMembersCache(userList.id);
+        }
 }

--- a/packages/backend/src/services/user-list/push.ts
+++ b/packages/backend/src/services/user-list/push.ts
@@ -4,17 +4,20 @@ import type { UserList } from "@/models/entities/user-list.js";
 import { UserListJoinings, Users } from "@/models/index.js";
 import type { UserListJoining } from "@/models/entities/user-list-joining.js";
 import { genId } from "@/misc/gen-id.js";
+import { invalidateListMembersCache } from "@/misc/antenna-members-cache.js";
 import { ensureProxyFollowsListedUser } from "./ensure-proxy-follow.js";
 
 export async function pushUserToUserList(target: User, list: UserList) {
-	await UserListJoinings.insert({
-		id: genId(),
-		createdAt: new Date(),
-		userId: target.id,
-		userListId: list.id,
-	} as UserListJoining);
+        await UserListJoinings.insert({
+                id: genId(),
+                createdAt: new Date(),
+                userId: target.id,
+                userListId: list.id,
+        } as UserListJoining);
 
-	publishUserListStream(list.id, "userAdded", await Users.pack(target));
+        invalidateListMembersCache(list.id);
+
+        publishUserListStream(list.id, "userAdded", await Users.pack(target));
 
         await ensureProxyFollowsListedUser(target);
 }


### PR DESCRIPTION
## 概要
- アンテナで使用するリスト・グループメンバー取得キャッシュを共通化
- リストやグループのメンバー追加・削除時にキャッシュを明示的に無効化し、変更を即時反映

## テスト
- 未実施


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691409b6daf483269b5c39426c068977)