### PR TITLE
ミュート関連クエリの単体照会化とアンテナ処理の負荷削減

### DIFF
--- a/packages/backend/src/services/add-note-to-antenna.ts
+++ b/packages/backend/src/services/add-note-to-antenna.ts
@@ -8,6 +8,7 @@ import { createNotification } from "@/services/create-notification.js";
 import { webhookDeliver } from "@/queue/index.js";
 import { getActiveWebhooks } from "@/misc/webhook-cache.js";
 import type { User } from "@/models/entities/user.js";
+import { In } from "typeorm";
 
 export async function addNoteToAntenna(
 	antenna: Antenna,
@@ -16,48 +17,55 @@ export async function addNoteToAntenna(
 ) {
 	// 通知しない設定になっているか、自分自身の投稿なら既読にする
 	const read = !antenna.notify || antenna.userId === noteUser.id;
-	
+
 	AntennaNotes.insert({
 		id: genId(),
 		antennaId: antenna.id,
 		noteId: note.id,
 		read: read,
 	});
-	
+
 	publishAntennaStream(antenna.id, "note", note);
-	
+
 	if (!read) {
-		const mutingsPromise = Mutings.find({
-			where: {
-				muterId: antenna.userId,
-			},
-			select: ["muteeId"],
-		});
-	
-		const notePromises = (async () => {
-			const _note: Note = { ...note };
-	
+		const hydratedNote = await (async () => {
+			const expanded: Note = { ...note };
+
 			const [reply, renote] = await Promise.all([
 				note.replyId ? Notes.findOneBy({ id: note.replyId }) : null,
 				note.renoteId ? Notes.findOneBy({ id: note.renoteId }) : null,
 			]);
-	
-			_note.reply = reply;
-			_note.renote = renote;
-	
+
+			expanded.reply = reply;
+			expanded.renote = renote;
+
 			if (noteUser.id != null) {
-				_note.user = await Users.findOneBy({ id: noteUser.id });
+				expanded.user = await Users.findOneBy({ id: noteUser.id });
 			}
-	
-			return _note;
+
+			return expanded;
 		})();
-	
-		const [mutings, _note] = await Promise.all([mutingsPromise, notePromises]);
-	
-		if (isUserRelated(_note, new Set<string>(mutings.map((x) => x.muteeId)))) {
-			return;
+
+		const relatedUserIds = Array.from(collectRelatedUserIds(hydratedNote));
+
+		if (relatedUserIds.length > 0) {
+			const mutedUsers = await Mutings.find({
+				where: {
+					muterId: antenna.userId,
+					muteeId: In(relatedUserIds),
+				},
+				select: ["muteeId"],
+			});
+
+			if (mutedUsers.length > 0) {
+				const mutedUserSet = new Set<string>(mutedUsers.map((x) => x.muteeId));
+
+				if (isUserRelated(hydratedNote, mutedUserSet)) {
+					return;
+				}
+			}
 		}
-	
+
 		// 3秒経っても既読にならなかったら通知
 		setTimeout(async () => {
 			const unread = await AntennaNotes.findOneBy({
@@ -66,9 +74,9 @@ export async function addNoteToAntenna(
 			});
 			if (unread) {
 				publishMainStream(antenna.userId, "unreadAntenna", antenna);
-	
-				const __note = note.renoteId && !note.text ? _note.renote : note;
-	
+
+				const __note = note.renoteId && !note.text ? hydratedNote.renote : note;
+
 				// 通知を作成
 				createNotification(antenna.userId, "unreadAntenna", {
 					notifierId: noteUser.id,
@@ -76,7 +84,7 @@ export async function addNoteToAntenna(
 					noteId: __note.id,
 					reaction: antenna.name,
 				});
-	
+
 				const webhooks = await getActiveWebhooks().then((webhooks) =>
 					webhooks.filter(
 						(x) =>
@@ -85,7 +93,7 @@ export async function addNoteToAntenna(
 							!x.on.includes(`exclude-${x.id}`),
 					),
 				);
-	
+
 				const webhookPromises = webhooks.map(async (webhook) => {
 					const antennaUser = await Users.findOneByOrFail({
 						id: antenna.userId,
@@ -95,13 +103,41 @@ export async function addNoteToAntenna(
 						antenna: {
 							id: antenna.id,
 							name: antenna.name,
-							noteUser: _note.user,
+							noteUser: hydratedNote.user,
 						},
 					});
 				});
-	
+
 				await Promise.all(webhookPromises);
 			}
 		}, 3000);
-	}	
+	}
+}
+
+function collectRelatedUserIds(note: any, acc: Set<string> = new Set()): Set<string> {
+	if (note == null) {
+		return acc;
+	}
+
+	if (typeof note.userId === "string") {
+		acc.add(note.userId);
+	}
+
+	if (Array.isArray(note.mentions)) {
+		for (const userId of note.mentions) {
+			if (typeof userId === "string") {
+				acc.add(userId);
+			}
+		}
+	}
+
+	if (note.reply) {
+		collectRelatedUserIds(note.reply, acc);
+	}
+
+	if (note.renote) {
+		collectRelatedUserIds(note.renote, acc);
+	}
+
+	return acc;
 }

--- a/packages/backend/src/services/create-notification.ts
+++ b/packages/backend/src/services/create-notification.ts
@@ -92,13 +92,16 @@ export async function createNotification(
 		if (fresh.isRead) return;
 	
 		//#region ただしミュートしているユーザーからの通知なら無視
-		const mutings = await Mutings.findBy({
-			muterId: notifieeId,
-		});
-		if (
-			data.notifierId &&
-			mutings.map((m) => m.muteeId).includes(data.notifierId)
-		) {
+		const isNotifierMuted =
+			data.notifierId != null
+				? await Mutings.exist({
+						where: {
+							muterId: notifieeId,
+							muteeId: data.notifierId,
+						},
+					})
+				: false;
+		if (isNotifierMuted) {
 			return;
 		}
 		//#endregion

--- a/packages/backend/src/services/messages/create.ts
+++ b/packages/backend/src/services/messages/create.ts
@@ -97,10 +97,13 @@ export async function createMessage(
 			if (freshMessage.isRead) return; // 既読
 
 			//#region ただしミュートされているなら発行しない
-			const mute = await Mutings.findBy({
-				muterId: recipientUser.id,
+			const isSenderMuted = await Mutings.exist({
+				where: {
+					muterId: recipientUser.id,
+					muteeId: user.id,
+				},
 			});
-			if (mute.map((m) => m.muteeId).includes(user.id)) return;
+			if (isSenderMuted) return;
 			//#endregion
 
 			publishMainStream(recipientUser.id, "unreadMessagingMessage", messageObj);

--- a/packages/backend/src/services/note/unread.ts
+++ b/packages/backend/src/services/note/unread.ts
@@ -15,10 +15,13 @@ export async function insertNoteUnread(
 ) {
 	//#region ミュートしているなら無視
 	// TODO: 現在の仕様ではChannelにミュートは適用されないのでよしなにケアする
-	const mute = await Mutings.findBy({
-		muterId: userId,
+	const isMuted = await Mutings.exist({
+		where: {
+			muterId: userId,
+			muteeId: note.userId,
+		},
 	});
-	if (mute.map((m) => m.muteeId).includes(note.userId)) return;
+	if (isMuted) return;
 	//#endregion
 
 	// スレッドミュート


### PR DESCRIPTION
## 概要
- 未読登録・通知・DMでのミュート判定を `exist` を用いた単体照会に切り替えて全件取得を排除
- アンテナ通知経路で関連ユーザーIDのみを抽出し、`IN` 句でミュート情報を取得するよう最適化
- ノートに紐づくユーザーIDを再帰的に集めるヘルパーを追加し、アンテナ処理のミュート判定を効率化

## テスト
- 未実行（環境未整備のため）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914085248708326b0f8e0fdb0502af6)