### PR TITLE
iOS安全領域に合わせてナビ関連ボタンの下端位置を調整

### DIFF
--- a/packages/client/src/pages/messaging/messaging-room.vue
+++ b/packages/client/src/pages/messaging/messaging-room.vue
@@ -408,7 +408,7 @@ XMessage:last-of-type {
 		z-index: 2;
 		bottom: 0;
 		padding-top: 0.5rem;
-		bottom: calc(env(safe-area-inset-bottom, 0) + var(--stickyBottom));
+                bottom: var(--stickyBottom);
 
 		> .new-message {
 			width: 100%;

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -431,7 +431,13 @@ function top() {
 let navFooterHeight = $ref(0);
 provide<Ref<number>>("CURRENT_STICKY_BOTTOM", $$(navFooterHeight));
 
-const applyNavFooterMetrics = (height: number) => {
+const applyNavFooterMetrics = (el: HTMLElement) => {
+        const style = window.getComputedStyle(el);
+        const paddingBottom = Number.parseFloat(style.paddingBottom) || 0;
+        const paddingTop = Number.parseFloat(style.paddingTop) || 0;
+        const safeAreaInsetBottom = Math.max(paddingBottom - paddingTop, 0);
+        const height = Math.max(el.offsetHeight - safeAreaInsetBottom, 0);
+
         navFooterHeight = height;
         document.body.style.setProperty("--stickyBottom", `${height}px`);
         document.body.style.setProperty(
@@ -449,7 +455,7 @@ const resetNavFooterMetrics = () => {
 let navFooterObserver: ResizeObserver | null = null;
 
 const observeNavFooter = (el: HTMLElement) => {
-        const update = () => applyNavFooterMetrics(el.offsetHeight);
+        const update = () => applyNavFooterMetrics(el);
         update();
         navFooterObserver = new ResizeObserver(() => {
                 update();
@@ -584,9 +590,9 @@ console.log(mainRouter.currentRoute.value.name);
 		background: var(--bg);
 	}
 
-	> .postButton,
-	.widgetButton {
-		bottom: calc(env(safe-area-inset-bottom, 0) + var(--stickyBottom));
+        > .postButton,
+        .widgetButton {
+                bottom: var(--stickyBottom);
 		right: 1.5rem;
 		height: 4rem;
 		width: 4rem;


### PR DESCRIPTION
## 概要
- ナビフッターの高さから安全領域相当分を差し引いて `--stickyBottom` を設定
- ポストボタンとメッセージ画面フッターの `bottom` を `var(--stickyBottom)` のみに統一

## テスト
- 未実施（環境未整備のため）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691412e55dc48326a8ef636342f69406)