### PR TITLE
ビューポート変数の安定値を提供

### DIFF
--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -174,24 +174,51 @@ const initializeViewport = () => {
 
 	//#region SEE: https://css-tricks.com/the-trick-to-viewport-units-on-mobile/
 	// TODO: いつの日にか消したい
-	const vh = window.innerHeight * 0.01;
-	if (CSS.supports("height", "100dvh")) {
-		document.documentElement.style.setProperty("--vh", "1dvh");
-		document.documentElement.style.setProperty("--wph", "100dvh");
-	} else {
-		document.documentElement.style.setProperty("--vh", `${vh}px`);
-		document.documentElement.style.setProperty(
-			"--wph",
-			`${window.innerHeight}px`,
-		);
-	}
+        const supportsDynamicViewport = CSS.supports("height", "100dvh");
+        const rootStyle = document.documentElement.style;
+        const setViewportVariables = (height: number) => {
+                const vh = height * 0.01;
+                rootStyle.setProperty("--vh", `${vh}px`);
+                rootStyle.setProperty("--wph", `${height}px`);
+        };
+        // キーボード展開時に追従させたくない用途向けの安定値
+        const setStableViewportVariables = (height: number) => {
+                const vh = height * 0.01;
+                rootStyle.setProperty("--vh-stable", `${vh}px`);
+                rootStyle.setProperty("--wph-stable", `${height}px`);
+        };
+        const applyWindowInnerHeight = (height: number) => {
+                setStableViewportVariables(height);
+                if (!supportsDynamicViewport) {
+                        setViewportVariables(height);
+                }
+        };
 
-	window.addEventListener("resize", () => {
-		if (!CSS.supports("height", "100dvh")) {
-			const vh = window.innerHeight * 0.01;
-			document.documentElement.style.setProperty("--vh", `${vh}px`);
-		}
-	});
+        if (supportsDynamicViewport) {
+                rootStyle.setProperty("--vh", "1dvh");
+                rootStyle.setProperty("--wph", "100dvh");
+        } else {
+                setViewportVariables(window.innerHeight);
+        }
+
+        applyWindowInnerHeight(window.innerHeight);
+
+        window.addEventListener("resize", () => {
+                applyWindowInnerHeight(window.innerHeight);
+        });
+
+        const visualViewport = window.visualViewport;
+        if (!supportsDynamicViewport && visualViewport) {
+                const updateWithVisualViewport = () => {
+                        setViewportVariables(visualViewport.height);
+                };
+                visualViewport.addEventListener("resize", updateWithVisualViewport, {
+                        passive: true,
+                });
+                visualViewport.addEventListener("scroll", updateWithVisualViewport, {
+                        passive: true,
+                });
+        }
 	//#endregion
 
 	// If mobile, insert the viewport meta tag

--- a/packages/client/src/style.scss
+++ b/packages/client/src/style.scss
@@ -48,7 +48,7 @@ html {
 	touch-action: manipulation;
 	background-attachment: fixed;
 	background-size: cover;
-	background-size: auto calc(var(--wph) - var(--minBottomSpacing, 0));
+	background-size: auto calc(var(--wph-stable, var(--wph)) - var(--minBottomSpacing, 0));
 	background-position: top;
 	background-repeat: repeat-y;
 	color: var(--fg);
@@ -78,7 +78,7 @@ html {
 			background: var(--scrollbarHandle);
 			background-attachment: fixed;
 			background-size: cover;
-			background-size: auto calc(var(--wph) - var(--minBottomSpacing, 0));
+			background-size: auto calc(var(--wph-stable, var(--wph)) - var(--minBottomSpacing, 0));
 			background-position: top;
 			background-repeat: repeat-y;
 
@@ -86,7 +86,7 @@ html {
 				background: var(--scrollbarHandleHover);
 				background-attachment: fixed;
 				background-size: cover;
-				background-size: auto calc(var(--wph) - var(--minBottomSpacing, 0));
+				background-size: auto calc(var(--wph-stable, var(--wph)) - var(--minBottomSpacing, 0));
 				background-position: top;
 				background-repeat: repeat-y;
 			}
@@ -95,7 +95,7 @@ html {
 				background: var(--accent);
 				background-attachment: fixed;
 				background-size: cover;
-				background-size: auto calc(var(--wph) - var(--minBottomSpacing, 0));
+				background-size: auto calc(var(--wph-stable, var(--wph)) - var(--minBottomSpacing, 0));
 				background-position: top;
 				background-repeat: repeat-y;
 			}


### PR DESCRIPTION
## 概要
- ビューポート初期化時に `--vh-stable` / `--wph-stable` を設定し、キーボード展開時に追従させたくない用途向けの値を保持
- 背景などのレイアウト計算に安定値を利用し、ソフトキーボード表示時に不要なレイアウト移動を抑制

## テスト
- 未実施


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141568ac1c83268ffd6788b16dee43)