### PR TITLE
CARDINALITY を用いたノート添付ファイル判定とインデックス最適化

### DIFF
--- a/packages/backend/migration/1731000000000-note-has-files-index.js
+++ b/packages/backend/migration/1731000000000-note-has-files-index.js
@@ -1,0 +1,15 @@
+export class noteHasFilesIndex1731000000000 {
+        name = "noteHasFilesIndex1731000000000";
+
+        async up(queryRunner) {
+                await queryRunner.query(
+                        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_has_files" ON "note" USING btree ("id") WHERE CARDINALITY("fileIds") > 0`,
+                );
+        }
+
+        async down(queryRunner) {
+                await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_has_files"`);
+        }
+}
+
+noteHasFilesIndex1731000000000.prototype.transaction = false;

--- a/packages/backend/src/models/entities/note.ts
+++ b/packages/backend/src/models/entities/note.ts
@@ -137,12 +137,16 @@ export class Note {
 	})
 	public score: number;
 
-	@Index()
-	@Column({
-		...id(),
-		array: true, default: '{}',
-	})
-	public fileIds: DriveFile["id"][];
+        /**
+         * ファイル添付の有無を判定するクエリでは、必ず CARDINALITY(note."fileIds") を使用すること。
+         * 文字列リテラルの '{}' との比較は禁止（部分インデックスと同条件に揃えるため）。
+         */
+        @Index()
+        @Column({
+                ...id(),
+                array: true, default: '{}',
+        })
+        public fileIds: DriveFile["id"][];
 
 	@Index()
 	@Column('varchar', {

--- a/packages/backend/src/server/api/endpoints/notes.ts
+++ b/packages/backend/src/server/api/endpoints/notes.ts
@@ -70,11 +70,13 @@ export default define(meta, paramDef, async (ps) => {
 		);
 	}
 
-	if (ps.withFiles !== undefined) {
-		query.andWhere(
-			ps.withFiles ? "note.fileIds != '{}'" : "note.fileIds = '{}'",
-		);
-	}
+        if (ps.withFiles !== undefined) {
+                query.andWhere(
+                        ps.withFiles
+                                ? 'CARDINALITY(note."fileIds") > 0'
+                                : 'CARDINALITY(note."fileIds") = 0',
+                );
+        }
 
 	if (ps.poll !== undefined) {
 		query.andWhere(ps.poll ? "note.hasPoll = TRUE" : "note.hasPoll = FALSE");

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -116,7 +116,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.where("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -130,7 +130,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.where("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -144,9 +144,9 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 	query.andWhere("note.visibility != 'hidden'");
 	//#endregion
 

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -120,7 +120,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.userId = :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -134,7 +134,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.userId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -148,7 +148,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -162,7 +162,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserHost IS NOT NULL");
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -170,9 +170,9 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
 	query.andWhere("note.visibility != 'hidden'");
 	//#endregion

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -236,7 +236,7 @@ export default define(meta, paramDef, async (ps, user) => {
                         new Brackets((qb) => {
                                 qb.where("note.renoteId IS NULL");
                                 qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
                                 qb.orWhere(
                                         '0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
                                 );
@@ -251,7 +251,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.where("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -265,12 +265,12 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
-	if (ps.fileType != null) {
-		query.andWhere("note.fileIds != '{}'");
+        if (ps.fileType != null) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
 		query.andWhere(
 			new Brackets((qb) => {
 				for (const type of ps.fileType!) {

--- a/packages/backend/src/server/api/endpoints/notes/recommended-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/recommended-timeline.ts
@@ -86,10 +86,10 @@ export default define(meta, paramDef, async (ps, user) => {
 		ps.untilId,
 		ps.sinceDate,
 		ps.untilDate,
-	)
-		.andWhere(
-			"(note.fileIds != '{}' OR (note.renoteId IS NOT NULL AND note.text IS NULL AND renote.fileIds != '{}'))",
-		)
+        )
+                .andWhere(
+                        '(CARDINALITY(note."fileIds") > 0 OR (note.renoteId IS NOT NULL AND note.text IS NULL AND CARDINALITY(renote."fileIds") > 0))',
+                )
 		.andWhere("(note.visibility = 'public')")
 		.innerJoinAndSelect("note.user", "user")
 		.leftJoinAndSelect("user.avatar", "avatar")
@@ -139,12 +139,12 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
-	if (ps.fileType != null) {
-		query.andWhere("note.fileIds != '{}'");
+        if (ps.fileType != null) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
 		query.andWhere(
 			new Brackets((qb) => {
 				for (const type of ps.fileType!) {

--- a/packages/backend/src/server/api/endpoints/notes/search-by-tag.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search-by-tag.ts
@@ -140,9 +140,9 @@ export default define(meta, paramDef, async (ps, me) => {
 		}
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
 	if (ps.poll != null) {
 		if (ps.poll) {

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -413,7 +413,7 @@ export default define(meta, paramDef, async (ps, me) => {
                                 case "media":
                                 case "images":
                                 case "videos":
-                                        query.andWhere("note.fileIds != '{}'");
+                                        query.andWhere('CARDINALITY(note."fileIds") > 0');
                                         break;
                                 case "hashtags":
                                         query.andWhere("note.tags != '{}'");
@@ -431,7 +431,7 @@ export default define(meta, paramDef, async (ps, me) => {
                                         break;
                                 case "quote":
                                         query.andWhere("note.renoteId IS NOT NULL");
-                                        query.andWhere("(note.text IS NOT NULL OR note.fileIds != '{}')");
+                                        query.andWhere('(note.text IS NOT NULL OR CARDINALITY(note."fileIds") > 0)');
                                         break;
                                 case "safe":
                                         query.andWhere(`(note.cw NOT ILIKE '%シモ%' OR note.cw IS NULL)`);

--- a/packages/backend/src/server/api/endpoints/notes/spotlight-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/spotlight-timeline.ts
@@ -213,12 +213,12 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
-	if (ps.fileType != null) {
-		query.andWhere("note.fileIds != '{}'");
+        if (ps.fileType != null) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
 		query.andWhere(
 			new Brackets((qb) => {
 				for (const type of ps.fileType!) {

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -114,7 +114,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.userId = :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -128,7 +128,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.userId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -142,7 +142,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -156,7 +156,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserHost IS NOT NULL");
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -164,9 +164,9 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
 	query.andWhere("note.visibility != 'hidden'");
 	//#endregion

--- a/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -127,7 +127,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.userId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -141,7 +141,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -155,7 +155,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserHost IS NOT NULL");
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);
@@ -163,9 +163,9 @@ export default define(meta, paramDef, async (ps, user) => {
 		);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 	//#endregion
 
 	process.nextTick(() => {

--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -95,12 +95,12 @@ export default define(meta, paramDef, async (ps, me) => {
 		generateBlockedUserQuery(query, me);
 	}
 
-	if (ps.withFiles) {
-		query.andWhere("note.fileIds != '{}'");
-	}
+        if (ps.withFiles) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
+        }
 
-	if (ps.fileType != null) {
-		query.andWhere("note.fileIds != '{}'");
+        if (ps.fileType != null) {
+                query.andWhere('CARDINALITY(note."fileIds") > 0');
 		query.andWhere(
 			new Brackets((qb) => {
 				for (const type of ps.fileType!) {
@@ -137,7 +137,7 @@ export default define(meta, paramDef, async (ps, me) => {
 				qb.orWhere("note.userId != :userId", { userId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
 				qb.orWhere("note.text IS NOT NULL");
-				qb.orWhere("note.fileIds != '{}'");
+                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
 				qb.orWhere(
 					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
 				);


### PR DESCRIPTION
## 概要
- ノートの添付ファイル有無判定を CARDINALITY 比較に切り替え
- Note エンティティに CARDINALITY 条件利用の注意書きを追記
- 添付ファイル付きノートを高速化する部分インデックスを追加

## テスト
- `pnpm --filter backend lint` (rome が見つからず失敗)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141aa035a88326a553a79ba427f34b)