### PR TITLE
Followings.exist を用いた存在判定の最適化

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -219,17 +219,16 @@ export const NoteRepository = db.getRepository(Note).extend({
                                         following = !!_hint_.followings.get(note.userId);
                                         user = await userPromise;
                                 } else {
-                                        const [followingCount, resolvedUser] = await Promise.all([
-                                                Followings.count({
+                                        const [isFollowing, resolvedUser] = await Promise.all([
+                                                Followings.exist({
                                                         where: {
                                                                 followeeId: note.userId,
                                                                 followerId: meId,
                                                         },
-                                                        take: 1,
                                                 }),
                                                 userPromise,
                                         ]);
-                                        following = followingCount > 0;
+                                        following = isFollowing;
                                         user = resolvedUser;
                                 }
 

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -59,13 +59,11 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, user) => {
-	const hasFollowing =
-		(await Followings.count({
-			where: {
-				followerId: user.id,
-			},
-			take: 1,
-		})) !== 0;
+        const hasFollowing = await Followings.exist({
+                where: {
+                        followerId: user.id,
+                },
+        });
 
 	//#region Construct query
 	const followingQuery = Followings.createQueryBuilder("following")

--- a/packages/backend/src/services/following/create.ts
+++ b/packages/backend/src/services/following/create.ts
@@ -246,12 +246,14 @@ export default async function (
 			);
 	}
 
-	if (
-		(await Followings.countBy({
-			followerId: follower.id,
-			followeeId: followee.id,
-		})) > 0
-	) {
+        if (
+                await Followings.exist({
+                        where: {
+                                followerId: follower.id,
+                                followeeId: followee.id,
+                        },
+                })
+        ) {
 		// すでにフォロー関係が存在している場合
 		if (Users.isRemoteUser(follower) && Users.isLocalUser(followee)) {
 			// リモート → ローカル: acceptを送り返しておしまい


### PR DESCRIPTION
## 概要
- Followings.count/take を利用した存在判定を Followings.exist に置き換え
- Note パック処理やタイムライン生成におけるフォロー状態の判定結果型を boolean に整理
- フォロー作成サービスでの重複フォロー検知を exist 判定に刷新

## テスト
- pnpm lint (packages/calckey-js の依存関係不足により失敗)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141defb80c83268706c2b67e722fa1)