### PR TITLE
フォロー参照クエリをEXISTSで共通化

### DIFF
--- a/packages/backend/src/server/api/common/following-exists-condition.ts
+++ b/packages/backend/src/server/api/common/following-exists-condition.ts
@@ -1,0 +1,19 @@
+export interface FollowingExistsCondition {
+        clause(column: string): string;
+        parameters: Record<string, unknown>;
+}
+
+export function createFollowingExistsCondition(
+        followerId: string,
+        options?: { parameterName?: string; alias?: string },
+): FollowingExistsCondition {
+        const parameterName = options?.parameterName ?? "followingFollowerId";
+        const alias = options?.alias ?? "following_exists";
+
+        return {
+                clause(column: string) {
+                        return `EXISTS (SELECT 1 FROM "following" ${alias} WHERE ${alias}."followerId" = :${parameterName} AND ${alias}."followeeId" = ${column})`;
+                },
+                parameters: { [parameterName]: followerId },
+        };
+}

--- a/packages/backend/src/server/api/common/generate-replies-query.ts
+++ b/packages/backend/src/server/api/common/generate-replies-query.ts
@@ -1,12 +1,13 @@
 import type { User } from "@/models/entities/user.js";
 import type { SelectQueryBuilder } from "typeorm";
 import { Brackets } from "typeorm";
+import type { FollowingExistsCondition } from "./following-exists-condition.js";
 
 export function generateRepliesQuery(
-	q: SelectQueryBuilder<any>,
-	me?: Pick<User, "id" | "showTimelineReplies"> | null,
-	following?: string | null,
-	mode?: "all" | "notBotOnly" | "personalOnly"
+        q: SelectQueryBuilder<any>,
+        me?: Pick<User, "id" | "showTimelineReplies"> | null,
+        following?: FollowingExistsCondition | null,
+        mode?: "all" | "notBotOnly" | "personalOnly"
 ) {
 	if (me == null) {
 		q.andWhere(
@@ -26,13 +27,13 @@ export function generateRepliesQuery(
 					);
 			}),
 		);
-	} else if (!me.showTimelineReplies) {
-		if (following != null) {
-			q.andWhere(
-				new Brackets((qb) => {
-					qb.where("note.replyId IS NULL") // 返信ではない
-						.orWhere("note.replyUserId = :meId", { meId: me.id }) // 返信だけど自分のノートへの返信
-						.orWhere(
+        } else if (!me.showTimelineReplies) {
+                if (following != null) {
+                        q.andWhere(
+                                new Brackets((qb) => {
+                                        qb.where("note.replyId IS NULL") // 返信ではない
+                                                .orWhere("note.replyUserId = :meId", { meId: me.id }) // 返信だけど自分のノートへの返信
+                                                .orWhere(
 							new Brackets((qb) => {
 								qb.where(
 									// 返信だけど自分の行った返信
@@ -40,32 +41,52 @@ export function generateRepliesQuery(
 								).andWhere("note.userId = :meId", { meId: me.id });
 							}),
 						)
-						.orWhere(
-							new Brackets((qb) => {
-								qb.where(
-									// 返信だけど投稿者自身への返信
-									// ただし一つ前の投稿の返信へ遡ってチェックを行う
-									"note.replyId IS NOT NULL",
-								)
-									.andWhere("note.replyUserId = note.userId")
-									.andWhere(
-										`((reply.replyUserId IS NULL) OR (reply.replyUserId = note.userId) OR (reply.replyUserId IN (${following}) AND note.userId IN (${following})))`,
-									);
-							}),
-						)
-						if (mode !== "personalOnly") {
-							qb.orWhere(
-								new Brackets((qb) => {
-									qb.where(
-										// 返信だけどノート主、返信先をフォローしている
-										"note.replyId IS NOT NULL",
-									)
-										.andWhere(`note.replyUserId IN (${following})`)
-										.andWhere(`note.userId IN (${following})`);
-										if (mode === "notBotOnly") {
-											qb.andWhere("replyUser.isBot = false")
-											qb.andWhere("user.isBot = false")
-										}
+                                                .orWhere(
+                                                        new Brackets((qb) => {
+                                                                qb.where(
+                                                                        // 返信だけど投稿者自身への返信
+                                                                        // ただし一つ前の投稿の返信へ遡ってチェックを行う
+                                                                        "note.replyId IS NOT NULL",
+                                                                )
+                                                                        .andWhere("note.replyUserId = note.userId")
+                                                                        .andWhere(
+                                                                                new Brackets((qb) => {
+                                                                                        qb.where("reply.replyUserId IS NULL")
+                                                                                                .orWhere("reply.replyUserId = note.userId")
+                                                                                                .orWhere(
+                                                                                                        new Brackets((qb) => {
+                                                                                                                qb.where(
+                                                                                                                        following.clause(
+                                                                                                                                "reply.replyUserId",
+                                                                                                                        ),
+                                                                                                                ).andWhere(
+                                                                                                                        following.clause(
+                                                                                                                                "note.userId",
+                                                                                                                        ),
+                                                                                                                );
+                                                                                                        }),
+                                                                                                );
+                                                                                }),
+                                                                        );
+                                                        }),
+                                                )
+                                                if (mode !== "personalOnly") {
+                                                        qb.orWhere(
+                                                                new Brackets((qb) => {
+                                                                        qb.where(
+                                                                                // 返信だけどノート主、返信先をフォローしている
+                                                                                "note.replyId IS NOT NULL",
+                                                                        )
+                                                                                .andWhere(
+                                                                                        following.clause("note.replyUserId"),
+                                                                                )
+                                                                                .andWhere(
+                                                                                        following.clause("note.userId"),
+                                                                                );
+                                                                                if (mode === "notBotOnly") {
+                                                                                        qb.andWhere("replyUser.isBot = false")
+                                                                                        qb.andWhere("user.isBot = false")
+                                                                                }
 								}),
 							);
 						}

--- a/packages/backend/src/server/api/common/generate-visibility-query.ts
+++ b/packages/backend/src/server/api/common/generate-visibility-query.ts
@@ -1,7 +1,7 @@
 import type { User } from "@/models/entities/user.js";
-import { Followings } from "@/models/index.js";
 import type { SelectQueryBuilder } from "typeorm";
 import { Brackets } from "typeorm";
+import { createFollowingExistsCondition } from "./following-exists-condition.js";
 
 export function generateVisibilityQuery(
 	q: SelectQueryBuilder<any>,
@@ -16,13 +16,14 @@ export function generateVisibilityQuery(
 				);
 			}),
 		).andWhere(`note.localOnly = false`);
-	} else {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :meId");
+        } else {
+                const followingCondition = createFollowingExistsCondition(me.id, {
+                        parameterName: "visibilityFollowerId",
+                        alias: "following_visibility",
+                });
 
-		q.andWhere(
-			new Brackets((qb) => {
+                q.andWhere(
+                        new Brackets((qb) => {
 				qb
 					// 公開投稿である
 					.where(
@@ -41,22 +42,30 @@ export function generateVisibilityQuery(
 					.orWhere(
 						new Brackets((qb) => {
 							qb
-								// または フォロワー宛ての投稿であり、
-								.where(`note.visibility = 'followers'`)
-								.andWhere(
-									new Brackets((qb) => {
-										qb
-											// 自分がフォロワーである
-											.where(`note.userId IN (${followingQuery.getQuery()})`)
-											// または 自分の投稿へのリプライ
-											.orWhere("note.replyUserId = :meId");
-									}),
-								);
-						}),
-					);
-			}),
-		);
+                                                                // または フォロワー宛ての投稿であり、
+                                                                .where(`note.visibility = 'followers'`)
+                                                                .andWhere(
+                                                                        new Brackets((qb) => {
+                                                                                qb
+                                                                                        // 自分がフォロワーである
+                                                                                        .where(
+                                                                                                followingCondition.clause(
+                                                                                                        "note.userId",
+                                                                                                ),
+                                                                                        )
+                                                                                        // または 自分の投稿へのリプライ
+                                                                                        .orWhere("note.replyUserId = :meId");
+                                                                        }),
+                                                                );
+                                                }),
+                                        );
+                        }),
+                );
 
-		q.setParameters({ meId: me.id, meIdAsList: [me.id] });
-	}
+                q.setParameters({
+                        meId: me.id,
+                        meIdAsList: [me.id],
+                        ...followingCondition.parameters,
+                });
+        }
 }

--- a/packages/backend/src/server/api/endpoints/channels/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/channels/timeline.ts
@@ -1,7 +1,7 @@
 import define from "../../define.js";
 import { Brackets } from "typeorm";
 import { ApiError } from "../../error.js";
-import { Notes, Channels, Followings } from "@/models/index.js";
+import { Notes, Channels } from "@/models/index.js";
 import { safeForSql } from "@/misc/safe-for-sql.js";
 import { normalizeForSearch } from "@/misc/normalize-for-search.js";
 import { makePaginationQuery } from "../../common/make-pagination-query.js";
@@ -12,6 +12,7 @@ import { generateRepliesQuery } from "../../common/generate-replies-query.js";
 import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes", "channels"],
@@ -86,15 +87,13 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner")
 		.leftJoinAndSelect("note.channel", "channel");
 
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery());
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition);
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	generateVisibilityQuery(query, user);
 	if (user) generateMutedUserQuery(query, user);
 	if (user) generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/i/notifications.ts
+++ b/packages/backend/src/server/api/endpoints/i/notifications.ts
@@ -1,16 +1,11 @@
 import { Brackets } from "typeorm";
-import {
-	Notifications,
-	Followings,
-	Mutings,
-	Users,
-	UserProfiles,
-} from "@/models/index.js";
+import { Notifications, Mutings, Users, UserProfiles } from "@/models/index.js";
 import { notificationTypes } from "@/types.js";
 import read from "@/services/note/read.js";
 import { readNotification } from "../../common/read-notification.js";
 import define from "../../define.js";
 import { makePaginationQuery } from "../../common/make-pagination-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["account", "notifications"],
@@ -73,9 +68,7 @@ export default define(meta, paramDef, async (ps, user) => {
 	if (notificationTypes.every((type) => ps.excludeTypes?.includes(type))) {
 		return [];
 	}
-	const followingQuery = Followings.createQueryBuilder("following")
-		.select("following.followeeId")
-		.where("following.followerId = :followerId", { followerId: user.id });
+        const followingCondition = createFollowingExistsCondition(user.id);
 
 	const mutingQuery = Mutings.createQueryBuilder("muting")
 		.select("muting.muteeId")
@@ -140,13 +133,16 @@ export default define(meta, paramDef, async (ps, user) => {
 		}),
 	);
 
-	if (ps.following) {
-		query.andWhere(
-			`((notification.notifierId IN (${followingQuery.getQuery()})) OR (notification.notifierId = :meId))`,
-			{ meId: user.id },
-		);
-		query.setParameters(followingQuery.getParameters());
-	}
+        if (ps.following) {
+                query.andWhere(
+                        new Brackets((qb) => {
+                                qb.where(
+                                        followingCondition.clause("notification.notifierId"),
+                                ).orWhere("notification.notifierId = :meId", { meId: user.id });
+                        }),
+                );
+                query.setParameters(followingCondition.parameters);
+        }
 
 	if (false && !ps.allTypes) {
 		query.andWhere("notification.type <> 'unreadAntenna'");

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -1,6 +1,6 @@
 import { Brackets } from "typeorm";
 import { fetchMeta } from "@/misc/fetch-meta.js";
-import { Notes, Followings } from "@/models/index.js";
+import { Notes } from "@/models/index.js";
 import { activeUsersChart } from "@/services/chart/index.js";
 import define from "../../define.js";
 import { ApiError } from "../../error.js";
@@ -10,6 +10,7 @@ import { generateRepliesQuery } from "../../common/generate-replies-query.js";
 import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -93,15 +94,13 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
 		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner");
 
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery(), ps.showReplyMode ?? "all");
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition, ps.showReplyMode ?? "all");
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	if (user) {
 		generateMutedUserQuery(query, user);
 		generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -12,6 +12,7 @@ import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.j
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -70,28 +71,29 @@ export default define(meta, paramDef, async (ps, user) => {
 	}
 
 	//#region Construct query
-	const followingQuery = Followings.createQueryBuilder("following")
-		.select("following.followeeId")
-		.where("following.followerId = :followerId", { followerId: user.id });
+        const followingCondition = createFollowingExistsCondition(user.id);
 
-	const query = makePaginationQuery(
-		Notes.createQueryBuilder("note"),
+        const query = makePaginationQuery(
+                Notes.createQueryBuilder("note"),
 		ps.sinceId,
 		ps.untilId,
 		ps.sinceDate,
 		ps.untilDate,
 	)
-		.andWhere(
-			new Brackets((qb) => {
-				qb.where(
-					`((note.userId IN (${followingQuery.getQuery()})) OR (note.userId = :meId))`,
-					{ meId: user.id },
-				).orWhere(
+                .andWhere(
+                        new Brackets((qb) => {
+                                qb.where(
+                                        new Brackets((qb) => {
+                                                qb.where(
+                                                        followingCondition.clause("note.userId"),
+                                                ).orWhere("note.userId = :meId", { meId: user.id });
+                                        }),
+                                ).orWhere(
                 `(note.visibility = 'public') AND (note.userHost IS NULL OR note.userHost = ANY (:recommendedHosts))`,
                 { recommendedHosts: m.recommendedInstances },
             )
-			}),
-		)
+                        }),
+                )
 		.innerJoinAndSelect("note.user", "user")
 		.leftJoinAndSelect("user.avatar", "avatar")
 		.leftJoinAndSelect("user.banner", "banner")
@@ -100,13 +102,13 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("reply.user", "replyUser")
 		.leftJoinAndSelect("replyUser.avatar", "replyUserAvatar")
 		.leftJoinAndSelect("replyUser.banner", "replyUserBanner")
-		.leftJoinAndSelect("renote.user", "renoteUser")
-		.leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
-		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner")
-		.setParameters(followingQuery.getParameters());
+                .leftJoinAndSelect("renote.user", "renoteUser")
+                .leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
+                .leftJoinAndSelect("renoteUser.banner", "renoteUserBanner")
+                .setParameters(followingCondition.parameters);
 
-	generateChannelQuery(query, user);
-	generateRepliesQuery(query, user, followingQuery.getQuery());
+        generateChannelQuery(query, user);
+        generateRepliesQuery(query, user, followingCondition);
 	generateVisibilityQuery(query, user);
 	generateMutedUserQuery(query, user);
 	generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -12,6 +12,7 @@ import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.j
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 import type { Packed } from "@/misc/schema.js";
 
 export const meta = {
@@ -197,16 +198,14 @@ export default define(meta, paramDef, async (ps, user) => {
 			});
 	}
 
-	generateChannelQuery(query, user);
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery(), ps.showReplyMode ?? "all");
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        generateChannelQuery(query, user);
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition, ps.showReplyMode ?? "all");
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	generateVisibilityQuery(query, user);
 	if (user) generateMutedUserQuery(query, user);
 	if (user) generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/mentions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/mentions.ts
@@ -1,12 +1,13 @@
 import { Brackets } from "typeorm";
 import read from "@/services/note/read.js";
-import { Notes, Followings } from "@/models/index.js";
+import { Notes } from "@/models/index.js";
 import define from "../../define.js";
 import { generateVisibilityQuery } from "../../common/generate-visibility-query.js";
 import { generateMutedUserQuery } from "../../common/generate-muted-user-query.js";
 import { makePaginationQuery } from "../../common/make-pagination-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedNoteThreadQuery } from "../../common/generate-muted-note-thread-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -39,9 +40,7 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, user) => {
-	const followingQuery = Followings.createQueryBuilder("following")
-		.select("following.followeeId")
-		.where("following.followerId = :followerId", { followerId: user.id });
+        const followingCondition = createFollowingExistsCondition(user.id);
 
 	const query = makePaginationQuery(
 		Notes.createQueryBuilder("note"),
@@ -84,13 +83,17 @@ export default define(meta, paramDef, async (ps, user) => {
 		});
 	}
 
-	if (ps.following) {
-		query.andWhere(
-			`((note.userId IN (${followingQuery.getQuery()})) OR (note.userId = :meId))`,
-			{ meId: user.id },
-		);
-		query.setParameters(followingQuery.getParameters());
-	}
+        if (ps.following) {
+                query.andWhere(
+                        new Brackets((qb) => {
+                                qb.where(followingCondition.clause("note.userId")).orWhere(
+                                        "note.userId = :meId",
+                                        { meId: user.id },
+                                );
+                        }),
+                );
+                query.setParameters(followingCondition.parameters);
+        }
 
 	// We fetch more than requested because some may be filtered out, and if there's less than
 	// requested, the pagination stops.

--- a/packages/backend/src/server/api/endpoints/notes/recommended-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/recommended-timeline.ts
@@ -11,6 +11,7 @@ import { generateRepliesQuery } from "../../common/generate-replies-query.js";
 import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.js";
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -104,15 +105,13 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner");
 
 	generateChannelQuery(query, user);
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery(), ps.showReplyMode ?? "all");
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition, ps.showReplyMode ?? "all");
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	generateVisibilityQuery(query, user);
 
 	if (user) generateMutedUserQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -1,4 +1,4 @@
-import { In } from "typeorm";
+import { In, Brackets } from "typeorm";
 import { Followings, Notes } from "@/models/index.js";
 import { Note } from "@/models/entities/note.js";
 import config from "@/config/index.js";
@@ -10,6 +10,7 @@ import { generateVisibilityQuery } from "../../common/generate-visibility-query.
 import { generateMutedUserQuery } from "../../common/generate-muted-user-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { genId } from "@/misc/gen-id.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -392,16 +393,15 @@ export default define(meta, paramDef, async (ps, me) => {
                         switch (filter) {
                                 case "follows":
                                         if (me) {
-                                                const followingQuery = Followings.createQueryBuilder("following")
-                                                        .select("following.followeeId")
-                                                        .where("following.followerId = :followerId", {
-                                                                followerId: me.id,
-                                                        });
+                                                const followingCondition = createFollowingExistsCondition(me.id);
                                                 query.andWhere(
-                                                        `((note.userId IN (${followingQuery.getQuery()})) OR (note.userId = :meId))`,
-                                                        { meId: me.id },
+                                                        new Brackets((qb) => {
+                                                                qb.where(
+                                                                        followingCondition.clause("note.userId"),
+                                                                ).orWhere("note.userId = :meId", { meId: me.id });
+                                                        }),
                                                 );
-                                                query.setParameters(followingQuery.getParameters());
+                                                query.setParameters(followingCondition.parameters);
                                         }
                                         break;
                                 case "cw":

--- a/packages/backend/src/server/api/endpoints/notes/spotlight-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/spotlight-timeline.ts
@@ -13,6 +13,7 @@ import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.j
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -137,16 +138,14 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
 		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner");
 
-	generateChannelQuery(query, user);
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery());
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        generateChannelQuery(query, user);
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition);
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	generateVisibilityQuery(query, user);
 	if (user) generateMutedUserQuery(query, user);
 	if (user) generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -11,6 +11,7 @@ import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
 import { ApiError } from "../../error.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -66,12 +67,10 @@ export default define(meta, paramDef, async (ps, user) => {
         });
 
 	//#region Construct query
-	const followingQuery = Followings.createQueryBuilder("following")
-		.select("following.followeeId")
-		.where("following.followerId = :followerId", { followerId: user.id });
+        const followingCondition = createFollowingExistsCondition(user.id);
 
-	const query = makePaginationQuery(
-		Notes.createQueryBuilder("note"),
+        const query = makePaginationQuery(
+                Notes.createQueryBuilder("note"),
 		ps.sinceId,
 		ps.untilId,
 		ps.sinceDate,
@@ -79,11 +78,11 @@ export default define(meta, paramDef, async (ps, user) => {
 	)
 		.andWhere(
 			new Brackets((qb) => {
-				qb.where("note.userId = :meId", { meId: user.id });
-				if (hasFollowing)
-					qb.orWhere(`note.userId IN (${followingQuery.getQuery()})`);
-			}),
-		)
+                                qb.where("note.userId = :meId", { meId: user.id });
+                                if (hasFollowing)
+                                        qb.orWhere(followingCondition.clause("note.userId"));
+                        }),
+                )
 		.innerJoinAndSelect("note.user", "user")
 		.leftJoinAndSelect("user.avatar", "avatar")
 		.leftJoinAndSelect("user.banner", "banner")
@@ -94,11 +93,11 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("replyUser.banner", "replyUserBanner")
 		.leftJoinAndSelect("renote.user", "renoteUser")
 		.leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
-		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner")
-		.setParameters(followingQuery.getParameters());
+                .leftJoinAndSelect("renoteUser.banner", "renoteUserBanner")
+                .setParameters(followingCondition.parameters);
 
-	generateChannelQuery(query, user);
-	generateRepliesQuery(query, user, followingQuery.getQuery());
+        generateChannelQuery(query, user);
+        generateRepliesQuery(query, user, followingCondition);
 	generateVisibilityQuery(query, user);
 	generateMutedUserQuery(query, user);
 	generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -16,6 +16,7 @@ import { generateMutedNoteQuery } from "../../common/generate-muted-note-query.j
 import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["notes", "lists"],
@@ -105,16 +106,14 @@ export default define(meta, paramDef, async (ps, user) => {
 			userListId: list.id,
 		});
 
-	generateChannelQuery(query, user);
-	if (user) {
-		const followingQuery = Followings.createQueryBuilder("following")
-			.select("following.followeeId")
-			.where("following.followerId = :followerId", { followerId: user.id });
-		query.setParameters(followingQuery.getParameters());
-		generateRepliesQuery(query, user, followingQuery.getQuery());
-	} else {
-		generateRepliesQuery(query, user);
-	}
+        generateChannelQuery(query, user);
+        if (user) {
+                const followingCondition = createFollowingExistsCondition(user.id);
+                query.setParameters(followingCondition.parameters);
+                generateRepliesQuery(query, user, followingCondition);
+        } else {
+                generateRepliesQuery(query, user);
+        }
 	generateVisibilityQuery(query, user);
 	if (user) generateMutedUserQuery(query, user);
 	if (user) generateMutedNoteQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/users/recommendation.ts
+++ b/packages/backend/src/server/api/endpoints/users/recommendation.ts
@@ -1,11 +1,12 @@
-import { Users, Followings } from "@/models/index.js";
+import { Users } from "@/models/index.js";
 import define from "../../define.js";
 import { generateMutedUserQueryForUsers } from "../../common/generate-muted-user-query.js";
 import {
-	generateBlockedUserQuery,
-	generateBlockQueryForUsers,
+        generateBlockedUserQuery,
+        generateBlockQueryForUsers,
 } from "../../common/generate-block-query.js";
 import { DAY } from "@/const.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["users"],
@@ -54,13 +55,11 @@ export default define(meta, paramDef, async (ps, me) => {
 	generateBlockQueryForUsers(query, me);
 	generateBlockedUserQuery(query, me);
 
-	const followingQuery = Followings.createQueryBuilder("following")
-		.select("following.followeeId")
-		.where("following.followerId = :followerId", { followerId: me.id });
+        const followingCondition = createFollowingExistsCondition(me.id);
 
-	query.andWhere(`user.id NOT IN (${followingQuery.getQuery()})`);
+        query.andWhere(`NOT ${followingCondition.clause("user.id")}`);
 
-	query.setParameters(followingQuery.getParameters());
+        query.setParameters(followingCondition.parameters);
 
 	const users = await query.take(ps.limit).skip(ps.offset).getMany();
 

--- a/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
+++ b/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
@@ -1,9 +1,10 @@
 import { Brackets } from "typeorm";
-import { Followings, Users } from "@/models/index.js";
+import { Users } from "@/models/index.js";
 import { USER_ACTIVE_THRESHOLD } from "@/const.js";
 import type { User } from "@/models/entities/user.js";
 import define from "../../define.js";
 import config from "@/config/index.js";
+import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
 
 export const meta = {
 	tags: ["users"],
@@ -46,14 +47,12 @@ export default define(meta, paramDef, async (ps, me) => {
 		let users: User[] = [];
 
 		if (me) {
-			const followingQuery = Followings.createQueryBuilder("following")
-				.select("following.followeeId")
-				.where("following.followerId = :followerId", { followerId: me.id });
+                        const followingCondition = createFollowingExistsCondition(me.id);
 
-			const query = Users.createQueryBuilder("user");
-				query.where(`user.id IN (${followingQuery.getQuery()})`)
-				query.andWhere("user.id != :meId", { meId: me.id })
-				query.andWhere("user.isSuspended = FALSE")
+                        const query = Users.createQueryBuilder("user");
+                                query.where(followingCondition.clause("user.id"))
+                                query.andWhere("user.id != :meId", { meId: me.id })
+                                query.andWhere("user.isSuspended = FALSE")
 				if (ps.host) {
 					query.andWhere("coalesce(user.host, :url) LIKE :host", {
 						url: config.host,
@@ -76,7 +75,7 @@ export default define(meta, paramDef, async (ps, me) => {
 					);
 				}
 
-			query.setParameters(followingQuery.getParameters());
+                        query.setParameters(followingCondition.parameters);
 
 			users = await query
 				.orderBy("user.usernameLower", "ASC")
@@ -84,8 +83,8 @@ export default define(meta, paramDef, async (ps, me) => {
 				.getMany();
 
 			if (users.length < ps.limit) {
-				const otherQuery = Users.createQueryBuilder("user")
-					.where(`user.id NOT IN (${followingQuery.getQuery()})`)
+                                const otherQuery = Users.createQueryBuilder("user")
+                                        .where(`NOT ${followingCondition.clause("user.id")}`)
 					.andWhere("user.id != :meId", { meId: me.id })
 					.andWhere("user.isSuspended = FALSE")
 					if (ps.host) {
@@ -100,7 +99,7 @@ export default define(meta, paramDef, async (ps, me) => {
 						});
 					}
 
-				otherQuery.setParameters(followingQuery.getParameters());
+                                otherQuery.setParameters(followingCondition.parameters);
 
 				const otherUsers = await otherQuery
 					.orderBy("user.usernameLower", "ASC")


### PR DESCRIPTION
## 概要
- フォロー関係を判定する派生テーブルを`EXISTS`を使った相関サブクエリに統一
- 返信表示条件や可視性判定などで新しい共通ヘルパーを利用するように更新
- タイムラインや通知、ユーザー検索などのエンドポイントから重複した`followingQuery`文字列展開を撤廃

## テスト
- [ ] `pnpm --filter backend run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914204461388326a80370c752d22892)