### PR TITLE
ローカル絵文字更新判定の範囲を調整

### DIFF
--- a/packages/backend/src/server/api/endpoints.ts
+++ b/packages/backend/src/server/api/endpoints.ts
@@ -140,6 +140,7 @@ import * as ep___drive_stream from "./endpoints/drive/stream.js";
 import * as ep___emailAddress_available from "./endpoints/email-address/available.js";
 import * as ep___emoji from "./endpoints/emoji.js";
 import * as ep___emojis from "./endpoints/emojis.js";
+import * as ep___emojis_latest from "./endpoints/emojis/latest.js";
 import * as ep___emoji_stats from "./endpoints/emoji-stats.js";
 import * as ep___endpoint from "./endpoints/endpoint.js";
 import * as ep___endpoints from "./endpoints/endpoints.js";
@@ -509,9 +510,10 @@ const eps = [
 	["drive/folders/update", ep___drive_folders_update],
 	["drive/stream", ep___drive_stream],
 	["email-address/available", ep___emailAddress_available],
-	["emoji", ep___emoji],
-	["emojis", ep___emojis],
-	["emoji-stats", ep___emoji_stats],
+        ["emoji", ep___emoji],
+        ["emojis", ep___emojis],
+        ["emojis/latest", ep___emojis_latest],
+        ["emoji-stats", ep___emoji_stats],
 	["endpoint", ep___endpoint],
 	["endpoints", ep___endpoints],
 	["export-custom-emojis", ep___exportCustomEmojis],

--- a/packages/backend/src/server/api/endpoints/emojis.ts
+++ b/packages/backend/src/server/api/endpoints/emojis.ts
@@ -4,6 +4,16 @@ import { fetchMeta } from "@/misc/fetch-meta.js";
 import { Ads, Emojis, Users, RegistryItems } from "@/models/index.js";
 import define from "../define.js";
 
+async function getEmojiUpdatedAt() {
+        const latestEmoji = await Emojis.createQueryBuilder("emoji")
+                .select("MAX(COALESCE(emoji.updatedAt, emoji.createdAt))", "updatedAt")
+                .where("emoji.oldEmoji = :oldEmoji", { oldEmoji: false })
+                .andWhere("emoji.host IS NULL")
+                .getRawOne<{ updatedAt: Date | string | null }>();
+
+        return latestEmoji?.updatedAt ? new Date(latestEmoji.updatedAt) : null;
+}
+
 export const meta = {
 	tags: ["meta"],
 
@@ -15,13 +25,13 @@ export const meta = {
 		type: "object",
 		optional: false,
 		nullable: false,
-		properties: {
-			emojis: {
-				type: "array",
-				optional: false,
-				nullable: false,
-				items: {
-					type: "object",
+                properties: {
+                        emojis: {
+                                type: "array",
+                                optional: false,
+                                nullable: false,
+                                items: {
+                                        type: "object",
 					optional: false,
 					nullable: false,
 					properties: {
@@ -58,11 +68,17 @@ export const meta = {
 							nullable: false,
 							format: "url",
 						},
-					},
-				},
-			},
-		},
-	},
+                                        },
+                                },
+                        },
+                        emojiUpdatedAt: {
+                                type: "string",
+                                optional: true,
+                                nullable: true,
+                                format: "date-time",
+                        },
+                },
+        },
 } as const;
 
 export const paramDef = {
@@ -72,9 +88,11 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, me) => {
-	if (Object.keys(ps ?? {})?.filter((x) => x !== "i").length === 0 && me) {
-		const item = RegistryItems.createQueryBuilder("item")
-			.where("item.domain IS NULL")
+        const emojiUpdatedAtPromise = getEmojiUpdatedAt();
+
+        if (Object.keys(ps ?? {})?.filter((x) => x !== "i").length === 0 && me) {
+                const item = RegistryItems.createQueryBuilder("item")
+                        .where("item.domain IS NULL")
 			.andWhere("item.userId = :userId", { userId: me.id })
 			.andWhere("item.key = 'externalOutputAllEmojis'")
 			.andWhere("item.scope = :scope", { scope: ["client", "base"] })
@@ -126,12 +144,13 @@ export default define(meta, paramDef, async (ps, me) => {
 						updatedAt: emoji.updatedAt,
 					};
 				})
-				.filter(Boolean);
-			return {
-				emojis,
-			};
-		}
-	}
+                                .filter(Boolean);
+                        return {
+                                emojis,
+                                emojiUpdatedAt: await emojiUpdatedAtPromise,
+                        };
+                }
+        }
 
 	let emojis = await Emojis.find({
 		where: {
@@ -250,11 +269,12 @@ export default define(meta, paramDef, async (ps, me) => {
 		remoteEmojiMode = "all";
 	}
 
-	return {
-		emojis: await Emojis.packMany(
-			emojis.filter((x) => !x.category?.startsWith("!")),
-		),
-		...(remoteEmojiMode && remoteEmojis && me
+        return {
+                emojiUpdatedAt: await emojiUpdatedAtPromise,
+                emojis: await Emojis.packMany(
+                        emojis.filter((x) => !x.category?.startsWith("!")),
+                ),
+                ...(remoteEmojiMode && remoteEmojis && me
 			? {
 					emojiFetchDate: new Date(),
 					remoteEmojiMode: remoteEmojiMode,

--- a/packages/backend/src/server/api/endpoints/emojis/latest.ts
+++ b/packages/backend/src/server/api/endpoints/emojis/latest.ts
@@ -1,0 +1,49 @@
+import { Emojis } from "@/models/index.js";
+import define from "../../define.js";
+
+export const meta = {
+        tags: ["meta"],
+        requireCredential: false,
+        requireCredentialPrivateMode: true,
+        allowGet: true,
+        res: {
+                type: "object",
+                optional: false,
+                nullable: false,
+                properties: {
+                        emojiUpdatedAt: {
+                                type: "string",
+                                optional: true,
+                                nullable: true,
+                        },
+                },
+        },
+} as const;
+
+export const paramDef = {
+        type: "object",
+        properties: {},
+        required: [],
+} as const;
+
+export default define(meta, paramDef, async () => {
+        const latestEmoji = await Emojis.createQueryBuilder("emoji")
+                .select("MAX(COALESCE(emoji.updatedAt, emoji.createdAt))", "updatedAt")
+                .where("emoji.oldEmoji = :oldEmoji", { oldEmoji: false })
+                .andWhere("emoji.host IS NULL")
+                .getRawOne<{ updatedAt: Date | string | null }>();
+
+        let emojiUpdatedAt: string | null = null;
+
+        if (latestEmoji?.updatedAt != null) {
+                const timestamp = new Date(latestEmoji.updatedAt).valueOf();
+                if (!Number.isNaN(timestamp)) {
+                        emojiUpdatedAt = new Date(timestamp).toISOString();
+                }
+        }
+
+        return {
+                emojiUpdatedAt,
+        };
+});
+

--- a/packages/calckey-js/src/api.types.ts
+++ b/packages/calckey-js/src/api.types.ts
@@ -362,24 +362,27 @@ export type Endpoints = {
 		};
 		res: TODO;
 	};
-	"charts/users": {
-		req: { span: "day" | "hour"; limit?: number; offset?: number | null };
-		res: {
-			local: {
-				dec: number[];
-				inc: number[];
-				total: number[];
-			};
-			remote: {
-				dec: number[];
-				inc: number[];
-				total: number[];
-			};
-		};
-	};
+        "charts/users": {
+                req: { span: "day" | "hour"; limit?: number; offset?: number | null };
+                res: {
+                        local: {
+                                dec: number[];
+                                inc: number[];
+                                total: number[];
+                        };
+                        remote: {
+                                dec: number[];
+                                inc: number[];
+                                total: number[];
+                        };
+                };
+        };
 
-	// clips
-	"clips/add-note": { req: TODO; res: TODO };
+        // emojis
+        "emojis/latest": { req: NoParams; res: { emojiUpdatedAt: DateString | null } };
+
+        // clips
+        "clips/add-note": { req: TODO; res: TODO };
 	"clips/create": { req: TODO; res: TODO };
 	"clips/delete": { req: { clipId: Clip["id"] }; res: null };
 	"clips/list": { req: TODO; res: TODO };

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -312,12 +312,13 @@ export type LiteInstanceMetadata = {
 	maxNoteTextLength: number;
 	enableEmail: boolean;
 	enableTwitterIntegration: boolean;
-	enableGithubIntegration: boolean;
-	enableDiscordIntegration: boolean;
-	enableServiceWorker: boolean;
-	emojis: CustomEmoji[];
-	ads: {
-		id: ID;
+        enableGithubIntegration: boolean;
+        enableDiscordIntegration: boolean;
+        enableServiceWorker: boolean;
+        emojiUpdatedAt: DateString | null;
+        emojis: CustomEmoji[];
+        ads: {
+                id: ID;
 		ratio: number;
 		place: string;
 		url: string;

--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -622,64 +622,108 @@ const initializePlugins = () => {
 };
 
 const initializeEmoji = async () => {
-	fetchEmoji();
-	fetchEmojiStats(defaultStore.state.enableDataSaverMode ? 31 : 120);
-	const lastEmojiFetchDate = (await get("remoteEmojiData"))
-		? (await get("remoteEmojiData"))?.emojiFetchDate
-		: undefined;
-	const emojiFetchDateInt = Math.max(
-		lastEmojiFetchDate ? new Date(lastEmojiFetchDate).valueOf() : 0,
-		(await get("emojiFetchAttemptDate"))
-			? Number.parseInt(await get("emojiFetchAttemptDate"), 10)
-			: 0,
-	);
-	const defaultRemoteEmojisFetchMode = defaultStore.def.remoteEmojisFetch.default;
-	let fetchModeMax =
-		defaultStore.state.remoteEmojisFetch ?? defaultRemoteEmojisFetchMode ?? "all";
-	// 更新間隔 : データセーバーなら、24時間 そうでないなら、6時間
-	const fetchTimeBorder = defaultStore.state.enableDataSaverMode
-		? 1000 * 60 * 60 * 24
-		: 1000 * 60 * 60 * 6;
+        fetchEmojiStats(defaultStore.state.enableDataSaverMode ? 31 : 120);
 
-	if (
-		fetchModeMax === "always" ||
-		Date.now() - emojiFetchDateInt > fetchTimeBorder ||
-		fetchModeMax !== ((await get("lastFetchModeMax")) ?? fetchModeMax)
-	) {
-		// 常に取得がon or 最終取得日が無い or 前回取得から更新間隔以上 or 取得設定が前回と異なる場合絵文字を取得
-		//一度キャッシュを破棄
-		if (fetchModeMax !== "keep") {
-			localStorage.removeItem("emojiData");
-			localStorage.removeItem("remoteEmojiData");
-			localStorage.removeItem("lastFetchModeMax");
-			localStorage.removeItem("emojiFetchAttemptDate");
-			await del("remoteEmojiData");
-		}
-		// 一度だけ更新の場合、データモードを前回と同じにしておく
-		if (fetchModeMax === "once") {
-			const lastFetchModeMax = (await get("lastFetchModeMax")) ?? fetchModeMax;
-			fetchModeMax = lastFetchModeMax;
-			defaultStore.set("remoteEmojisFetch", lastFetchModeMax);
-		}
-		// 取得設定を保存
-		await set("lastFetchModeMax", fetchModeMax);
-		// 最終試行日を更新する
-		await set("emojiFetchAttemptDate", Date.now());
-		if (fetchModeMax === "always") {
-			fetchAllEmojiNoCache();
-		} else if (fetchModeMax === "all") {
-			fetchAllEmoji().catch(() => {
-				// 保存に失敗した場合は軽量版リモート絵文字の取得を試行
-				fetchPlusEmoji();
-			});
-		} else if (fetchModeMax === "plus") {
-			fetchPlusEmoji();
-		}
-	}
-	// 取得設定を保存
-	await set("lastFetchModeMax", fetchModeMax);
-	// 絵文字を読み込み直す
-	emojiLoad();
+        const [remoteEmojiData, cachedEmojiData, emojiFetchAttemptDateRaw, lastFetchModeMaxRaw] =
+                await Promise.all([
+                        get("remoteEmojiData"),
+                        get("emojiData"),
+                        get("emojiFetchAttemptDate"),
+                        get("lastFetchModeMax"),
+                ]);
+
+        const toTimestamp = (value: unknown): number | null => {
+                if (value == null) return null;
+                if (typeof value === "number") {
+                        return Number.isFinite(value) ? value : null;
+                }
+                const date = value instanceof Date ? value : new Date(value as any);
+                const timestamp = date.valueOf();
+                return Number.isNaN(timestamp) ? null : timestamp;
+        };
+
+        let serverUpdatedAt: number | null = null;
+        try {
+                const latest = await api("emojis/latest");
+                serverUpdatedAt = toTimestamp(latest?.emojiUpdatedAt);
+        } catch (err) {
+                console.warn("絵文字の更新時刻の取得に失敗しました", err);
+        }
+
+        const localUpdatedAt = toTimestamp((cachedEmojiData as any)?.emojiUpdatedAt);
+        const serverMatchesLocalCache =
+                serverUpdatedAt !== null &&
+                localUpdatedAt !== null &&
+                serverUpdatedAt <= localUpdatedAt;
+
+        const TWELVE_HOURS = 1000 * 60 * 60 * 12;
+
+        const localFetchDate = toTimestamp((cachedEmojiData as any)?.emojiFetchDate);
+        const hasLocalEmojis = Array.isArray((cachedEmojiData as any)?.emojis)
+                ? ((cachedEmojiData as any)?.emojis?.length ?? 0) > 0
+                : false;
+        const localFetchIsStale =
+                localFetchDate === null || Date.now() - localFetchDate >= TWELVE_HOURS;
+
+        if (!hasLocalEmojis || !serverMatchesLocalCache || localFetchIsStale) {
+                fetchEmoji();
+        }
+
+        const defaultRemoteEmojisFetchMode = defaultStore.def.remoteEmojisFetch.default;
+        let fetchModeMax =
+                defaultStore.state.remoteEmojisFetch ?? defaultRemoteEmojisFetchMode ?? "all";
+
+        const storedLastFetchModeMax =
+                typeof lastFetchModeMaxRaw === "string" ? lastFetchModeMaxRaw : undefined;
+        const fetchModeChanged =
+                storedLastFetchModeMax !== undefined && fetchModeMax !== storedLastFetchModeMax;
+
+        const fetchAttemptDate = toTimestamp(emojiFetchAttemptDateRaw);
+        const remoteFetchDate = toTimestamp((remoteEmojiData as any)?.emojiFetchDate);
+        const emojiFetchDateInt = Math.max(remoteFetchDate ?? 0, fetchAttemptDate ?? 0);
+
+        const fetchTimeBorder = defaultStore.state.enableDataSaverMode
+                ? 1000 * 60 * 60 * 24
+                : 1000 * 60 * 60 * 6;
+
+        const remoteFetchIsStale =
+                emojiFetchDateInt === 0 || Date.now() - emojiFetchDateInt >= fetchTimeBorder;
+
+        if (
+                fetchModeMax === "always" ||
+                remoteFetchIsStale ||
+                fetchModeChanged
+        ) {
+                if (fetchModeMax !== "keep") {
+                        localStorage.removeItem("emojiData");
+                        localStorage.removeItem("remoteEmojiData");
+                        localStorage.removeItem("lastFetchModeMax");
+                        localStorage.removeItem("emojiFetchAttemptDate");
+                        await del("remoteEmojiData");
+                }
+
+                if (fetchModeMax === "once") {
+                        const lastFetchModeMax = storedLastFetchModeMax ?? fetchModeMax;
+                        fetchModeMax = lastFetchModeMax;
+                        defaultStore.set("remoteEmojisFetch", lastFetchModeMax);
+                }
+
+                await set("lastFetchModeMax", fetchModeMax);
+                await set("emojiFetchAttemptDate", Date.now());
+
+                if (fetchModeMax === "always") {
+                        fetchAllEmojiNoCache();
+                } else if (fetchModeMax === "all") {
+                        fetchAllEmoji().catch(() => {
+                                fetchPlusEmoji();
+                        });
+                } else if (fetchModeMax === "plus") {
+                        fetchPlusEmoji();
+                }
+        }
+
+        await set("lastFetchModeMax", fetchModeMax);
+        emojiLoad();
 };
 
 const saveFailedQueueDatas = () => {

--- a/packages/client/src/instance.ts
+++ b/packages/client/src/instance.ts
@@ -43,10 +43,24 @@ stream.on("emojiDeleted", (emojiData) => {
 });
 
 export async function emojiLoad() {
-	if (!localStorage.getItem("followCategoriesTime") || Date.now() - localStorage.getItem("followCategoriesTime") > 60 * 60 * 1000) {
-		await fetchCustomCategory()
-		
-	}
+        const cachedEmojiData = await get("emojiData");
+
+        if (cachedEmojiData?.emojis) {
+                instance.emojis = cachedEmojiData.emojis as typeof instance.emojis;
+        }
+
+        if (cachedEmojiData?.emojiUpdatedAt) {
+                instance.emojiUpdatedAt = cachedEmojiData.emojiUpdatedAt;
+        }
+
+        if (cachedEmojiData?.emojiFetchDate) {
+                instance.emojiFetchDate = cachedEmojiData.emojiFetchDate;
+        }
+
+        if (!localStorage.getItem("followCategoriesTime") || Date.now() - localStorage.getItem("followCategoriesTime") > 60 * 60 * 1000) {
+                await fetchCustomCategory()
+
+        }
 	if (!instance.remoteEmojiMode) {
 		const remoteEmoji = await get("remoteEmojiData");
 
@@ -152,15 +166,18 @@ export async function fetchInstance() {
 }
 
 export async function fetchEmoji() {
-	const meta = await api("emojis", {
-		includeUrl: true,
-	});
+        const meta = await api("emojis", {
+                includeUrl: true,
+        });
 
-	await set("emojiData", meta);
+        const emojiFetchDate = new Date().toISOString();
+        const storedMeta = { ...meta, emojiFetchDate };
 
-	for (const [k, v] of Object.entries(meta)) {
-		instance[k] = v;
-	}
+        await set("emojiData", storedMeta);
+
+        for (const [k, v] of Object.entries(storedMeta)) {
+                instance[k] = v;
+        }
 }
 
 type EmojiFetchOptions = {
@@ -193,18 +210,27 @@ export async function fetchPlusEmoji(options?: EmojiFetchOptions) {
                 options,
         );
 
-	const remoteEmojiData = {
-		emojiFetchDate: meta.emojiFetchDate,
-		remoteEmojiMode: meta.remoteEmojiMode,
-		remoteEmojiCount: meta.remoteEmojiCount,
-		allEmojis: meta.allEmojis,
-	};
+        const remoteEmojiData = {
+                emojiFetchDate: meta.emojiFetchDate,
+                remoteEmojiMode: meta.remoteEmojiMode,
+                remoteEmojiCount: meta.remoteEmojiCount,
+                allEmojis: meta.allEmojis,
+                emojiUpdatedAt: meta.emojiUpdatedAt,
+        };
 
-	await set("remoteEmojiData", remoteEmojiData);
+        await set("remoteEmojiData", remoteEmojiData);
 
-	for (const [k, v] of Object.entries(meta)) {
-		instance[k] = v;
-	}
+        const localEmojiSnapshot = {
+                emojis: meta.emojis,
+                emojiUpdatedAt: meta.emojiUpdatedAt,
+                emojiFetchDate: meta.emojiFetchDate ?? new Date().toISOString(),
+        };
+
+        await set("emojiData", localEmojiSnapshot);
+
+        for (const [k, v] of Object.entries(meta)) {
+                instance[k] = v;
+        }
 }
 
 export async function fetchAllEmoji(options?: EmojiFetchOptions) {
@@ -215,18 +241,27 @@ export async function fetchAllEmoji(options?: EmojiFetchOptions) {
                 options,
         );
 
-	const remoteEmojiData = {
-		emojiFetchDate: meta.emojiFetchDate,
-		remoteEmojiMode: meta.remoteEmojiMode,
-		remoteEmojiCount: meta.remoteEmojiCount,
-		allEmojis: meta.allEmojis,
-	};
+        const remoteEmojiData = {
+                emojiFetchDate: meta.emojiFetchDate,
+                remoteEmojiMode: meta.remoteEmojiMode,
+                remoteEmojiCount: meta.remoteEmojiCount,
+                allEmojis: meta.allEmojis,
+                emojiUpdatedAt: meta.emojiUpdatedAt,
+        };
 
-	await set("remoteEmojiData", remoteEmojiData);
+        await set("remoteEmojiData", remoteEmojiData);
 
-	for (const [k, v] of Object.entries(meta)) {
-		instance[k] = v;
-	}
+        const localEmojiSnapshot = {
+                emojis: meta.emojis,
+                emojiUpdatedAt: meta.emojiUpdatedAt,
+                emojiFetchDate: meta.emojiFetchDate ?? new Date().toISOString(),
+        };
+
+        await set("emojiData", localEmojiSnapshot);
+
+        for (const [k, v] of Object.entries(meta)) {
+                instance[k] = v;
+        }
 }
 
 export async function fetchAllEmojiNoCache(options?: EmojiFetchOptions) {
@@ -237,9 +272,17 @@ export async function fetchAllEmojiNoCache(options?: EmojiFetchOptions) {
                 options,
         );
 
-	for (const [k, v] of Object.entries(meta)) {
-		instance[k] = v;
-	}
+        const localEmojiSnapshot = {
+                emojis: meta.emojis,
+                emojiUpdatedAt: meta.emojiUpdatedAt,
+                emojiFetchDate: meta.emojiFetchDate ?? new Date().toISOString(),
+        };
+
+        await set("emojiData", localEmojiSnapshot);
+
+        for (const [k, v] of Object.entries(meta)) {
+                instance[k] = v;
+        }
 }
 
 export async function fetchEmojiStats(limit) {


### PR DESCRIPTION
## 概要
- emojis API が返す更新時刻をホストが null のローカル絵文字に限定
- フロントエンド初期化でローカル絵文字のみ更新時刻比較に用い、リモート取得ロジックは従来通りの条件に戻した
- emojis/latest エンドポイントを API テーブルへ登録し、レスポンスの更新時刻を ISO 文字列として返すよう調整

## テスト
- なし

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141da022188326a9058367c6cbdcb5)