### PR TITLE
トランザクション強制モードに対応するためのインデックスマイグレーション修正

### DIFF
--- a/packages/backend/migration/1731000000000-note-has-files-index.js
+++ b/packages/backend/migration/1731000000000-note-has-files-index.js
@@ -3,13 +3,11 @@ export class noteHasFilesIndex1731000000000 {
 
         async up(queryRunner) {
                 await queryRunner.query(
-                        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_note_has_files" ON "note" USING btree ("id") WHERE CARDINALITY("fileIds") > 0`,
+                        `CREATE INDEX IF NOT EXISTS "IDX_note_has_files" ON "note" USING btree ("id") WHERE CARDINALITY("fileIds") > 0`,
                 );
         }
 
         async down(queryRunner) {
-                await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "IDX_note_has_files"`);
+                await queryRunner.query(`DROP INDEX IF EXISTS "IDX_note_has_files"`);
         }
 }
-
-noteHasFilesIndex1731000000000.prototype.transaction = false;


### PR DESCRIPTION
## 概要
- noteHasFilesIndex1731000000000 マイグレーションからトランザクション上書き設定を削除
- CREATE/DROP INDEX 文から CONCURRENTLY を外し、グローバルトランザクションモード "all" に対応

## テスト
- 未実施


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691428eaa7d8832695175875526f2b16)