### PR TITLE
設定ページのクエリ取得で未定義アクセスを防止

### DIFF
--- a/packages/client/src/pages/settings/index.vue
+++ b/packages/client/src/pages/settings/index.vue
@@ -367,20 +367,30 @@ const headerTabs = $computed(() => []);
 definePageMetadata(INFO);
 
 function scrollToSettingFromQuery() {
-       const key = router.currentRoute.value.query.setting as string | undefined;
-       if (!key) return;
-       nextTick(() => {
-               const rootEl = el.value;
-               const blocks = rootEl?.querySelectorAll("._formBlock");
-               const text = i18n.ts[key] as unknown as string | undefined;
-               if (!blocks || !text) return;
-               for (const block of blocks) {
-                       if (block.textContent && block.textContent.includes(text)) {
-                               scroll(block as HTMLElement, { behavior: "smooth" });
-                               break;
-                       }
-               }
-       });
+        const currentPath = router.getCurrentPath();
+        if (typeof window === "undefined") return;
+
+        let key: string | null = null;
+        try {
+                key = new URL(currentPath, window.location.origin).searchParams.get("setting");
+        } catch (error) {
+                return;
+        }
+
+        if (!key) return;
+
+        nextTick(() => {
+                const rootEl = el.value;
+                const blocks = rootEl?.querySelectorAll("._formBlock");
+                const text = i18n.ts[key] as unknown as string | undefined;
+                if (!blocks || !text) return;
+                for (const block of blocks) {
+                        if (block.textContent && block.textContent.includes(text)) {
+                                scroll(block as HTMLElement, { behavior: "smooth" });
+                                break;
+                        }
+                }
+        });
 }
 // w 890
 // h 700


### PR DESCRIPTION
## 概要
- 設定ページのスクロール処理でルーターのクエリ参照時に未定義アクセスが発生する問題を修正
- 現在のパスからクエリ文字列を解析して設定ブロックへスクロールするよう調整

## テスト
- 未実行（コード変更のみ）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142c86a5a48326b804e68aa2dad37e)