### PR TITLE
下書きデータ破損時の投稿フォーム表示不具合を修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -1921,11 +1921,15 @@ function loadDrafts(): DraftMap | null {
         try {
                 const raw = localStorage.getItem("drafts");
                 if (!raw) return {} as DraftMap;
-                const parsed = JSON.parse(raw) as DraftMap | null;
-                return (parsed ?? {}) as DraftMap;
+                const parsed = JSON.parse(raw);
+                if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+                        return {} as DraftMap;
+                }
+                return parsed as DraftMap;
         } catch (error) {
                 console.error(error);
-                return null;
+                localStorage.removeItem("drafts");
+                return {} as DraftMap;
         }
 }
 


### PR DESCRIPTION
## 概要
- 投稿フォームの下書き読み込み処理でJSONが破損している場合に空のマップとして扱うよう変更
- 破損データ検知時はdrafts項目をlocalStorageから削除して再初期化

## テスト
- 未実施（フロントエンド自動テスト環境なし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142fd7b0508326ab42f58bb485ec43)