### PR TITLE
投稿ボタンの並び順を降順に修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -941,12 +941,18 @@ function createSequentialQuickVisibilitySlots(
         }
 
         return slots.sort((a, b) => {
-                const orderA = a.order ?? Number.POSITIVE_INFINITY;
-                const orderB = b.order ?? Number.POSITIVE_INFINITY;
-                if (orderA !== orderB) {
-                        return orderA - orderB;
+                const orderA = a.order;
+                const orderB = b.order;
+
+                if (orderA == null && orderB == null) {
+                        return a.quickType.localeCompare(b.quickType);
                 }
-                return a.quickType.localeCompare(b.quickType);
+                if (orderA == null) return 1;
+                if (orderB == null) return -1;
+                if (orderA !== orderB) {
+                        return orderB - orderA;
+                }
+                return b.quickType.localeCompare(a.quickType);
         });
 }
 


### PR DESCRIPTION
## 概要
- クイック投稿ボタンのソート処理を見直し、設定済みの投稿ボタンが5→4→3→2→1の順で表示されるように修正しました

## テスト
- 未実施（コード変更のみ）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691435d7c1dc8326bcb787569dd85495)