### PR TITLE
feat: unique MFMタグを追加

### DIFF
--- a/packages/client/src/scripts/mfm-tags.ts
+++ b/packages/client/src/scripts/mfm-tags.ts
@@ -109,12 +109,18 @@ export const MFM_TAGS_JP = [
 		defaultOption: "$[space ",
 	},
 	{
-		name: "morse",
-		ja: "モールス",
-		exportLeft: "$[morse ",
+		name: "unique",
+		ja: "ユニーク化",
+		exportLeft: "$[unique ",
 		exportRight: "]",
-		defaultOption: "$[morse ",
 	},
+        {
+                name: "morse",
+                ja: "モールス",
+                exportLeft: "$[morse ",
+                exportRight: "]",
+                defaultOption: "$[morse ",
+        },
 	{ name: "ruby", ja: "ルビ振り", exportLeft: "$[ruby ", exportRight: "]" },
 	{
 		name: "time",


### PR DESCRIPTION
## 概要
- MFMタグの候補にuniqueを追加し、日本語ラベルをモールスの上に配置

## テスト
- [ ] テスト未実施（小規模な定義変更のため）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914405432088326a9511ab2750034f8)