### PR TITLE
クイック投稿ボタンの並び順と無効化処理を調整

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -950,9 +950,9 @@ function createSequentialQuickVisibilitySlots(
                 if (orderA == null) return 1;
                 if (orderB == null) return -1;
                 if (orderA !== orderB) {
-                        return orderB - orderA;
+                        return orderA - orderB;
                 }
-                return b.quickType.localeCompare(a.quickType);
+                return a.quickType.localeCompare(b.quickType);
         });
 }
 
@@ -1039,30 +1039,42 @@ const submitButtonConfigs = $computed<QuickPostButtonConfig[]>(() => {
 		}
 	);
 
-        let sequentialChainBroken = false;
+        const sequentialQuickButtons: {
+                key: string;
+                config: Omit<QuickPostButtonConfig, "key">;
+        }[] = [];
         for (const preset of quickVisibilityPresets) {
+                if (preset.order != null && !preset.isEnabled) {
+                        break;
+                }
                 if (!preset.isEnabled) {
-                        sequentialChainBroken = true;
                         continue;
                 }
-                if (sequentialChainBroken) {
-                        continue;
-                }
-                addButton(
-                        `quick-${preset.quickType}`,
-                        !isChannel && visibility !== "specified",
-                        {
+                sequentialQuickButtons.unshift({
+                        key: `quick-${preset.quickType}`,
+                        config: {
                                 label: zeroWidthSpace,
                                 buttonClass: "submit_h _buttonGradate",
                                 classObject: createShortcutClasses(preset.order ?? null),
-                                disabled: !canPost && preset.parsed.visibility !== "specified",
+                                disabled:
+                                        !canPost &&
+                                        preset.parsed.visibility !== "specified",
                                 iconClass: joinClasses(
-                                        getVisibilityIconClass(preset.parsed.visibility, preset.parsed.localOnly),
+                                        getVisibilityIconClass(
+                                                preset.parsed.visibility,
+                                                preset.parsed.localOnly
+                                        ),
                                         preset.isWide ? "widePostButton" : undefined
                                 ),
-                                behavior: { type: "quick", quickType: preset.quickType },
-                        }
-                );
+                                behavior: {
+                                        type: "quick",
+                                        quickType: preset.quickType,
+                                },
+                        },
+                });
+        }
+        for (const entry of sequentialQuickButtons) {
+                addButton(entry.key, !isChannel && visibility !== "specified", entry.config);
         }
 
 	addButton(


### PR DESCRIPTION
## 概要
- クイック投稿ボタンを一時配列に収集し、右端が「1」になるよう逆順で描画するように変更
- 数字付きプリセットで無効なボタンに遭遇した場合、それ以降を表示しないよう break 処理を追加

## テスト
- 未実行

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144f24ac8c8326b63dfca967e7aae2)