### PR TITLE
ユーザーリストのメンバー名が長い場合でも削除操作を表示

### DIFF
--- a/packages/client/src/pages/my-lists/list.vue
+++ b/packages/client/src/pages/my-lists/list.vue
@@ -177,19 +177,31 @@ definePageMetadata(
 
 					> .body {
 						flex: 1;
+						min-width: 0;
 						padding: 0.5rem;
 
 						> .name {
 							display: block;
 							font-weight: bold;
+							overflow: hidden;
+							text-overflow: ellipsis;
+							white-space: nowrap;
 						}
 
 						> .acct {
 							opacity: 0.5;
+							overflow: hidden;
+							text-overflow: ellipsis;
+							white-space: nowrap;
 						}
+					}
+
+					> .action {
+						flex: 0 0 auto;
 					}
 				}
 			}
+		}
 		}
 	}
 }


### PR DESCRIPTION
### Motivation
- ユーザーリストのメンバー表示でユーザー名が長いと削除ボタンなどの操作要素が名前に隠れてクリックできなくなる問題を修正するため。 

### Description
- `packages/client/src/pages/my-lists/list.vue` のメンバー行スタイルを調整して、本文領域に `min-width: 0` を追加しました。 
- 名前とアカウント表示に `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` を適用して長すぎるテキストを省略するようにしました。 
- 操作ボタン領域に `flex: 0 0 auto` を設定して本文が縮小しても操作領域が常に表示されるようにしました。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551824d040832688ea50e5577302f5)