### PR TITLE
リストページのSCSS構文エラー（余分な閉じ波括弧）を修正

### DIFF
--- a/packages/client/src/pages/my-lists/list.vue
+++ b/packages/client/src/pages/my-lists/list.vue
@@ -202,7 +202,6 @@ definePageMetadata(
 				}
 			}
 		}
-		}
 	}
 }
 </style>


### PR DESCRIPTION
### Motivation
- ビルド時にSassの構文エラー `unmatched "}"` が発生していたため、ビルドを通す必要があった。
- 問題はリストページのコンポーネント内のSCSSにある余分な閉じ波括弧 (`}`) に起因していた。
- 最小限の修正でスタイル構文を正しくして、ページの描画とビルドの安定化を図るための変更です。

### Description
- `packages/client/src/pages/my-lists/list.vue` の `<style lang="scss" scoped>` 内で余分な閉じ波括弧 (`}`) を削除しました。
- スタイル以外のコードやロジックには変更を加えていません。
- 変更は1ファイルのみの簡潔な修正です。

### Testing
- 自動テストは実行しておらず、未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551914a4188326b44a881ee9cdf9dc)