### PR TITLE
投票の結果非公開モードを追加

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1610,6 +1610,7 @@ _poll:
   choiceN: "Choice {n}"
   noMore: "You cannot add more choices"
   canMultipleVote: "Allow selecting multiple choices"
+  hideResults: "Hide results until you vote or the poll ends"
   expiration: "End poll"
   infinite: "Never"
   at: "End at..."

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1850,6 +1850,7 @@ _poll:
   choiceN: "選択肢{n}"
   noMore: "これ以上追加できません"
   canMultipleVote: "複数回答可"
+  hideResults: "結果非公開（投票または終了まで）"
   expiration: "期限"
   infinite: "無期限"
   at: "日時指定"

--- a/packages/backend/migration/1732000000000-poll-hide-results.js
+++ b/packages/backend/migration/1732000000000-poll-hide-results.js
@@ -1,0 +1,13 @@
+export class pollHideResults1732000000000 {
+	name = "pollHideResults1732000000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "poll" ADD COLUMN "hideResults" boolean NOT NULL DEFAULT false`,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "poll" DROP COLUMN "hideResults"`);
+	}
+}

--- a/packages/backend/src/models/entities/poll.ts
+++ b/packages/backend/src/models/entities/poll.ts
@@ -40,6 +40,11 @@ export class Poll {
 	})
 	public votes: number[];
 
+	@Column('boolean', {
+		default: false,
+	})
+	public hideResults: boolean;
+
 	//#region Denormalized fields
 	@Column('enum', {
 		enum: noteVisibilities,
@@ -76,4 +81,5 @@ export type IPoll = {
 	votes?: number[];
 	multiple: boolean;
 	expiresAt: Date | null;
+	hideResults?: boolean;
 };

--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -31,9 +31,9 @@ import { IdentifiableError } from "@/misc/identifiable-error.js";
 
 export async function populatePoll(note: Note, meId: User["id"] | null) {
 	const poll = await Polls.findOneByOrFail({ noteId: note.id });
-	const choices = poll.choices.map((c) => ({
+	const choices = poll.choices.map((c, index) => ({
 		text: c,
-		votes: poll.votes[poll.choices.indexOf(c)],
+		votes: poll.votes[index],
 		isVoted: false,
 	}));
 
@@ -60,9 +60,22 @@ export async function populatePoll(note: Note, meId: User["id"] | null) {
 		}
 	}
 
+	const hasVoted = choices.some((choice) => choice.isVoted);
+	const isOwner = meId != null && meId === note.userId;
+	const isExpired = poll.expiresAt != null && poll.expiresAt.getTime() <= Date.now();
+	const canShowResults =
+		!poll.hideResults || isOwner || hasVoted || isExpired;
+
+	if (!canShowResults) {
+		for (const choice of choices) {
+			choice.votes = 0;
+		}
+	}
+
 	return {
 		multiple: poll.multiple,
 		expiresAt: poll.expiresAt,
+		hideResults: poll.hideResults,
 		choices,
 	};
 }

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -162,6 +162,7 @@ export const paramDef = {
 					items: { type: "string", minLength: 1, maxLength: 50 },
 				},
 				multiple: { type: "boolean", default: false },
+				hideResults: { type: "boolean", default: false },
 				expiresAt: { type: "integer", nullable: true },
 				expiredAfter: { type: "integer", nullable: true, minimum: 1 },
 			},
@@ -431,6 +432,7 @@ export default define(meta, paramDef, async (ps, user) => {
 									choices: Array.from(choices),
 									multiple: ps.poll.multiple,
 									expiresAt: ps.poll.expiresAt ? new Date(ps.poll.expiresAt) : null,
+									hideResults: ps.poll.hideResults ?? false,
 							}
 							: undefined,
 					text: ps.text || undefined,

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -1401,6 +1401,7 @@ async function insertNote(
 					choices: data.poll!.choices,
 					expiresAt: data.poll!.expiresAt,
 					multiple: data.poll!.multiple,
+					hideResults: data.poll!.hideResults ?? false,
 					votes: new Array(data.poll!.choices.length).fill(0),
 					noteVisibility: insert.visibility,
 					userId: user.id,

--- a/packages/calckey-js/src/api.types.ts
+++ b/packages/calckey-js/src/api.types.ts
@@ -822,6 +822,7 @@ export type Endpoints = {
 			poll?: null | {
 				choices: string[];
 				multiple?: boolean;
+				hideResults?: boolean;
 				expiresAt?: null | number;
 				expiredAfter?: null | number;
 			};

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -165,6 +165,7 @@ export type Note = {
 	poll?: {
 		expiresAt: DateString | null;
 		multiple: boolean;
+		hideResults?: boolean;
 		choices: {
 			isVoted: boolean;
 			text: string;

--- a/packages/client/src/components/MkPoll.vue
+++ b/packages/client/src/components/MkPoll.vue
@@ -33,8 +33,8 @@
 			</li>
 		</ul>
 		<p v-if="!readOnly">
-			<span>{{ i18n.t("_poll.totalVotes", { n: total }) }}</span>
-			<span v-if="!closed && !isVoted">
+			<span v-if="canShowResults">{{ i18n.t("_poll.totalVotes", { n: total }) }}</span>
+			<span v-if="canShowResults && !closed && !isVoted">
 				<span> · </span>
 				<a @click.stop="showResult = !showResult">{{
 					showResult ? i18n.ts._poll.vote : i18n.ts._poll.showResult
@@ -52,13 +52,14 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onUnmounted, ref, toRef } from "vue";
+import { computed, ref, watch } from "vue";
 import * as misskey from "calckey-js";
 import { sum } from "@/scripts/array";
 import { pleaseLogin } from "@/scripts/please-login";
 import * as os from "@/os";
 import { i18n } from "@/i18n";
 import { useInterval } from "@/scripts/use-interval";
+import { $i } from "@/account";
 
 const props = defineProps<{
 	note: misskey.entities.Note;
@@ -67,14 +68,22 @@ const props = defineProps<{
 
 const remaining = ref(-1);
 
-const total = computed(() => sum(props.note.poll.choices.map((x) => x.votes)));
+const hasVoted = computed(() =>
+	props.note.poll.choices.some((choice) => choice.isVoted),
+);
+const isOwner = computed(() => $i?.id === props.note.userId);
+const canShowResults = computed(() => {
+	if (!props.note.poll.hideResults) return true;
+	return isOwner.value || hasVoted.value || closed.value;
+});
+const total = computed(() =>
+	canShowResults.value
+		? sum(props.note.poll.choices.map((x) => x.votes))
+		: 0,
+);
 const closed = computed(() => remaining.value === 0);
 const isLocal = computed(() => !props.note.uri);
-const isVoted = computed(
-	() =>
-		!props.note.poll.multiple &&
-		props.note.poll.choices.some((c) => c.isVoted)
-);
+const isVoted = computed(() => !props.note.poll.multiple && hasVoted.value);
 const timer = computed(() =>
 	i18n.t(
 		remaining.value >= 86400
@@ -93,7 +102,19 @@ const timer = computed(() =>
 	)
 );
 
-const showResult = ref(props.readOnly || isVoted.value);
+const showResult = ref(
+	props.note.poll.hideResults
+		? canShowResults.value
+		: props.readOnly || isVoted.value,
+);
+
+watch(canShowResults, (value) => {
+	if (!value) {
+		showResult.value = false;
+	} else if (props.note.poll.hideResults) {
+		showResult.value = true;
+	}
+});
 
 // 期限付きアンケート
 if (props.note.poll.expiresAt) {
@@ -116,7 +137,13 @@ if (props.note.poll.expiresAt) {
 }
 
 async function refresh() {
-	if (!props.note.uri) return;
+	if (!props.note.uri) {
+		const obj = await os.api("notes/show", { noteId: props.note.id });
+		if (obj.poll) {
+			props.note.poll = obj.poll;
+		}
+		return;
+	}
 	const obj = await os.apiWithDialog("ap/show", { uri: props.note.uri });
 	if (obj.type === "Note" && obj.object.poll) {
 		props.note.poll = obj.object.poll;
@@ -140,7 +167,12 @@ const vote = async (id) => {
 		noteId: props.note.id,
 		choice: id,
 	});
-	if (!showResult.value) showResult.value = !props.note.poll.multiple;
+	if (props.note.poll.hideResults) {
+		showResult.value = true;
+		await refresh();
+	} else if (!showResult.value) {
+		showResult.value = !props.note.poll.multiple;
+	}
 };
 </script>
 

--- a/packages/client/src/components/MkPollEditor.vue
+++ b/packages/client/src/components/MkPollEditor.vue
@@ -28,6 +28,9 @@
 		<MkSwitch v-model="multiple">{{
 			i18n.ts._poll.canMultipleVote
 		}}</MkSwitch>
+		<MkSwitch v-model="hideResults">{{
+			i18n.ts._poll.hideResults
+		}}</MkSwitch>
 		<section>
 			<div>
 				<MkSelect v-model="expiration" small>
@@ -86,6 +89,7 @@ const props = defineProps<{
 		expiredAfter: number;
 		choices: string[];
 		multiple: boolean;
+		hideResults: boolean;
 	};
 }>();
 const emit = defineEmits<{
@@ -96,12 +100,14 @@ const emit = defineEmits<{
 			expiredAfter: number;
 			choices: string[];
 			multiple: boolean;
+			hideResults: boolean;
 		}
 	): void;
 }>();
 
 const choices = ref(props.modelValue.choices);
 const multiple = ref(props.modelValue.multiple);
+const hideResults = ref(props.modelValue.hideResults ?? false);
 const expiration = ref("after");
 const atDate = ref(
 	formatDateTimeString(addTime(new Date(), new Date().getHours() >= 22 ? 2 : 1, "day"), "yyyy-MM-dd")
@@ -165,6 +171,7 @@ function get() {
 	return {
 		choices: choices.value,
 		multiple: multiple.value,
+		hideResults: hideResults.value,
 		...(expiration.value === "at"
 			? { expiresAt: calcAt() }
 			: expiration.value === "after"
@@ -174,7 +181,7 @@ function get() {
 }
 
 watch(
-	[choices, multiple, expiration, atDate, atTime, after, unit],
+	[choices, multiple, hideResults, expiration, atDate, atTime, after, unit],
 	() => emit("update:modelValue", get()),
 	{
 		deep: true,

--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -483,6 +483,7 @@ let poll = $ref<{
 	multiple: boolean;
 	expiresAt: string | null;
 	expiredAfter: string | null;
+	hideResults: boolean;
 } | null>(null);
 let useCw = $ref(false);
 let showPreview = $computed(defaultStore.makeGetterSetter("showPreview"));
@@ -1467,6 +1468,7 @@ function togglePoll() {
 			multiple: false,
 			expiresAt: null,
 			expiredAfter: null,
+			hideResults: false,
 		};
 	}
 }
@@ -2109,6 +2111,7 @@ type PollValue = {
         multiple: boolean;
         expiresAt: string | null;
         expiredAfter: string | null;
+		hideResults: boolean;
 } | null;
 
 interface NormalizeVisibilityOptions {
@@ -2501,7 +2504,10 @@ function loadDraft(key?) {
 				})
 			);
 			if (draft.data.poll) {
-				poll = draft.data.poll;
+				poll = {
+					...draft.data.poll,
+					hideResults: draft.data.poll.hideResults ?? false,
+				};
 			}
 			if (
 				draft.data.quoteId &&
@@ -2608,6 +2614,7 @@ onMounted(() => {
 					multiple: init.poll.multiple,
 					expiresAt: init.poll.expiresAt,
 					expiredAfter: init.poll.expiredAfter,
+					hideResults: init.poll.hideResults ?? false,
 				};
 			}
 			visibility = init.visibility;


### PR DESCRIPTION
### Motivation
- 投票作成時に「結果非公開」オプションを追加し、作成者以外の未投票者が投票終了か投票するまで票数を確認できないようにするため。 
- クライアント側のUI・サーバ側の永続化・API型定義・ローカライズを一貫して対応する必要があったため。 

### Description
- DBマイグレーションを追加し、`poll` テーブルに `hideResults` 列（`boolean`、デフォルト `false`）を追加するファイルを追加しました（`packages/backend/migration/1732000000000-poll-hide-results.js`）。
- エンティティと作成処理に `hideResults` を追加し、`create` フローで `poll.hideResults` を保存するようにしました（`packages/backend/src/models/entities/poll.ts`、`packages/backend/src/services/note/create.ts`、`packages/backend/src/server/api/endpoints/notes/create.ts`）。
- 投票取得ロジックで表示条件を判定し、未投票者かつ非作成者でかつ終了前のときは票数をマスクするように `populatePoll` を変更しました（`packages/backend/src/models/repositories/note.ts`）。
- クライアント側に作成UIのスイッチを追加し、`MkPollEditor.vue`／`MkPostForm.vue` の状態とペイロードに `hideResults` を反映しました（`packages/client/src/components/MkPollEditor.vue`、`packages/client/src/components/MkPostForm.vue`）。
- 投票表示コンポーネント `MkPoll.vue` を更新し、`hideResults` の判定に基づき票数表示の可否や投票後の再取得処理を追加しました（`packages/client/src/components/MkPoll.vue`）。
- API型定義とフロントエンドのエンティティ型（`calckey-js`）およびローカライズ文言を更新しました（`packages/calckey-js/src/api.types.ts`、`packages/calckey-js/src/entities.ts`、`locales/ja-JP.yml`、`locales/en-US.yml`）。

### Testing
- 自動テスト（ユニット/CI）は実行していません。 
- マイグレーション・ビルド・ランタイムでの動作確認は行っていないため、デプロイ前にCIと手動での動作確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966135cbd1c8326adae8147b3302515)