### PR TITLE
投票非公開モードで総投票数表示を常時化し作成者の初期表示を通常挙動に合わせる

### DIFF
--- a/packages/client/src/components/MkPoll.vue
+++ b/packages/client/src/components/MkPoll.vue
@@ -33,7 +33,7 @@
 			</li>
 		</ul>
 		<p v-if="!readOnly">
-			<span v-if="canShowResults">{{ i18n.t("_poll.totalVotes", { n: total }) }}</span>
+			<span>{{ i18n.t("_poll.totalVotes", { n: total }) }}</span>
 			<span v-if="canShowResults && !closed && !isVoted">
 				<span> · </span>
 				<a @click.stop="showResult = !showResult">{{
@@ -76,11 +76,7 @@ const canShowResults = computed(() => {
 	if (!props.note.poll.hideResults) return true;
 	return isOwner.value || hasVoted.value || closed.value;
 });
-const total = computed(() =>
-	canShowResults.value
-		? sum(props.note.poll.choices.map((x) => x.votes))
-		: 0,
-);
+const total = computed(() => sum(props.note.poll.choices.map((x) => x.votes)));
 const closed = computed(() => remaining.value === 0);
 const isLocal = computed(() => !props.note.uri);
 const isVoted = computed(() => !props.note.poll.multiple && hasVoted.value);
@@ -102,16 +98,15 @@ const timer = computed(() =>
 	)
 );
 
-const showResult = ref(
-	props.note.poll.hideResults
-		? canShowResults.value
-		: props.readOnly || isVoted.value,
-);
+const showResult = ref(props.readOnly || isVoted.value);
 
 watch(canShowResults, (value) => {
 	if (!value) {
 		showResult.value = false;
-	} else if (props.note.poll.hideResults) {
+	} else if (
+		props.note.poll.hideResults &&
+		(hasVoted.value || closed.value)
+	) {
 		showResult.value = true;
 	}
 });


### PR DESCRIPTION
### Motivation
- 非公開（hideResults）設定の投票で総投票数が非表示になっている挙動を見直して、総投票数は常に表示したい。 
- 作成者が未投票の場合でも結果表示がデフォルトで有効になってしまっているため、作成者は非公開モードでも通常のユーザーと同じ初期表示（未表示）に合わせたい。 
- 投票結果の表示・非表示の初期値や切替ロジックを簡潔にして予期せぬ表示を防ぐ。 
- 影響箇所は投票コンポーネントの表示ロジックに限定する。 

### Description
- `packages/client/src/components/MkPoll.vue` のテンプレートで総投票数表示を `v-if=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966188937ec8326946227747338b9ec)