### PR TITLE
非公開投票の総投票数を配信してクライアント表示に反映

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -31,6 +31,7 @@ import { IdentifiableError } from "@/misc/identifiable-error.js";
 
 export async function populatePoll(note: Note, meId: User["id"] | null) {
 	const poll = await Polls.findOneByOrFail({ noteId: note.id });
+	const totalVotes = poll.votes.reduce((total, votes) => total + votes, 0);
 	const choices = poll.choices.map((c, index) => ({
 		text: c,
 		votes: poll.votes[index],
@@ -76,6 +77,7 @@ export async function populatePoll(note: Note, meId: User["id"] | null) {
 		multiple: poll.multiple,
 		expiresAt: poll.expiresAt,
 		hideResults: poll.hideResults,
+		totalVotes,
 		choices,
 	};
 }

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -166,6 +166,7 @@ export type Note = {
 		expiresAt: DateString | null;
 		multiple: boolean;
 		hideResults?: boolean;
+		totalVotes?: number;
 		choices: {
 			isVoted: boolean;
 			text: string;

--- a/packages/client/src/components/MkPoll.vue
+++ b/packages/client/src/components/MkPoll.vue
@@ -76,7 +76,9 @@ const canShowResults = computed(() => {
 	if (!props.note.poll.hideResults) return true;
 	return isOwner.value || hasVoted.value || closed.value;
 });
-const total = computed(() => sum(props.note.poll.choices.map((x) => x.votes)));
+const total = computed(
+	() => props.note.poll.totalVotes ?? sum(props.note.poll.choices.map((x) => x.votes)),
+);
 const closed = computed(() => remaining.value === 0);
 const isLocal = computed(() => !props.note.uri);
 const isVoted = computed(() => !props.note.poll.multiple && hasVoted.value);


### PR DESCRIPTION
### Motivation
- 非公開（結果非公開）モードのアンケートで未投票時に総投票数が常に0になる問題を解消するため、総投票数を配信可能にする。 
- フロントエンドで配信された総投票数を優先して表示することでUXを改善する。 

### Description
- サーバー側の`populatePoll`で`poll.votes`の合計を計算して`totalVotes`として返すようにした（`packages/backend/src/models/repositories/note.ts`）。
- API型定義に`poll.totalVotes?: number`を追加してクライアントで利用可能にした（`packages/calckey-js/src/entities.ts`）。
- クライアントの`MkPoll.vue`で`props.note.poll.totalVotes`があればそれを総投票数として優先的に使い、なければ従来通り各選択肢の合計を算出するように変更した（`packages/client/src/components/MkPoll.vue`）。

### Testing
- Playwrightでブラウザスクリーンショットを取得する自動チェックを試行したが、`http://localhost:3000`に接続できず失敗した（サーバー未起動により）。
- 単体テストやE2Eテストの自動実行は行っておらず、既存のテストは未実施のままです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966206d45788326aacd4c1b290b8a43)