### PR TITLE
投票合計表示を外部総数と選択肢合計の大きい方に変更

### DIFF
--- a/packages/client/src/components/MkPoll.vue
+++ b/packages/client/src/components/MkPoll.vue
@@ -72,14 +72,16 @@ const hasVoted = computed(() =>
 	props.note.poll.choices.some((choice) => choice.isVoted),
 );
 const isOwner = computed(() => $i?.id === props.note.userId);
+const closed = computed(() => remaining.value === 0);
 const canShowResults = computed(() => {
 	if (!props.note.poll.hideResults) return true;
 	return isOwner.value || hasVoted.value || closed.value;
 });
-const total = computed(
-	() => props.note.poll.totalVotes ?? sum(props.note.poll.choices.map((x) => x.votes)),
-);
-const closed = computed(() => remaining.value === 0);
+const total = computed(() => {
+	const choiceTotal = sum(props.note.poll.choices.map((x) => x.votes));
+	const totalVotes = props.note.poll.totalVotes ?? 0;
+	return Math.max(totalVotes, choiceTotal);
+});
 const isLocal = computed(() => !props.note.uri);
 const isVoted = computed(() => !props.note.poll.multiple && hasVoted.value);
 const timer = computed(() =>


### PR DESCRIPTION
### Motivation
- 非公開や集計状況に関わらず、表示する合計がサーバ提供の `note.poll.totalVotes` とローカルの選択肢合計のどちらか大きい方になるようにしたい。 
- 未投票時や集計途上で不正確な合計が表示されるのを防止する意図。 
- 表示ロジックを簡素化して誤差が小さくなるようにしたい。 

### Description
- `packages/client/src/components/MkPoll.vue` の `total` 計算を `Math.max(props.note.poll.totalVotes ?? 0, sum(choices.votes))` に変更した。 
- `closed` の `computed` を `canShowResults` より前に移動して参照可能にした。 
- 合計算出ロジックを簡潔化して `choiceTotal` と `totalVotes` の大きい方を常に返すようにした。 

### Testing
- 自動テスト（CI/ユニットテスト）は実行しておらず、テストは未実施である。 
- 手元での自動化検証は行っていないため、動作確認は保留中である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696622ce4348832695faf59f0955b0e9)