### PR TITLE
非公開投票の途中経過を0票で連合配信し終了時に最終結果を送信

### DIFF
--- a/packages/backend/src/queue/processors/ended-poll-notification.ts
+++ b/packages/backend/src/queue/processors/ended-poll-notification.ts
@@ -4,6 +4,7 @@ import { Notes, Polls, PollVotes } from "@/models/index.js";
 import { queueLogger } from "../logger.js";
 import type { EndedPollNotificationJobData } from "@/queue/types.js";
 import { createNotification } from "@/services/create-notification.js";
+import { deliverQuestionUpdate } from "@/services/note/polls/update.js";
 
 const logger = queueLogger.createSubLogger("ended-poll-notification");
 
@@ -30,6 +31,11 @@ export async function endedPollNotification(
 		createNotification(userId, "pollEnded", {
 			noteId: note.id,
 		});
+	}
+
+	const poll = await Polls.findOneBy({ noteId: note.id });
+	if (poll?.hideResults) {
+		await deliverQuestionUpdate(note.id);
 	}
 
 	job.progress(100);

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -17,6 +17,7 @@ export default async function renderNote(
 	note: Note,
 	dive = true,
 	isTalk = false,
+	options: { pollOverride?: Poll | null } = {},
 ): Promise<Record<string, unknown>> {
 	const getPromisedFiles = async (ids: string[]) => {
 		if (!ids || ids.length === 0) return [];
@@ -135,7 +136,11 @@ export default async function renderNote(
 	let poll: Poll | null = null;
 
 	if (note.hasPoll) {
-		poll = await Polls.findOneBy({ noteId: note.id });
+		if (options.pollOverride !== undefined) {
+			poll = options.pollOverride;
+		} else {
+			poll = await Polls.findOneBy({ noteId: note.id });
+		}
 	}
 
 	if (note.referenceIds?.length) {

--- a/packages/backend/src/services/note/polls/update.ts
+++ b/packages/backend/src/services/note/polls/update.ts
@@ -1,8 +1,9 @@
 import renderUpdate from "@/remote/activitypub/renderer/update.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import renderNote from "@/remote/activitypub/renderer/note.js";
-import { Users, Notes } from "@/models/index.js";
+import { Users, Notes, Polls } from "@/models/index.js";
 import type { Note } from "@/models/entities/note.js";
+import type { Poll } from "@/models/entities/poll.js";
 import { deliverToFollowers } from "@/remote/activitypub/deliver-manager.js";
 import { deliverToRelays } from "../../relay.js";
 
@@ -14,8 +15,23 @@ export async function deliverQuestionUpdate(noteId: Note["id"]) {
 	if (user == null) throw new Error("user not found");
 
 	if (Users.isLocalUser(user)) {
+		let pollOverride: { pollOverride?: Poll | null } | undefined;
+		if (note.hasPoll) {
+			const poll = await Polls.findOneBy({ noteId: note.id });
+			if (poll?.hideResults) {
+				const now = new Date();
+				if (poll.expiresAt == null || poll.expiresAt > now) {
+					pollOverride = {
+						pollOverride: {
+							...poll,
+							votes: poll.votes.map(() => 0),
+						},
+					};
+				}
+			}
+		}
 		const content = renderActivity(
-			renderUpdate(await renderNote(note, false), user),
+			renderUpdate(await renderNote(note, false, false, pollOverride), user),
 		);
 		deliverToFollowers(user, content);
 		deliverToRelays(user, content);


### PR DESCRIPTION
### Motivation
- 非公開（`hideResults`）に設定された投票について、投票期間中は途中経過をそのまま連合先に送らないようにしつつ、連合先には途中経過として全選択肢を0票で配信し、投票終了時に最終結果を再送できるようにするための変更です。

### Description
- `renderNote` に投票データ上書き用のオプション `options: { pollOverride?: Poll | null }` を追加し、レンダリング時に外部から `poll` データを差し替え可能にしました（`packages/backend/src/remote/activitypub/renderer/note.ts`）。
- 連合更新を行う `deliverQuestionUpdate` で、ローカル投稿かつ `note.hasPoll` の場合に `Polls.findOneBy` を参照し、`hideResults` かつ未終了の投票であれば `votes` を全て0にした `pollOverride` を作成して `renderNote` に渡すようにしました（`packages/backend/src/services/note/polls/update.ts`）。
- 投票終了ハンドラ側で `hideResults` の投票に対しては終了時に `deliverQuestionUpdate(note.id)` を呼んで最終結果を再度送信する処理が追加されています（既存の終了通知作成は維持されています）。

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f45cd8c188326afde521d680fc30f)