### PR TITLE
ログイン中の閲覧者に isExplorable を公開

### DIFF
--- a/packages/backend/src/models/repositories/user.ts
+++ b/packages/backend/src/models/repositories/user.ts
@@ -884,6 +884,11 @@ export const UserRepository = db.getRepository(User).extend({
 						lastFetchedAt: user.lastFetchedAt
 							? user.lastFetchedAt.toISOString()
 							: null,
+						...(me
+							? {
+									isExplorable: user.isExplorable,
+							  }
+							: {}),
 						bannerUrl: user.banner
 							? DriveFiles.getPublicUrl(user.banner, false)
 							: null,
@@ -1001,7 +1006,6 @@ export const UserRepository = db.getRepository(User).extend({
 						autoAcceptFollowed: profile!.autoAcceptFollowed,
 						noCrawle: profile!.noCrawle,
 						preventAiLearning: profile!.preventAiLearning,
-						isExplorable: user.isExplorable,
 						isRemoteExplorable: user.isRemoteExplorable,
 						isDeleted: user.isDeleted,
 						hideOnlineStatus: user.hideOnlineStatus,


### PR DESCRIPTION
### Motivation
- ログインしている閲覧者がユーザー詳細を取得した際に `isExplorable` の値を参照できるようにするため。 

### Description
- `packages/backend/src/models/repositories/user.ts` のレスポンス生成で `opts.detail` のブロックにおいて、`me` が存在する場合に `isExplorable: user.isExplorable` を追加し、従来 `opts.detail && isMe` ブロックで返していた `isExplorable` を削除しました。 

### Testing
- 自動テストは実行しておらず、変更はコード差分のみです（テスト未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ab4c993c8326ad81758a573575b4)