### PR TITLE
RT/引用時のリアクション再送と配送制御の調整

### DIFF
--- a/packages/backend/src/misc/reaction-lib.ts
+++ b/packages/backend/src/misc/reaction-lib.ts
@@ -27,6 +27,27 @@ export async function getFallbackReaction() {
 	return meta.defaultReaction;
 }
 
+const apFallbackReactionHosts = [
+	"voskey.icalo.net",
+	"9ineverse.com",
+	"mogeko.monster",
+];
+
+export async function resolveApReaction(
+	reaction: string,
+	emoji?: { host?: string | null; license?: string | null } | null,
+): Promise<string> {
+	if (
+		emoji?.host &&
+		(apFallbackReactionHosts.includes(emoji.host) ||
+			emoji.license?.includes("コピー可否 : deny"))
+	) {
+		return await getFallbackReaction();
+	}
+
+	return reaction;
+}
+
 export function convertLegacyReactions(reactions: Record<string, number>) {
 	const _reactions = new Map();
 	const decodedReactions = new Map();

--- a/packages/backend/src/remote/activitypub/deliver-manager.ts
+++ b/packages/backend/src/remote/activitypub/deliver-manager.ts
@@ -80,6 +80,17 @@ export default class DeliverManager {
 	public async execute() {
 		if (!Users.isLocalUser(this.actor)) return;
 
+		const inboxes = await this.collectInboxes();
+
+		await deliverToInboxes(this.actor, this.activity, inboxes);
+	}
+
+	/**
+	 * Collect inboxes from recipes
+	 */
+	public async collectInboxes() {
+		if (!Users.isLocalUser(this.actor)) return new Map<string, boolean>();
+
 		const inboxes = new Map<string, boolean>();
 
 		/*
@@ -176,32 +187,7 @@ export default class DeliverManager {
 			}`,
 		);
 
-		// Validate Inboxes first
-		const validInboxes = [];
-		for (const inbox of inboxes) {
-			try {
-				validInboxes.push({
-					inbox,
-					host: new URL(inbox[0]).host,
-				});
-			} catch (error) {
-				console.error(error);
-				console.error(`Invalid Inbox ${inbox}`);
-			}
-		}
-
-		const instancesToSkip = await skippedInstances(
-			// get (unique) list of hosts
-			Array.from(new Set(validInboxes.map((valid) => valid.host))),
-		);
-
-		// deliver
-		for (const valid of validInboxes) {
-			// skip instances as indicated
-			if (instancesToSkip.includes(valid.host)) continue;
-
-			deliver(this.actor, this.activity, valid.inbox[0], valid.inbox[1]);
-		}
+		return inboxes;
 	}
 }
 
@@ -233,5 +219,47 @@ export async function deliverToUser(
 	const manager = new DeliverManager(actor, activity);
 	manager.addDirectRecipe(to);
 	await manager.execute();
+}
+
+/**
+ * Deliver activity to inboxes
+ * @param activity Activity
+ * @param inboxes Map of inbox and shared inbox flag
+ */
+export async function deliverToInboxes(
+	actor: { id: ILocalUser["id"]; host: null },
+	activity: any,
+	inboxes: Map<string, boolean>,
+) {
+	if (!Users.isLocalUser(actor)) return;
+
+	if (inboxes.size === 0) return;
+
+	// Validate Inboxes first
+	const validInboxes = [];
+	for (const inbox of inboxes) {
+		try {
+			validInboxes.push({
+				inbox,
+				host: new URL(inbox[0]).host,
+			});
+		} catch (error) {
+			console.error(error);
+			console.error(`Invalid Inbox ${inbox}`);
+		}
+	}
+
+	const instancesToSkip = await skippedInstances(
+		// get (unique) list of hosts
+		Array.from(new Set(validInboxes.map((valid) => valid.host))),
+	);
+
+	// deliver
+	for (const valid of validInboxes) {
+		// skip instances as indicated
+		if (instancesToSkip.includes(valid.host)) continue;
+
+		deliver(actor, activity, valid.inbox[0], valid.inbox[1]);
+	}
 }
 //#endregion

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -6,10 +6,14 @@ import {
 	publishNotesStream,
 	publishNoteStream,
 } from "@/services/stream.js";
-import DeliverManager, { deliverToUser } from "@/remote/activitypub/deliver-manager.js";
+import DeliverManager, {
+	deliverToInboxes,
+	deliverToUser,
+} from "@/remote/activitypub/deliver-manager.js";
 import renderNote from "@/remote/activitypub/renderer/note.js";
 import renderCreate from "@/remote/activitypub/renderer/create.js";
 import renderAnnounce from "@/remote/activitypub/renderer/announce.js";
+import { renderLike } from "@/remote/activitypub/renderer/like.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import { resolveUser } from "@/remote/resolve-user.js";
 import config from "@/config/index.js";
@@ -28,6 +32,7 @@ import {
         Users,
         NoteWatchings,
 	Notes,
+	NoteReactions,
 	Instances,
 	UserProfiles,
 	Antennas,
@@ -37,11 +42,12 @@ import {
 	ChannelFollowings,
 	Blockings,
 	NoteThreadMutings,
+	Emojis,
 } from "@/models/index.js";
 import type { DriveFile } from "@/models/entities/drive-file.js";
 import type { App } from "@/models/entities/app.js";
 import { Not, In, IsNull } from "typeorm";
-import { User, ILocalUser, IRemoteUser } from "@/models/entities/user.js";
+import type { User, ILocalUser, IRemoteUser } from "@/models/entities/user.js";
 import { genId } from "@/misc/gen-id.js";
 import {
 	notesChart,
@@ -73,6 +79,9 @@ import renderDelete from "@/remote/activitypub/renderer/delete.js";
 import renderTombstone from "@/remote/activitypub/renderer/tombstone.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import { StatusError } from "@/misc/fetch.js";
+import { decodeReaction, resolveApReaction } from "@/misc/reaction-lib.js";
+import { buildReactionDeliverManager } from "@/services/note/reaction/deliver.js";
+import type { NoteReaction } from "@/models/entities/note-reaction.js";
 
 const mutedWordsCache = new Cache<
 	{ userId: UserProfile["userId"]; mutedWords: UserProfile["mutedWords"] }[]
@@ -1160,66 +1169,30 @@ export default async (
 			if (Users.isLocalUser(user) && !dontFederateInitially) {
 				(async () => {
 					const noteActivity = await renderNoteOrRenoteActivity(data, note);
+					if (!noteActivity) return;
+
 					const dm = new DeliverManager(user, noteActivity);
+					await addNoteActivityDeliveryRecipes(dm, {
+						data,
+						note,
+						mentionedUsers,
+						user,
+					});
 
-					// メンションされたリモートユーザーに配送
-					for (const u of mentionedUsers.filter((u) => Users.isRemoteUser(u))) {
-						dm.addDirectRecipe(u as IRemoteUser);
-					}
+					const noteInboxes = await dm.collectInboxes();
+					await deliverToInboxes(user, noteActivity, noteInboxes);
 
-					// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
-					if (data.reply && data.reply.userHost !== null) {
-						const u = await Users.findOneBy({ id: data.reply.userId });
-						if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
-					}
-
-					// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
-					if (data.renote && data.renote.userHost !== null) {
-						const u = await Users.findOneBy({ id: data.renote.userId });
-						if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
-					}
-
-					// フォロワーに配送
-					if (["public", "home", "followers"].includes(note.visibility)) {
-						if (
-							data.reply &&
-							data.reply.userId === user.id &&
-							data.reply.replyId
-						) {
-							// 自己リプライでリプライのリプライがある場合
-							// リプライのリプライが自分ではない場合
-							if (
-								data.reply.replyUserId !== user.id &&
-								data.reply.replyUserHost === null
-							) {
-								console.log(`reReply deliver : ${data.reply.replyId}`);
-								const u = await Users.findOneBy({ id: data.reply.replyUserId });
-								dm.addFollowersRecipe(u as ILocalUser);
-							} else {
-								console.log(`reReply deliver : ${data.reply.replyId}`);
-								// リプライのリプライが自分の場合
-								dm.addFollowersRecipe();
-							}
-						} else if (
-							data.reply &&
-							data.reply.userId !== user.id &&
-							data.reply.userHost === null
-						) {
-							console.log(`reply deliver : ${data.reply.id}`);
-							// 他人宛のリプライがある場合
-							const u = await Users.findOneBy({ id: data.reply.userId });
-							dm.addFollowersRecipe(u as ILocalUser);
-						} else {
-							dm.addFollowersRecipe();
-						}
+					if (data.renote) {
+						await resendLocalReactionsForRenote(
+							data.renote,
+							noteInboxes,
+						);
 					}
 
 					//リレーに配送
 					if (["public"].includes(note.visibility)) {
 						deliverToRelays(user, noteActivity);
 					}
-
-					dm.execute();
 				})();
 			}
 			//#endregion
@@ -1279,6 +1252,136 @@ export async function appendNoteVisibleUser(
 	// ストリームに流す
 	const noteObj = await Notes.pack(note, null);
 	publishNotesStream(noteObj);
+}
+
+async function addNoteActivityDeliveryRecipes(
+	dm: DeliverManager,
+	params: {
+		data: Option;
+		note: Note;
+		mentionedUsers: MinimumUser[];
+		user: { id: User["id"]; host: User["host"] };
+	},
+) {
+	const { data, note, mentionedUsers, user } = params;
+
+	// メンションされたリモートユーザーに配送
+	for (const u of mentionedUsers.filter((u) => Users.isRemoteUser(u))) {
+		dm.addDirectRecipe(u as IRemoteUser);
+	}
+
+	// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
+	if (data.reply && data.reply.userHost !== null) {
+		const u = await Users.findOneBy({ id: data.reply.userId });
+		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	}
+
+	// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
+	if (data.renote && data.renote.userHost !== null) {
+		const u = await Users.findOneBy({ id: data.renote.userId });
+		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	}
+
+	// フォロワーに配送
+	if (["public", "home", "followers"].includes(note.visibility)) {
+		if (data.reply && data.reply.userId === user.id && data.reply.replyId) {
+			// 自己リプライでリプライのリプライがある場合
+			// リプライのリプライが自分ではない場合
+			if (data.reply.replyUserId !== user.id && data.reply.replyUserHost === null) {
+				console.log(`reReply deliver : ${data.reply.replyId}`);
+				const u = await Users.findOneBy({ id: data.reply.replyUserId });
+				dm.addFollowersRecipe(u as ILocalUser);
+			} else {
+				console.log(`reReply deliver : ${data.reply.replyId}`);
+				// リプライのリプライが自分の場合
+				dm.addFollowersRecipe();
+			}
+		} else if (
+			data.reply &&
+			data.reply.userId !== user.id &&
+			data.reply.userHost === null
+		) {
+			console.log(`reply deliver : ${data.reply.id}`);
+			// 他人宛のリプライがある場合
+			const u = await Users.findOneBy({ id: data.reply.userId });
+			dm.addFollowersRecipe(u as ILocalUser);
+		} else {
+			dm.addFollowersRecipe();
+		}
+	}
+}
+
+async function getReactionEmojiMap(reactions: NoteReaction[]) {
+	const emojiKeys = new Map<string, { name: string; host: string | null }>();
+
+	for (const reaction of reactions) {
+		const decoded = decodeReaction(reaction.reaction);
+		if (!decoded.name) continue;
+		const host = decoded.host ?? null;
+		const key = `${decoded.name}@${host ?? ""}`;
+		if (!emojiKeys.has(key)) {
+			emojiKeys.set(key, { name: decoded.name, host });
+		}
+	}
+
+	if (emojiKeys.size === 0) return new Map();
+
+	const emojis = await Emojis.find({
+		where: Array.from(emojiKeys.values()).map((entry) => ({
+			name: entry.name,
+			host: entry.host ?? IsNull(),
+		})),
+		select: ["name", "host", "license"],
+	});
+
+	return new Map(
+		emojis.map((emoji) => [
+			`${emoji.name}@${emoji.host ?? ""}`,
+			emoji,
+		]),
+	);
+}
+
+async function resendLocalReactionsForRenote(
+	renote: Note,
+	noteInboxes: Map<string, boolean>,
+) {
+	if (noteInboxes.size === 0) return;
+
+	const reactions = await NoteReactions.createQueryBuilder("reaction")
+		.leftJoinAndSelect("reaction.user", "user")
+		.where("reaction.noteId = :noteId", { noteId: renote.id })
+		.andWhere("user.host IS NULL")
+		.getMany();
+
+	if (reactions.length === 0) return;
+
+	const emojiMap = await getReactionEmojiMap(reactions);
+
+	for (const reaction of reactions) {
+		const reactionUser = reaction.user;
+		if (!reactionUser || reactionUser.host !== null) continue;
+
+		const decoded = decodeReaction(reaction.reaction);
+		const emojiKey = decoded.name
+			? `${decoded.name}@${decoded.host ?? ""}`
+			: null;
+		const emoji = emojiKey ? emojiMap.get(emojiKey) : null;
+		const deliverReaction = await resolveApReaction(reaction.reaction, emoji);
+		const deliverRecord = {
+			...reaction,
+			reaction: deliverReaction,
+		} as NoteReaction;
+
+		const activity = renderActivity(await renderLike(deliverRecord, renote));
+		const dm = await buildReactionDeliverManager(reactionUser, renote, activity);
+		const reactionInboxes = await dm.collectInboxes();
+		const filteredInboxes = new Map(
+			Array.from(reactionInboxes).filter(([inbox]) => noteInboxes.has(inbox)),
+		);
+
+		await deliverToInboxes(reactionUser as ILocalUser, activity, filteredInboxes);
+	}
 }
 
 async function renderNoteOrRenoteActivity(data: Option, note: Note) {

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -1182,11 +1182,11 @@ export default async (
 					const noteInboxes = await dm.collectInboxes();
 					await deliverToInboxes(user, noteActivity, noteInboxes);
 
-					if (data.renote) {
-						await resendLocalReactionsForRenote(
-							data.renote,
-							noteInboxes,
-						);
+					if (
+						data.renote &&
+						(await countSameRenotes(user.id, data.renote.id, note.id)) === 0
+					) {
+						await resendLocalReactionsForRenote(data.renote, noteInboxes);
 					}
 
 					//リレーに配送

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -1,13 +1,12 @@
 import { publishNoteStream } from "@/services/stream.js";
 import { renderLike } from "@/remote/activitypub/renderer/like.js";
-import DeliverManager from "@/remote/activitypub/deliver-manager.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import {
 	toDbReaction,
 	decodeReaction,
-	getFallbackReaction,
+	resolveApReaction,
 } from "@/misc/reaction-lib.js";
-import type { User, IRemoteUser, ILocalUser } from "@/models/entities/user.js";
+import type { User } from "@/models/entities/user.js";
 import type { Note } from "@/models/entities/note.js";
 import {
 	NoteReactions,
@@ -33,6 +32,7 @@ import { MAX_REACTION_PER_ACCOUNT } from "@/const.js";
 import { Cache } from "@/misc/cache.js";
 import type { UserProfile } from "@/models/entities/user-profile.js";
 import { checkReactionMute } from "@/misc/check-word-mute.js";
+import { buildReactionDeliverManager } from "./deliver.js";
 
 export default async (
 	user: {
@@ -341,50 +341,10 @@ export default async (
 		) {
 			// ブラックリストに登録済みのホスト または リモート絵文字でライセンスにコピー拒否がある場合 は いいねに変更して外部に送信
 			// TODO : リアクション解除時も変換をかけた方が良いかも
-			if (
-				["voskey.icalo.net", "9ineverse.com", "mogeko.monster"].includes(
-					emoji?.host,
-				) ||
-				(emoji?.host && emoji?.license?.includes("コピー可否 : deny"))
-			)
-				record.reaction = await getFallbackReaction();
+			record.reaction = await resolveApReaction(record.reaction, emoji);
 
 			const content = renderActivity(await renderLike(record, note));
-			const dm = new DeliverManager(user, content);
-			if (note.userHost !== null) {
-				const reactee = await Users.findOneBy({ id: note.userId });
-				dm.addDirectRecipe(reactee as IRemoteUser);
-			}
-
-			if (
-				user.isExplorable &&
-				user.isRemoteExplorable &&
-				note.isPublicLikeList
-			) {
-				if (["public", "home", "followers"].includes(note.visibility)) {
-					if (note.userId !== user.id && note.userHost === null) {
-						const u = await Users.findOneBy({ id: note.userId });
-						dm.addFollowersRecipe(u as ILocalUser);
-					} else {
-						dm.addFollowersRecipe();
-					}
-				} else if (note.visibility === "specified") {
-					const visibleUsers = await Promise.all(
-						note.visibleUserIds.map((id) => Users.findOneBy({ id })),
-					);
-					for (const u of visibleUsers.filter(
-						(u) => u && Users.isRemoteUser(u),
-					)) {
-						dm.addDirectRecipe(u as IRemoteUser);
-					}
-					const ccUsers = await Promise.all(
-						note.ccUserIds.map((id) => Users.findOneBy({ id })),
-					);
-					for (const u of ccUsers.filter((u) => u && Users.isRemoteUser(u))) {
-						dm.addDirectRecipe(u as IRemoteUser);
-					}
-				}
-			}
+			const dm = await buildReactionDeliverManager(user, note, content);
 
 			dm.execute();
 		}

--- a/packages/backend/src/services/note/reaction/deliver.ts
+++ b/packages/backend/src/services/note/reaction/deliver.ts
@@ -1,0 +1,47 @@
+import DeliverManager from "@/remote/activitypub/deliver-manager.js";
+import { Users } from "@/models/index.js";
+import type { Note } from "@/models/entities/note.js";
+import type { ILocalUser, IRemoteUser, User } from "@/models/entities/user.js";
+
+export async function buildReactionDeliverManager(
+	user: Pick<User, "id" | "host" | "isExplorable" | "isRemoteExplorable">,
+	note: Note,
+	activity: any,
+) {
+	const dm = new DeliverManager(user as ILocalUser, activity);
+
+	if (note.userHost !== null) {
+		const reactee = await Users.findOneBy({ id: note.userId });
+		if (reactee && Users.isRemoteUser(reactee)) {
+			dm.addDirectRecipe(reactee as IRemoteUser);
+		}
+	}
+
+	if (user.isExplorable && user.isRemoteExplorable && note.isPublicLikeList) {
+		if (["public", "home", "followers"].includes(note.visibility)) {
+			if (note.userId !== user.id && note.userHost === null) {
+				const u = await Users.findOneBy({ id: note.userId });
+				if (u && Users.isLocalUser(u)) {
+					dm.addFollowersRecipe(u);
+				}
+			} else {
+				dm.addFollowersRecipe();
+			}
+		} else if (note.visibility === "specified") {
+			const visibleUsers = await Promise.all(
+				note.visibleUserIds.map((id) => Users.findOneBy({ id })),
+			);
+			for (const u of visibleUsers.filter((u) => u && Users.isRemoteUser(u))) {
+				dm.addDirectRecipe(u as IRemoteUser);
+			}
+			const ccUsers = await Promise.all(
+				note.ccUserIds.map((id) => Users.findOneBy({ id })),
+			);
+			for (const u of ccUsers.filter((u) => u && Users.isRemoteUser(u))) {
+				dm.addDirectRecipe(u as IRemoteUser);
+			}
+		}
+	}
+
+	return dm;
+}


### PR DESCRIPTION
### Motivation

- ローカルユーザーがRT/引用した際に、対象ノートに付いたローカルリアクションをActivityPubで再送し、受信側の配送範囲（フォロワー配信／指定公開の直送等）に従って適切に届くようにするための改修です。
- カスタム絵文字のライセンス制約によっては外部に絵文字画像を送信できないため、条件に応じてフォールバックリアクションへ置換する必要がありました。
- 同様の配送ロジックが複数箇所に散在していたため、DRY原則に基づいて配送先収集と送信処理を共通化しました。

### Description

- RT/引用時に対象ノート（renote）のローカルリアクションを再送する処理を`packages/backend/src/services/note/create.ts`に追加し、再送先を投稿時の配送先と交差させてフィルタリングするようにしました。
- 配送先収集ロジックを`DeliverManager`に移し、`collectInboxes()`と`deliverToInboxes()`を導入してフォロワー配信／ダイレクト配信の収集と送信を共通化しました（`packages/backend/src/remote/activitypub/deliver-manager.ts`）。
- カスタム絵文字のライセンスやブラックリストに応じたフォールバック判断を`resolveApReaction`として共通化し、`toDbReaction`/送信用変換のフローから利用するようにしました（`packages/backend/src/misc/reaction-lib.ts`）。
- リアクション送信のレシピ構築ロジックを`buildReactionDeliverManager`として抽出し、`notes/reaction/create`およびrenote再送処理から再利用するようにしました（`packages/backend/src/services/note/reaction/deliver.ts`、`packages/backend/src/services/note/reaction/create.ts`の変更）。

### Testing

- 自動テストは実行していません（CI/ユニット/統合テストは未実施）。
- 変更はローカルでソース編集・ビルド前の静的確認に留まります。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697619840df48326afdd06ce37e72500)