### PR TITLE
RT時のリアクション再配送で交差配送を無効化し最新リアクションのみ再配送

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -1377,6 +1377,8 @@ async function resendLocalReactionsForRenote(
 		.leftJoinAndSelect("reaction.user", "user")
 		.where("reaction.noteId = :noteId", { noteId: renote.id })
 		.andWhere("user.host IS NULL")
+		.orderBy("reaction.createdAt", "DESC")
+		.addOrderBy("reaction.id", "DESC")
 		.getMany();
 
 	if (reactions.length === 0) {
@@ -1385,13 +1387,21 @@ async function resendLocalReactionsForRenote(
 		);
 		return;
 	}
+	const latestReactionsByUser = new Map<string, NoteReaction>();
+	for (const reaction of reactions) {
+		if (!latestReactionsByUser.has(reaction.userId)) {
+			latestReactionsByUser.set(reaction.userId, reaction);
+		}
+	}
+
+	const latestReactions = Array.from(latestReactionsByUser.values());
 	console.log(
-		`[reaction-resend] local reactions: ${reactions.length} (renote=${renote.id})`,
+		`[reaction-resend] local reactions: ${latestReactions.length} (renote=${renote.id})`,
 	);
 
-	const emojiMap = await getReactionEmojiMap(reactions);
+	const emojiMap = await getReactionEmojiMap(latestReactions);
 
-	for (const reaction of reactions) {
+	for (const reaction of latestReactions) {
 		const reactionUser = reaction.user;
 		if (!reactionUser || reactionUser.host !== null) continue;
 
@@ -1407,16 +1417,22 @@ async function resendLocalReactionsForRenote(
 		} as NoteReaction;
 
 		const activity = renderActivity(await renderLike(deliverRecord, renote));
-		const dm = await buildReactionDeliverManager(reactionUser, renote, activity);
-		const reactionInboxes = await dm.collectInboxes();
-		const filteredInboxes = new Map(
-			Array.from(reactionInboxes).filter(([inbox]) => noteInboxes.has(inbox)),
+		const dm = await buildReactionDeliverManager(
+			reactionUser,
+			renote,
+			activity,
+			{ disableUnion: true },
 		);
+		const reactionInboxes = await dm.collectInboxes();
 		console.log(
-			`[reaction-resend] deliver reaction: reactionInboxes=${reactionInboxes.size} filtered=${filteredInboxes.size} (renote=${renote.id}, reaction=${reaction.id})`,
+			`[reaction-resend] deliver reaction: reactionInboxes=${reactionInboxes.size} (renote=${renote.id}, reaction=${reaction.id})`,
 		);
 
-		await deliverToInboxes(reactionUser as ILocalUser, activity, filteredInboxes);
+		await deliverToInboxes(
+			reactionUser as ILocalUser,
+			activity,
+			reactionInboxes,
+		);
 	}
 }
 

--- a/packages/backend/src/services/note/reaction/deliver.ts
+++ b/packages/backend/src/services/note/reaction/deliver.ts
@@ -7,6 +7,9 @@ export async function buildReactionDeliverManager(
 	user: Pick<User, "id" | "host" | "isExplorable" | "isRemoteExplorable">,
 	note: Note,
 	activity: any,
+	options?: {
+		disableUnion?: boolean;
+	},
 ) {
 	const dm = new DeliverManager(user as ILocalUser, activity);
 
@@ -22,7 +25,11 @@ export async function buildReactionDeliverManager(
 			if (note.userId !== user.id && note.userHost === null) {
 				const u = await Users.findOneBy({ id: note.userId });
 				if (u && Users.isLocalUser(u)) {
-					dm.addFollowersRecipe(u);
+					if (options?.disableUnion) {
+						dm.addFollowersRecipe();
+					} else {
+						dm.addFollowersRecipe(u);
+					}
 				}
 			} else {
 				dm.addFollowersRecipe();


### PR DESCRIPTION
### Motivation
- RT（renote）時に再配送されるリアクションの配信範囲を、交差配送（union）を行わない例外扱いにして欲しいための対応です。 
- また、同一ユーザーによる複数リアクションがある場合はユーザー毎に最後に付けられたリアクションのみを再配送する必要があるためです。

### Description
- `buildReactionDeliverManager` にオプション `disableUnion` を追加して、交差配送（union）を無効化できるようにしました（`packages/backend/src/services/note/reaction/deliver.ts`）。
- RT再配送処理 `resendLocalReactionsForRenote` を変更し、`NoteReactions.createQueryBuilder` による取得を `createdAt`/`id` 降順でソートした上で、ユーザ毎に最新のリアクションのみを採るように集約するロジックを追加しました（`packages/backend/src/services/note/create.ts`）。
- 再配送時は `buildReactionDeliverManager(..., { disableUnion: true })` を指定してunionを無効化し、計算された配信先 (`reactionInboxes`) をそのまま `deliverToInboxes` に渡すように変更しました（フィルタリングの削除）。
- 絵文字マップの生成は最新リアクション集合に対して行うように更新しました（`getReactionEmojiMap` の呼び出し対象を変更）。

### Testing
- 自動テストは実行していません。 
- 変更後のコンパイルやユニットテストの実行を行っていないため、CI 上でのビルド／テスト実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a23597e88326874cb05386a9b284)