### PR TITLE
プロフィール概要タブの自己紹介リンク押下不具合を修正

### DIFF
--- a/packages/client/src/pages/user/home.vue
+++ b/packages/client/src/pages/user/home.vue
@@ -954,6 +954,7 @@ onUnmounted(() => {
 					background-size: cover;
 					background-position: center;
 					z-index: 100;
+					pointer-events: none;
 
 					> .fade {
 						position: absolute;
@@ -973,6 +974,7 @@ onUnmounted(() => {
 						right: 0.75rem;
 						padding: 0.5rem;
 						border-radius: 1.5rem;
+						pointer-events: auto;
 
 						> .menu {
 							vertical-align: bottom;


### PR DESCRIPTION
### Motivation
- プロフィールの自己紹介欄上部に配置されたリンクが押下できない問題を解消するため、フォロー操作エリアのポインターイベント制御を見直しました。

### Description
- `packages/client/src/pages/user/home.vue` の `.follow-container` に `pointer-events: none;` を追加して背景要素がクリック可能になるようにし、`.actions` に `pointer-events: auto;` を追加してボタン類は引き続き操作できるようにしました。

### Testing
- Playwright を使ったスクリーンショット取得を試行しましたが、開発サーバが応答せず `net::ERR_EMPTY_RESPONSE` で失敗しました。
- 他に自動化されたテストは実行しておらず、ユニット・統合テストは未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69787eba65a883268ceb6be299ddaa00)