### PR TITLE
PWAインストール案内の抑制条件を追加

### DIFF
--- a/packages/client/src/scripts/helpMenu.ts
+++ b/packages/client/src/scripts/helpMenu.ts
@@ -5,6 +5,7 @@ import * as os from "@/os";
 import XTutorial from "../components/MkTutorialDialog.vue";
 import { $i } from "@/account";
 import { i18n } from "@/i18n";
+import { resetPwaInstallPromptSuppression } from "@/scripts/pwa-install-prompt";
 import {
 	MenuButton,
 	MenuItem,
@@ -87,6 +88,7 @@ export function openHelpMenu_(ev: MouseEvent) {
 			{
 				type: "button",
 				action: async () => {
+					resetPwaInstallPromptSuppression();
 					defaultStore.set("tutorial", 0);
 					defaultStore.set("showLocalPostsInfoPopup", false);
 					defaultStore.set("showInviteInfoPopupAccount", false);

--- a/packages/client/src/scripts/pwa-install-prompt.ts
+++ b/packages/client/src/scripts/pwa-install-prompt.ts
@@ -1,0 +1,41 @@
+const PWA_INSTALL_PROMPT_SUPPRESSED_KEY = "pwaInstallPromptSuppressed";
+const PWA_BROWSER_VISIT_COUNT_KEY = "pwaBrowserVisitCount";
+const PWA_BROWSER_VISIT_LIMIT = 10;
+
+const getIsStandalonePwa = () => {
+	if (typeof window === "undefined") return false;
+	const displayModeStandalone =
+		window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+	const navigatorStandalone =
+		"standalone" in navigator
+			? (navigator as Navigator & { standalone?: boolean }).standalone === true
+			: false;
+	return displayModeStandalone || navigatorStandalone;
+};
+
+const getVisitCount = () => {
+	const rawCount = localStorage.getItem(PWA_BROWSER_VISIT_COUNT_KEY);
+	const count = rawCount ? Number.parseInt(rawCount, 10) : 0;
+	return Number.isNaN(count) ? 0 : count;
+};
+
+export const getPwaInstallPromptVisibility = () => {
+	if (typeof window === "undefined") return false;
+	if (getIsStandalonePwa()) return false;
+	const suppressed =
+		localStorage.getItem(PWA_INSTALL_PROMPT_SUPPRESSED_KEY) === "1";
+	if (suppressed) return false;
+	const nextCount = getVisitCount() + 1;
+	localStorage.setItem(PWA_BROWSER_VISIT_COUNT_KEY, String(nextCount));
+	if (nextCount >= PWA_BROWSER_VISIT_LIMIT) {
+		localStorage.setItem(PWA_INSTALL_PROMPT_SUPPRESSED_KEY, "1");
+		return false;
+	}
+	return true;
+};
+
+export const resetPwaInstallPromptSuppression = () => {
+	if (typeof window === "undefined") return;
+	localStorage.removeItem(PWA_INSTALL_PROMPT_SUPPRESSED_KEY);
+	localStorage.removeItem(PWA_BROWSER_VISIT_COUNT_KEY);
+};

--- a/packages/client/src/ui/_common_/common.vue
+++ b/packages/client/src/ui/_common_/common.vue
@@ -11,7 +11,7 @@
 
 	<XStreamIndicator />
 
-	<pwa-install disable-screenshots="true" />
+	<pwa-install v-if="shouldShowPwaInstallPrompt" disable-screenshots="true" />
 
 	<!-- <div v-if="pendingApiRequestsCount > 0" id="wait"></div> -->
 
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts" setup>
-import { defineAsyncComponent } from "vue";
+import { defineAsyncComponent, ref } from "vue";
 import { swInject } from "./sw-inject";
 import { popup, popups, pendingApiRequestsCount } from "@/os";
 import { uploads } from "@/scripts/upload";
@@ -32,6 +32,7 @@ import { $i } from "@/account";
 import { stream } from "@/stream";
 import { i18n } from "@/i18n";
 import * as os from "@/os";
+import { getPwaInstallPromptVisibility } from "@/scripts/pwa-install-prompt";
 import "@khmyznikov/pwa-install";
 
 const XStreamIndicator = defineAsyncComponent(
@@ -40,6 +41,7 @@ const XStreamIndicator = defineAsyncComponent(
 const XUpload = defineAsyncComponent(() => import("./upload.vue"));
 
 const dev = _DEV_;
+const shouldShowPwaInstallPrompt = ref(getPwaInstallPromptVisibility());
 
 const onNotification = (notification) => {
 	if ($i.mutingNotificationTypes.includes(notification.type)) return;


### PR DESCRIPTION
### Motivation
- ブラウザで何度もアクセスしているユーザーには何度もPWAインストール案内が出ないようにし、必要であればチュートリアル再実行で案内を復活させられるようにするためです。 

### Description
- 新規ヘルパー `packages/client/src/scripts/pwa-install-prompt.ts` を追加し、`getPwaInstallPromptVisibility` と `resetPwaInstallPromptSuppression` を実装しました。 
- 共通UIの `packages/client/src/ui/_common_/common.vue` を変更し、`<pwa-install>` を表示するかどうかを `shouldShowPwaInstallPrompt`（`getPwaInstallPromptVisibility` を初期値にする）で制御するようにしました。 
- ヘルプメニューの `packages/client/src/scripts/helpMenu.ts` を更新して、「もう一度チュートリアルを見る」実行時に `resetPwaInstallPromptSuppression()` を呼び出して抑制状態を解除するようにしました。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e00ce5ce8832693ce8b38b5304d96)