### PR TITLE
未ログイン時のエラートーストを抑制

### DIFF
--- a/packages/client/src/os.ts
+++ b/packages/client/src/os.ts
@@ -968,7 +968,9 @@ async function errortoast(res, body, endpoint, parameter) {
 			: body.error.info?.message || body.error.message 
 		: body.error.message;
 
-	toast(`${[res.status, message].join(" ")}`);
+	if ($i) {
+		toast(`${[res.status, message].join(" ")}`);
+	}
 
 	const currentDate = new Date();
 	const formattedDate = `${currentDate.toLocaleDateString()} ${currentDate.toLocaleTimeString()}`;


### PR DESCRIPTION
### Motivation
- APIエラー発生時に未ログイン状態でもトーストが表示されてしまうため、ログインしていないユーザーにはトーストを表示しないようにする目的です。

### Description
- `packages/client/src/os.ts` の `errortoast` 関数内で `toast(...)` 呼び出しを `$i` が存在する場合のみ実行するガードを追加しました。エラーログの記録処理は従来通り維持されています。

### Testing
- 自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802e7bf21c8326935cd99edabe21ff)