### PR TITLE
本文がない投稿で翻訳メニューを非表示にする

### DIFF
--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -30,6 +30,8 @@ export function getNoteMenu(props: {
 		isRenote && !defaultStore.state.developerNoteMenu
 			? (props.note.renote as misskey.entities.Note)
 			: props.note;
+	const hasTranslatableText =
+		typeof appearNote.text === "string" && appearNote.text.trim().length > 0;
 
 	function del(): void {
 		os.confirm({
@@ -542,7 +544,9 @@ export function getNoteMenu(props: {
 								action: share,
 							}
 						: undefined,
-						instance.translatorAvailable && !appearNote.deletedAt
+						instance.translatorAvailable &&
+						hasTranslatableText &&
+						!appearNote.deletedAt
 							? {
 									icon: "ph-translate ph-bold ph-lg",
 									text: i18n.ts.translate,
@@ -813,7 +817,9 @@ export function getNoteMenu(props: {
 							action: share,
 						}
 					: undefined,
-				instance.translatorAvailable && !appearNote.deletedAt
+				instance.translatorAvailable &&
+				hasTranslatableText &&
+				!appearNote.deletedAt
 					? {
 							icon: "ph-translate ph-bold ph-lg",
 							text: i18n.ts.translate,


### PR DESCRIPTION
### Motivation
- 投稿本文が空または空白のみの投稿で翻訳メニューが表示されると無意味な翻訳操作を誘発するため、翻訳メニューを非表示にする条件を追加しました。

### Description
- `packages/client/src/scripts/get-note-menu.ts` に `hasTranslatableText` を追加し、`appearNote.text` が文字列かつ空白でないことを判定するようにしました。
- メニュー生成箇所の条件式で `instance.translatorAvailable && !appearNote.deletedAt` に `hasTranslatableText` を組み込み、翻訳メニューの表示を2箇所で抑制するように変更しました。
- 空文字や空白のみの本文を翻訳対象外と判定することで無駄な翻訳リクエストを防ぎます。

### Testing
- 自動テストは実行していません（CI／ユニットテスト未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803545d6cc8326bdb8b93ea1cb33f3)