### PR TITLE
DeepLの認証方式をフォームボディからヘッダーへ移行

### DIFF
--- a/packages/backend/src/services/translation/deepl.ts
+++ b/packages/backend/src/services/translation/deepl.ts
@@ -41,7 +41,6 @@ export async function translateWithDeepl(
   const normalizedTarget = targetLang.toUpperCase();
 
   const params = new URLSearchParams();
-  params.append("auth_key", meta.deeplAuthKey ?? "");
   params.append("text", text);
   params.append("target_lang", normalizedTarget);
 
@@ -52,6 +51,7 @@ export async function translateWithDeepl(
   const res = await fetch(endpoint, {
     method: "POST",
     headers: {
+      Authorization: `DeepL-Auth-Key ${meta.deeplAuthKey}`,
       "Content-Type": "application/x-www-form-urlencoded",
       "User-Agent": config.userAgent,
       Accept: "application/json, */*",


### PR DESCRIPTION
### Motivation
- DeepLのレガシー認証（フォームボディの`auth_key`）が廃止され、API呼び出しが`403`となるため、公式のヘッダー認証へ切り替える必要がある。 

### Description
- `packages/backend/src/services/translation/deepl.ts` の `translateWithDeepl` でフォームボディの `auth_key` を削除し、リクエストヘッダーに `Authorization: DeepL-Auth-Key ...` を追加した。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980320761dc83269f6f5d6c8a557836)