### PR TITLE
Discord連携表示でdiscriminatorが`0`/`0000`のとき `#` を省略

### DIFF
--- a/packages/client/src/pages/settings/integration.vue
+++ b/packages/client/src/pages/settings/integration.vue
@@ -10,9 +10,7 @@
 					:href="`https://discord.com/users/${integrations.discord.id}`"
 					rel="nofollow noopener"
 					target="_blank"
-					>@{{ integrations.discord.username }}#{{
-						integrations.discord.discriminator
-					}}</a
+					>{{ discordHandle }}</a
 				>
 			</p>
 			<MkButton
@@ -67,6 +65,14 @@ const discordForm = ref<Window | null>(null);
 const githubForm = ref<Window | null>(null);
 
 const integrations = computed(() => $i!.integrations);
+const discordHandle = computed(() => {
+	const discord = integrations.value.discord;
+	if (!discord) return "";
+	if (discord.discriminator === "0" || discord.discriminator === "0000") {
+		return `@${discord.username}`;
+	}
+	return `@${discord.username}#${discord.discriminator}`;
+});
 
 function openWindow(service: string, type: string) {
 	return window.open(


### PR DESCRIPTION
### Motivation
- Discordの新しいユーザ表記に対応し、discriminator が `0` または `0000` の場合に接続表示から不要な `#0` を除去するため。 

### Description
- `packages/client/src/pages/settings/integration.vue` に `discordHandle` の `computed` を追加して、`discriminator` が `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698038f860b0832683fa6a6564b107fd)