### PR TITLE
Enter送信時に2FA判定用の未取得ユーザー情報を補完する実装を追加

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -183,6 +183,7 @@ let challengeData = $ref(null);
 let queryingKey = $ref(false);
 let hCaptchaResponse = $ref(null);
 let reCaptchaResponse = $ref(null);
+let userFetching = $ref<Promise<void> | null>(null);
 
 const meta = $computed(() => instance);
 
@@ -208,22 +209,40 @@ const props = defineProps({
 	},
 });
 
+function fetchUser() {
+	if (!username) {
+		user = null;
+		return Promise.resolve();
+	}
+	if (userFetching) {
+		return userFetching;
+	}
+	const promise = os
+		.api(
+			"users/show",
+			{
+				username: username,
+			},
+			undefined,
+			true,
+		)
+		.then(
+			(userResponse) => {
+				user = userResponse;
+			},
+			() => {
+				user = null;
+			},
+		)
+		.finally(() => {
+			userFetching = null;
+		});
+	userFetching = promise;
+	return promise;
+}
+
 function onUsernameChange() {
-        os.api(
-                "users/show",
-                {
-                        username: username,
-                },
-                undefined,
-                true,
-        ).then(
-                (userResponse) => {
-                        user = userResponse;
-                },
-                () => {
-                        user = null;
-		}
-	);
+	fetchUser();
 }
 
 function onLogin(res) {
@@ -281,9 +300,11 @@ function queryKey() {
 		});
 }
 
-function onSubmit() {
+async function onSubmit() {
 	signing = true;
-	console.log("submit");
+	if (!user && username) {
+		await fetchUser();
+	}
 	if (!totpLogin && user && user.twoFactorEnabled) {
 		if (window.PublicKeyCredential && user.securityKeys) {
 			os.api("signin", {


### PR DESCRIPTION
### Motivation
- `Enter` 押下で送信した際に `user` が未取得のまま2FA判定に進んでしまい、ログインボタンと挙動が一致しない問題を解消するため。 

### Description
- `packages/client/src/components/MkSignin.vue` に `userFetching` (取得中の `Promise`) と `fetchUser` を追加し、`users/show` API の呼び出しを共通化して重複リクエストを抑制しました。 
- `onUsernameChange` を `fetchUser` 呼び出しに置き換え、入力変更時のユーザー取得を同一ロジックで行うようにしました。 
- `onSubmit` を `async` 化し、送信時に `user` が未取得で `username` がある場合は `await fetchUser()` してから2FA判定へ進むように変更しました。 

### Testing
- 自動化されたテストは実行しておらず、CI 上のテストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802ef5da1083269b636993fb0996b8)