### PR TITLE
ピン留め登録: 既存更新を維持し未登録時のみUPSERTを最小差分で適用

### DIFF
--- a/packages/backend/src/services/i/pin.ts
+++ b/packages/backend/src/services/i/pin.ts
@@ -10,7 +10,6 @@ import type { UserNotePining } from "@/models/entities/user-note-pining.js";
 import { genId } from "@/misc/gen-id.js";
 import { deliverToFollowers } from "@/remote/activitypub/deliver-manager.js";
 import { deliverToRelays } from "../relay.js";
-import { QueryFailedError } from "typeorm";
 
 /**
  * 指定した投稿をピン留めします
@@ -43,42 +42,36 @@ export async function addPinned(
 		);
 	}
 
-        const updateExisting = async () =>
-                UserNotePinings.update(
-                        {
-                                userId: user.id,
-                                noteId: note.id,
-                        },
-                        {
-                                id: genId(),
-                                createdAt: new Date(),
-                        } as UserNotePining,
-                );
+	const updateExisting = async () =>
+		UserNotePinings.update(
+			{
+				userId: user.id,
+				noteId: note.id,
+			},
+			{
+				id: genId(),
+				createdAt: new Date(),
+			} as UserNotePining,
+		);
 
-        if (pinings.some((pining) => pining.noteId === note.id)) {
-                // すでに登録済みの場合、上に持ってくるためにID・登録日を更新
-                await updateExisting();
-        } else {
-                try {
-                        await UserNotePinings.insert({
-                                id: genId(),
-                                createdAt: new Date(),
-                                userId: user.id,
-                                noteId: note.id,
-                        } as UserNotePining);
-                } catch (err) {
-                        const driverErrorCode =
-                                (err as QueryFailedError)?.driverError?.code ??
-                                (err as { code?: string }).code;
-
-                        if (driverErrorCode === "23505") {
-                                // 挿入競合時は既存レコードを更新
-                                await updateExisting();
-                        } else {
-                                throw err;
-                        }
-                }
-        }
+	if (pinings.some((pining) => pining.noteId === note.id)) {
+		// すでに登録済みの場合、上に持ってくるためにID・登録日を更新
+		await updateExisting();
+	} else {
+		// 同一ノートへの同時ピン留めで userId+noteId のユニーク制約が競合しても
+		// UPSERT で解決されるため、トランザクションが中断されないことを想定。
+		await UserNotePinings.upsert(
+			{
+				id: genId(),
+				createdAt: new Date(),
+				userId: user.id,
+				noteId: note.id,
+			} as UserNotePining,
+			{
+				conflictPaths: ["userId", "noteId"],
+			},
+		);
+	}
 
 	// Deliver to remote followers
 	if (


### PR DESCRIPTION
### Motivation
- 既存ピンの「上に持ってくる」挙動は維持しつつ、同時挿入による `userId`+`noteId` のユニーク競合でトランザクションが中断されないようにしたい。 

### Description
- `packages/backend/src/services/i/pin.ts` の `addPinned` で既存ピンは従来通り `update` を実行する分岐を保持しました。 
- 未登録時の挿入処理を `insert`+例外ハンドリングから `UserNotePinings.upsert(...)` に置き換え、`userId`+`noteId` の競合時に `id`/`createdAt` を更新するようにしました。 
- もともと不要だった `QueryFailedError` のインポートを削除し、差分を最小に抑えています。 

### Testing
- 自動化テストは実行していません（変更は局所的で既存の挙動を維持する形のため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698034835cf08326882db4c934661f4b)