### PR TITLE
プッシュ通知の安定化と通知既読境界のRedis保存を追加

### DIFF
--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -1,9 +1,10 @@
-import { In } from "typeorm";
+import { In, LessThanOrEqual } from "typeorm";
 import { publishMainStream } from "@/services/stream.js";
 import { pushNotification } from "@/services/push-notification.js";
 import type { User } from "@/models/entities/user.js";
 import type { Notification } from "@/models/entities/notification.js";
 import { Notifications, Users } from "@/models/index.js";
+import { redisClient } from "@/db/redis.js";
 
 export async function readNotification(
 	userId: User["id"],
@@ -28,6 +29,28 @@ export async function readNotification(
 	if (!(await Users.getHasUnreadNotification(userId)))
 		return postReadAllNotifications(userId);
 	else return postReadNotifications(userId, notificationIds);
+}
+
+export async function readAllNotifications(
+	userId: User["id"],
+	latestNotificationId: Notification["id"],
+) {
+	await redisClient.set(`latestReadNotification:${userId}`, latestNotificationId);
+
+	const result = await Notifications.update(
+		{
+			notifieeId: userId,
+			id: LessThanOrEqual(latestNotificationId),
+			isRead: false,
+		},
+		{
+			isRead: true,
+		},
+	);
+
+	if (result.affected === 0) return;
+
+	return postReadAllNotifications(userId);
 }
 
 export async function readNotificationByQuery(

--- a/packages/backend/src/server/api/endpoints/i/notifications.ts
+++ b/packages/backend/src/server/api/endpoints/i/notifications.ts
@@ -2,7 +2,7 @@ import { Brackets } from "typeorm";
 import { Notifications, Mutings, Users, UserProfiles } from "@/models/index.js";
 import { notificationTypes } from "@/types.js";
 import read from "@/services/note/read.js";
-import { readNotification } from "../../common/read-notification.js";
+import { readAllNotifications } from "../../common/read-notification.js";
 import define from "../../define.js";
 import { makePaginationQuery } from "../../common/make-pagination-query.js";
 import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
@@ -166,10 +166,12 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	// Mark all as read
 	if (notifications.length > 0 && ps.markAsRead) {
-		readNotification(
-			user.id,
-			notifications.map((x) => x.id),
+		const latestNotificationId = notifications.reduce(
+			(latest, notification) =>
+				notification.id > latest ? notification.id : latest,
+			notifications[0].id,
 		);
+		readAllNotifications(user.id, latestNotificationId);
 	}
 
 	const notes = notifications

--- a/packages/backend/src/services/push-notification.ts
+++ b/packages/backend/src/services/push-notification.ts
@@ -4,6 +4,9 @@ import { SwSubscriptions } from "@/models/index.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import type { Packed } from "@/misc/schema.js";
 import { getNoteSummary } from "@/misc/get-note-summary.js";
+import Logger from "@/services/logger.js";
+
+const logger = new Logger("push-notification", "yellow");
 
 // Defined also packages/sw/types.ts#L14-L21
 type pushNotificationsTypes = {
@@ -51,8 +54,10 @@ export async function pushNotification<T extends keyof pushNotificationsTypes>(
 		!meta.enableServiceWorker ||
 		meta.swPublicKey == null ||
 		meta.swPrivateKey == null
-	)
+	) {
+		logger.warn("Service Worker の設定が無効なため、プッシュ通知をスキップします。");
 		return;
+	}
 
 	// アプリケーションの連絡先と、サーバーサイドの鍵ペアの情報を登録
 	push.setVapidDetails(config.url, meta.swPublicKey, meta.swPrivateKey);
@@ -62,7 +67,7 @@ export async function pushNotification<T extends keyof pushNotificationsTypes>(
 		userId: userId,
 	});
 
-	for (const subscription of subscriptions) {
+	const tasks = subscriptions.map(async (subscription) => {
 		if (
 			[
 				"readNotifications",
@@ -70,9 +75,9 @@ export async function pushNotification<T extends keyof pushNotificationsTypes>(
 				"readAllMessagingMessages",
 				"readAllMessagingMessagesOfARoom",
 			].includes(type) &&
-			!subscription.sendReadMessage
+				!subscription.sendReadMessage
 		)
-			continue;
+			return;
 
 		const pushSubscription = {
 			endpoint: subscription.endpoint,
@@ -82,8 +87,8 @@ export async function pushNotification<T extends keyof pushNotificationsTypes>(
 			},
 		};
 
-		push
-			.sendNotification(
+		try {
+			await push.sendNotification(
 				pushSubscription,
 				JSON.stringify({
 					type,
@@ -97,19 +102,28 @@ export async function pushNotification<T extends keyof pushNotificationsTypes>(
 				{
 					proxy: config.proxy,
 				},
-			)
-			.catch((err: any) => {
-				//swLogger.info(err.statusCode);
-				//swLogger.info(err.headers);
-				//swLogger.info(err.body);
-				if (err.statusCode === 410) {
-					SwSubscriptions.delete({
-						userId: userId,
-						endpoint: subscription.endpoint,
-						auth: subscription.auth,
-						publickey: subscription.publickey,
-					});
-				}
-			});
-	}
+			);
+		} catch (err: any) {
+			const statusCode = err?.statusCode;
+			if (statusCode === 404 || statusCode === 410) {
+				await SwSubscriptions.delete({
+					userId: userId,
+					endpoint: subscription.endpoint,
+					auth: subscription.auth,
+					publickey: subscription.publickey,
+				});
+				logger.warn(
+					`購読が無効でした (status=${statusCode})。削除しました: ${subscription.endpoint}`,
+				);
+				return;
+			}
+
+			logger.error(
+				`プッシュ通知送信に失敗しました (status=${statusCode ?? "unknown"})`,
+			);
+			logger.error(err);
+		}
+	});
+
+	await Promise.all(tasks);
 }

--- a/packages/client/src/components/MkPushNotificationAllowButton.vue
+++ b/packages/client/src/components/MkPushNotificationAllowButton.vue
@@ -53,11 +53,12 @@
 </template>
 
 <script setup lang="ts">
-import { $i, getAccounts } from "@/account";
+import { $i } from "@/account";
 import MkButton from "@/components/MkButton.vue";
 import { instance } from "@/instance";
-import { api, apiWithDialog, promiseDialog } from "@/os";
+import { api, promiseDialog } from "@/os";
 import { i18n } from "@/i18n";
+import { apiUrl } from "@/config";
 
 defineProps<{
 	primary?: boolean;
@@ -139,22 +140,18 @@ async function unsubscribe() {
 	if (!pushSubscription) return;
 
 	const endpoint = pushSubscription.endpoint;
-	const accounts = await getAccounts();
 
 	pushRegistrationInServer = undefined;
 
-	if ($i && accounts.length >= 2) {
-		apiWithDialog("sw/unregister", {
-			i: $i.token,
+	await pushSubscription.unsubscribe();
+	pushSubscription = null;
+
+	await fetch(`${apiUrl}/sw/unregister`, {
+		method: "POST",
+		body: JSON.stringify({
 			endpoint,
-		});
-	} else {
-		pushSubscription.unsubscribe();
-		apiWithDialog("sw/unregister", {
-			endpoint,
-		});
-		pushSubscription = null;
-	}
+		}),
+	});
 }
 
 function encode(buffer: ArrayBuffer | null) {

--- a/packages/sw/src/scripts/notification-read.ts
+++ b/packages/sw/src/scripts/notification-read.ts
@@ -16,7 +16,7 @@ class SwNotificationReadManager {
 
 	public async construct() {
 		const accounts = await get("accounts");
-		if (!accounts) Error("Accounts are not recorded");
+		if (!accounts) throw new Error("Accounts are not recorded");
 
 		this.accounts = accounts.reduce((acc, e) => {
 			acc[e.id] = {
@@ -34,7 +34,7 @@ class SwNotificationReadManager {
 		data: pushNotificationDataMap[K],
 	) {
 		// 既読をサーバーに送信しない
-		if (data.type !== "notification" || !(data.userId in this.accounts) || true)
+		if (data.type !== "notification" || !(data.userId in this.accounts))
 			return;
 
 		const account = this.accounts[data.userId];


### PR DESCRIPTION
### Motivation
- 通知一覧取得時に `markAsRead` が true の場合に通知ID配列を個別に既読化するのではなく、最新通知IDを既読境界として保存して一括既読扱いにするための実装が必要だったため。  
- プッシュ送信や Service Worker 側の既読送信で例外や無効購読により動作が不安定になる問題を改善するため。  

### Description
- `packages/backend/src/server/api/common/read-notification.ts` に `readAllNotifications(userId, latestNotificationId)` を追加し、`redisClient.set('latestReadNotification:${userId}', latestNotificationId)` で境界を保存し、境界以下の通知を `isRead=true` に更新して `readAllNotifications` を発行するようにしたこと。  
- `packages/backend/src/server/api/endpoints/i/notifications.ts` の `markAsRead` 処理を変更し、取得した通知群から最も新しい通知IDを算出して `readAllNotifications` を呼ぶようにしたこと（`readNotification` の配列方式から切替）。  
- 以前の改修で行った安定化対応を含めて、`packages/backend/src/services/push-notification.ts` では Service Worker 設定無効時のスキップログ出力、送信エラー時の `404`/`410` を検知して無効な `SwSubscriptions` を削除、例外を `Logger` で記録しつつ送信を並列実行するように変更したこと。  
- `packages/client/src/components/MkPushNotificationAllowButton.vue` の解除処理を確実に `pushSubscription.unsubscribe()` しサーバーへは `fetch(\\`/sw/unregister\\`)` を確実に叩くよう簡素化したこと。  
- `packages/sw/src/scripts/notification-read.ts` で `accounts` 未設定時に明示的に例外を投げるよう修正し、誤って無効化していた既読送信条件の `|| true` を削除して既読送信を有効化したこと。  

### Testing
- 自動テストは実行していません。  
- 変更はローカルでソース修正およびコミット済みですが、統合テスト／CI 実行は未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802f90b8648326bf88a8135160ccd9)