### PR TITLE
ログアウト時にBull Dashboard用の`token` Cookieを削除

### DIFF
--- a/packages/client/src/account.ts
+++ b/packages/client/src/account.ts
@@ -55,7 +55,8 @@ export async function signout() {
 	} catch (err) {}
 	//#endregion
 
-	document.cookie = "igi=; path=/";
+	document.cookie = "igi=; path=/; max-age=0";
+	document.cookie = "token=; path=/; max-age=0";
 
 	if (accounts.length > 0) login(accounts[0].token);
 	else unisonReload("/");


### PR DESCRIPTION
### Motivation
- Bull Dashboard認証に使われる`token` Cookieがログアウト後も残る脆弱性を修正するため、ログアウト処理で明示的にCookieを削除する必要がありました。 

### Description
- `packages/client/src/account.ts` の `signout()` 内で `document.cookie` を更新して `igi` と `token` を `max-age=0` で上書きし、ログアウト時に確実に削除されるようにしました。 

### Testing
- 自動テストは実行していません（`signout()` の変更のみでユニットテストは未追加）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980480ed0088326a5f6f747987942b8)