### PR TITLE
タイムラインの先頭判定を厳格化（スワイプを先頭のみ許可）

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -178,6 +178,8 @@ const isTimelineAtTop = ref(true);
 let removeScrollListener: (() => void) | null = null;
 
 let queue = $ref(0);
+const TOP_SWIPE_TOLERANCE = 0;
+
 const allowTouchMove = computed(() => {
 	if (!defaultStore.state.swipeOnDesktop) {
 		return false;
@@ -212,7 +214,7 @@ const src = $computed({
 watch($$(src), () => (queue = 0));
 
 function updateTopState(): void {
-	isTimelineAtTop.value = isTopVisible(rootEl);
+	isTimelineAtTop.value = isTopVisible(rootEl, TOP_SWIPE_TOLERANCE);
 }
 
 function queueUpdated(q: number, a): void {


### PR DESCRIPTION
### Motivation
- タイムラインで「先頭にいるときのみスワイプを有効にする」判定が緩く、先頭以外でもスワイプが有効になってしまうため、先頭判定をより厳格にします。

### Description
- `packages/client/src/pages/timeline.vue` に `TOP_SWIPE_TOLERANCE = 0` を追加し、`updateTopState` で `isTopVisible(rootEl, TOP_SWIPE_TOLERANCE)` を使うよう変更して先頭判定の許容誤差を0に固定しました。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804887bb6083268878e6080b1166be)