### PR TITLE
TL先頭時のみスワイプ有効化の判定をSwiperに反映

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -197,6 +197,15 @@ const allowTouchMove = computed(() => {
 		!isPagingActive
 	);
 });
+
+const applyAllowTouchMove = (value: boolean) => {
+	if (!swiperRef) return;
+	swiperRef.allowTouchMove = value;
+};
+
+watch(allowTouchMove, (value) => {
+	applyAllowTouchMove(value);
+});
 const src = $computed({
 	get: () => {
 		if (timelines.includes(defaultStore.reactiveState.tl.value.src)) {
@@ -616,6 +625,7 @@ let swiperRef: any = null;
 function setSwiperRef(swiper) {
 	swiperRef = swiper;
 	syncSlide(timelines.indexOf(src));
+	applyAllowTouchMove(allowTouchMove.value);
 }
 
 function onSlideChange() {


### PR DESCRIPTION
### Motivation
- TLの先頭判定に応じてスワイプを有効/無効にするロジックがSwiper本体に反映されず常にスワイプ有効になっていたため、判定結果を実際のSwiper挙動に反映する。 

### Description
- `packages/client/src/pages/timeline.vue` に `applyAllowTouchMove` を追加し、`allowTouchMove` を `watch` して `swiperRef.allowTouchMove` に反映する処理を追加し、`setSwiperRef` 初期化時にも `applyAllowTouchMove(allowTouchMove.value)` を呼ぶようにしました。 

### Testing
- 自動テストは実行しておらず、変更に対する自動テストは未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981841c750c8326ba8088c048c3fc78)