### PR TITLE
タイムライン初期ロード時のスワイプ挙動を調整

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -178,8 +178,6 @@ const isTimelineAtTop = ref(true);
 let removeScrollListener: (() => void) | null = null;
 
 let queue = $ref(0);
-const TOP_SWIPE_TOLERANCE = 0;
-
 const allowTouchMove = computed(() => {
 	if (!defaultStore.state.swipeOnDesktop) {
 		return false;
@@ -188,6 +186,12 @@ const allowTouchMove = computed(() => {
 		return true;
 	}
 	const pagingComponent = tlComponent.value?.tlComponent?.pagingComponent;
+	const isInitialLoad =
+		(pagingComponent?.items?.value?.length ?? 0) === 0 &&
+		(pagingComponent?.queue?.value?.length ?? 0) === 0;
+	if (isInitialLoad) {
+		return true;
+	}
 	const isPagingActive =
 		(pagingComponent?.active || pagingComponent?.backed) ?? false;
 	return (
@@ -223,7 +227,7 @@ const src = $computed({
 watch($$(src), () => (queue = 0));
 
 function updateTopState(): void {
-	isTimelineAtTop.value = isTopVisible(rootEl, TOP_SWIPE_TOLERANCE);
+	isTimelineAtTop.value = isTopVisible(rootEl);
 }
 
 function queueUpdated(q: number, a): void {


### PR DESCRIPTION
### Motivation
- タイムラインの初期ロード中（表示項目もキューも空の状態）でもタブのスワイプ移動を許可するための対応を行いました。 
- 投稿の追加読み込み中（既に項目があり追加分を読み込んでいる状態）は従来どおりスワイプを抑止する意図を維持しています。 

### Description
- `packages/client/src/pages/timeline.vue` の `allowTouchMove` 計算プロパティに、`pagingComponent` の `items` と `queue` を参照して初期ロード（両方が空）の場合は `true` を返す判定を追加しました。 
- トップ判定は `isTopVisible(rootEl)` を使用するように統一し、古い `TOP_SWIPE_TOLERANCE` の扱いを整理しました。 
- 変更対象は主に `allowTouchMove` と `updateTopState` のロジックで、影響ファイルは `packages/client/src/pages/timeline.vue` です。 

### Testing
- 自動テストは実行しておらず、CI上のテストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818cd3e280832692edee3592e22e31)