### PR TITLE
タイムライン先頭判定の厳格化を再適用

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -178,6 +178,7 @@ const isTimelineAtTop = ref(true);
 let removeScrollListener: (() => void) | null = null;
 
 let queue = $ref(0);
+const TOP_SWIPE_TOLERANCE = 0;
 const allowTouchMove = computed(() => {
 	if (!defaultStore.state.swipeOnDesktop) {
 		return false;
@@ -227,7 +228,7 @@ const src = $computed({
 watch($$(src), () => (queue = 0));
 
 function updateTopState(): void {
-	isTimelineAtTop.value = isTopVisible(rootEl);
+	isTimelineAtTop.value = isTopVisible(rootEl, TOP_SWIPE_TOLERANCE);
 }
 
 function queueUpdated(q: number, a): void {


### PR DESCRIPTION
### Motivation
- PR #201 での変更を再適用して、スワイプ許可判定におけるタイムライン先頭の検出を厳格化するため。

### Description
- `packages/client/src/pages/timeline.vue` に `const TOP_SWIPE_TOLERANCE = 0` を追加し、`isTopVisible(rootEl)` を `isTopVisible(rootEl, TOP_SWIPE_TOLERANCE)` に変更しました。

### Testing
- 自動テストは実行しておらず、コミットのみ行っています（未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819725a5588326aef812ae1a041891)