### PR TITLE
初期ロード後にスワイプが有効なままになる問題を修正

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -186,20 +186,27 @@ const allowTouchMove = computed(() => {
 	if (!defaultStore.state.notTopToSwipeStop) {
 		return true;
 	}
-	const pagingComponent = tlComponent.value?.tlComponent?.pagingComponent;
+	const pagingComponent =
+		tlComponent.value?.tlComponent?.pagingComponent?.value;
 	const isInitialLoad =
 		(pagingComponent?.items?.value?.length ?? 0) === 0 &&
 		(pagingComponent?.queue?.value?.length ?? 0) === 0;
 	if (isInitialLoad) {
 		return true;
 	}
+	const isPagingBacked =
+		typeof pagingComponent?.backed === "boolean"
+			? pagingComponent.backed
+			: (pagingComponent?.backed?.value ?? false);
 	const isPagingActive =
-		(pagingComponent?.active || pagingComponent?.backed) ?? false;
+		typeof pagingComponent?.active === "boolean"
+			? pagingComponent.active
+			: (pagingComponent?.active?.value ?? false);
 	return (
 		isTimelineAtTop.value &&
 		queue === 0 &&
 		!queueActive &&
-		!isPagingActive
+		!(isPagingActive || isPagingBacked)
 	);
 });
 


### PR DESCRIPTION
### Motivation
- 初期読み込み完了後もスワイプが許可されたままになってしまい、スクロール/ページング状態が正しく反映されない問題を修正するための変更です。

### Description
- `packages/client/src/pages/timeline.vue` の `allowTouchMove` 判定で `tlComponent` 配下のページングコンポーネント参照先を `pagingComponent?.value` に修正しました。 
- ページングの `active` / `backed` が `ref` かプリミティブか両方の可能性を扱うように明示的に判定し、状態取得を安定化しました。 
- ページングがアクティブまたは遡り中の場合はスワイプを無効化する条件に変更して、初期ロード後の不正なスワイプを防止しています。

### Testing
- 自動テストは実行していません。
- 編集は該当箇所のみで、コンパイルや型エラーがないことをローカルで確認してコミットしています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981992c84948326937bf1de0fd93564)