### PR TITLE
タイムラインのスワイプ可否判定を安定化（アクティブコンポーネント参照修正）

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -176,6 +176,9 @@ const tlComponent = ref<InstanceType<typeof XTimeline>>();
 const rootEl = $ref<HTMLElement>();
 const isTimelineAtTop = ref(true);
 let removeScrollListener: (() => void) | null = null;
+const activeTimelineComponent = computed(() =>
+	Array.isArray(tlComponent.value) ? tlComponent.value[0] : tlComponent.value
+);
 
 let queue = $ref(0);
 const TOP_SWIPE_TOLERANCE = 0;
@@ -186,20 +189,30 @@ const allowTouchMove = computed(() => {
 	if (!defaultStore.state.notTopToSwipeStop) {
 		return true;
 	}
-	const pagingComponent = tlComponent.value?.tlComponent?.pagingComponent;
+	const pagingComponent =
+		activeTimelineComponent.value?.tlComponent?.pagingComponent?.value;
+	if (!pagingComponent) {
+		return false;
+	}
 	const isInitialLoad =
 		(pagingComponent?.items?.value?.length ?? 0) === 0 &&
 		(pagingComponent?.queue?.value?.length ?? 0) === 0;
 	if (isInitialLoad) {
 		return true;
 	}
+	const isPagingBacked =
+		typeof pagingComponent?.backed === "boolean"
+			? pagingComponent.backed
+			: (pagingComponent?.backed?.value ?? false);
 	const isPagingActive =
-		(pagingComponent?.active || pagingComponent?.backed) ?? false;
+		typeof pagingComponent?.active === "boolean"
+			? pagingComponent.active
+			: (pagingComponent?.active?.value ?? false);
 	return (
 		isTimelineAtTop.value &&
 		queue === 0 &&
 		!queueActive &&
-		!isPagingActive
+		!(isPagingActive || isPagingBacked)
 	);
 });
 


### PR DESCRIPTION
### Motivation
- 初期ロード後でも常にスワイプが有効になってしまう問題が継続しているため、参照しているタイムライン／ページングコンポーネントの取得方法を見直して判定を安定化しました。

### Description
- `packages/client/src/pages/timeline.vue` にアクティブなタイムライン参照補助として `activeTimelineComponent` の `computed` を追加しました。 
- `allowTouchMove` の判定でページングコンポーネントを `activeTimelineComponent.value?.tlComponent?.pagingComponent?.value` から取得するように変更しました。 
- ページングコンポーネントが取得できない場合はスワイプを無効化する早期 `return false` を追加しました。 
- `backed` と `active` の判定を明示的に `boolean` と `ref` の両方に対応する形に修正し、`!(isPagingActive || isPagingBacked)` でスワイプ無効条件を評価するようにしました。

### Testing
- 自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981992c84948326937bf1de0fd93564)