### PR TITLE
PR #201〜#206 の変更を差し戻し

### DIFF
--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -176,12 +176,8 @@ const tlComponent = ref<InstanceType<typeof XTimeline>>();
 const rootEl = $ref<HTMLElement>();
 const isTimelineAtTop = ref(true);
 let removeScrollListener: (() => void) | null = null;
-const activeTimelineComponent = computed(() =>
-	Array.isArray(tlComponent.value) ? tlComponent.value[0] : tlComponent.value
-);
 
 let queue = $ref(0);
-const TOP_SWIPE_TOLERANCE = 0;
 const allowTouchMove = computed(() => {
 	if (!defaultStore.state.swipeOnDesktop) {
 		return false;
@@ -189,30 +185,14 @@ const allowTouchMove = computed(() => {
 	if (!defaultStore.state.notTopToSwipeStop) {
 		return true;
 	}
-	const pagingComponent =
-		activeTimelineComponent.value?.tlComponent?.pagingComponent?.value;
-	if (!pagingComponent) {
-		return false;
-	}
-	const isInitialLoad =
-		(pagingComponent?.items?.value?.length ?? 0) === 0 &&
-		(pagingComponent?.queue?.value?.length ?? 0) === 0;
-	if (isInitialLoad) {
-		return true;
-	}
-	const isPagingBacked =
-		typeof pagingComponent?.backed === "boolean"
-			? pagingComponent.backed
-			: (pagingComponent?.backed?.value ?? false);
+	const pagingComponent = tlComponent.value?.tlComponent?.pagingComponent;
 	const isPagingActive =
-		typeof pagingComponent?.active === "boolean"
-			? pagingComponent.active
-			: (pagingComponent?.active?.value ?? false);
+		(pagingComponent?.active || pagingComponent?.backed) ?? false;
 	return (
 		isTimelineAtTop.value &&
 		queue === 0 &&
 		!queueActive &&
-		!(isPagingActive || isPagingBacked)
+		!isPagingActive
 	);
 });
 
@@ -241,7 +221,7 @@ const src = $computed({
 watch($$(src), () => (queue = 0));
 
 function updateTopState(): void {
-	isTimelineAtTop.value = isTopVisible(rootEl, TOP_SWIPE_TOLERANCE);
+	isTimelineAtTop.value = isTopVisible(rootEl);
 }
 
 function queueUpdated(q: number, a): void {


### PR DESCRIPTION
### Motivation
- タイムラインのスワイプ判定周りで導入された変更（PR #201 と #203〜#206）が挙動不安定を招いていたため、元の安定した判定ロジックに差し戻すための変更です。

### Description
- `packages/client/src/pages/timeline.vue` の差分を元に `activeTimelineComponent` と `TOP_SWIPE_TOLERANCE` の導入を取り除き、判定ロジックを単純化しました。
- `allowTouchMove` 内でのページング状態取得を `tlComponent.value?.tlComponent?.pagingComponent` に統一し、`isPagingActive` を `(pagingComponent?.active || pagingComponent?.backed) ?? false` で算出するように戻しました。
- 初期ロード判定や `isPagingBacked` を使った複雑な分岐を削除しました。\n- `updateTopState()` の呼び出しを `isTopVisible(rootEl)` に戻してトレランス引数を削除しました。
- 対象の差分はマージコミット（`230f7b9`, `7684869`, `7af7250`, `c064fcf`, `179ac7a`）に対して `git revert` を適用して差し戻しています。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819c5558ac83268d787c41c8b28d94)