### PR TITLE
不要な .tmp_firefish ディレクトリの削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ yarn*
 # Nix Development shell items
 .devenv
 .direnv
+
+# temp
+.tmp_firefish


### PR DESCRIPTION
### Motivation
- リポジトリに意図せず含まれていた ` .tmp_firefish`（サブモジュール相当のエントリ）を削除し、今後再混入しないようにするため。 

### Description
- リポジトリから ` .tmp_firefish` を削除し、再混入防止のために `.gitignore` に ` .tmp_firefish` を追記しました。 
- 変更を反映するためにコミットを作成および修正（`git commit` / `git commit --amend`）しています。 

### Testing
- 自動テストは実行していません; 変更は `git status -sb` と `git commit` 系コマンドで検証しており、コミット作成と `.gitignore` の更新が正常に行われました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698969e86970832681ab51b7cb8ffec4)