### PR TITLE
投稿フォームでファイル選択キャンセル時にアップロード待機が残る問題を修正

### DIFF
--- a/packages/client/src/scripts/select-file.ts
+++ b/packages/client/src/scripts/select-file.ts
@@ -36,35 +36,70 @@ function select(
 			const input = document.createElement("input");
 			input.type = "file";
 			input.multiple = multiple;
+			let handled = false;
+
+			const cleanupAndReject = (message: string) => {
+				if (handled) return;
+				handled = true;
+				rej(new Error(message));
+			};
+
+			const cleanupAndResolve = (files: DriveFile[]) => {
+				if (handled) return;
+				handled = true;
+				res(multiple ? files : files[0]);
+			};
+
 			input.onchange = () => {
-                                const promises = Array.from(input.files).map((file) =>
-                                        uploadFile(
-                                                file,
-                                                folderId,
-                                                undefined,
-                                                keepOriginal.value,
-                                                keepFileName.value,
-                                                requiredFilename,
-                                                options,
-                                        ),
-                                );
+				if (!input.files || input.files.length === 0) {
+					cleanupAndReject("No file was selected");
+					return;
+				}
+
+				const promises = Array.from(input.files).map((file) =>
+					uploadFile(
+						file,
+						folderId,
+						undefined,
+						keepOriginal.value,
+						keepFileName.value,
+						requiredFilename,
+						options,
+					),
+				);
 
 				Promise.all(promises)
 					.then((driveFiles) => {
-						res(multiple ? driveFiles : driveFiles[0]);
+						cleanupAndResolve(driveFiles);
 					})
 					.catch((err) => {
 						// エラー発生時にリジェクトする
-						rej(err);
+						cleanupAndReject(err?.message ?? "Failed to upload files");
 					});
 
 				// 一応廃棄
 				(window as any).__misskey_input_ref__ = null;
 			};
 
+			input.oncancel = () => {
+				cleanupAndReject("File selection was canceled");
+			};
+
 			// https://qiita.com/fukasawah/items/b9dc732d95d99551013d
 			// iOS Safari で正常に動かす為のおまじない
 			(window as any).__misskey_input_ref__ = input;
+
+			window.addEventListener(
+				"focus",
+				() => {
+					setTimeout(() => {
+						if (!handled && (!input.files || input.files.length === 0)) {
+							cleanupAndReject("File selection was canceled");
+						}
+					}, 0);
+				},
+				{ once: true },
+			);
 
 			input.click();
 		};


### PR DESCRIPTION
### Motivation
- ファイル選択ダイアログを閉じたりキャンセルした際に `selectFiles/selectFile` が未解決のまま残り、投稿が「アップロード待機中…」で進まなくなる問題を解消するため。

### Description
- `packages/client/src/scripts/select-file.ts` に `handled` フラグを導入して `resolve`/`reject` の多重実行を防止した。  
- `input.files` が空の場合の即時 `reject` チェックと `input.oncancel` を追加して選択キャンセルを明示的に検知するようにした。  
- `window.focus` のフォールバックでダイアログ閉鎖後に未選択ならキャンセル扱いにし、成功/失敗経路を `cleanupAndResolve` / `cleanupAndReject` に集約して処理を一元化した。

### Testing
- `pnpm --filter client run lint` を実行したが、実行環境に `rome` が存在しないためリンターは失敗し (`spawn rome ENOENT`)、静的チェックは完了しなかった。  
- 変更ファイルは `packages/client/src/scripts/select-file.ts` に適用済みで、CI あるいは依存をインストールしたローカル環境での検証実行を推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a954ea4788326a16eb33fc95f0d08)