### PR TITLE
fix(client): ★ボタンとピッカー併用時のリアクション数表示を分離

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -668,6 +668,15 @@ const showUndoReactionButton = $computed(
 );
 
 /**
+ * ★ボタンとピッカー系ボタンが同時に表示されるかどうか
+ */
+const showStarAndPickerButtons = $computed(
+	() =>
+		showStarButtonNoEmoji &&
+		(showReactionPickerButton || showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -678,7 +687,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showReactionPickerButton) {
+	if (showStarAndPickerButtons) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -689,8 +698,8 @@ const countForStarButton = $computed(() => {
  * 絵文字ピッカーボタン（+）に表示するカウント
  */
 const countForPickerButton = $computed(() => {
-	// ★ボタンが有効な場合（リスト表示状態に関わらず）、ピッカーはデフォルト以外を表示
-	if (isStarButtonEnabled) {
+	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
+	if (showStarAndPickerButtons) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -702,9 +711,9 @@ const countForPickerButton = $computed(() => {
  */
 const showReactionCount = $computed(
 	() =>
-		// ★ボタンが有効なら、リアクション一覧が表示されているときはカウント不要（リストに表示されるため）
-		// ★ボタンが無効なら、リアクション一覧が表示されていても（他に表示場所がないので）カウント表示
-		!(isStarButtonEnabled && isReactionListVisible) &&
+		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
+		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
+		!(showStarAndPickerButtons && isReactionListVisible) &&
 		countForPickerButton > 0 &&
 		(showReactionPickerButton || showUndoReactionButton)
 );
@@ -914,20 +923,20 @@ const undoReactionButtonRef = ref<HTMLElement>();
 useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
-		// ★ボタンが有効かつリアクション一覧表示中の場合、何もしない
-		if (isStarButtonEnabled && isReactionListVisible) {
+		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
+		if (showStarAndPickerButtons && isReactionListVisible) {
 			return;
 		}
 
-		// ★ボタン有効なら、デフォルト以外のリアクション（excludeTypeで除外）
+		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = isStarButtonEnabled
+		const type = showStarAndPickerButtons
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = isStarButtonEnabled
+		const excludeType = showStarAndPickerButtons
 			? instance.defaultReaction
 			: null;
 
@@ -941,7 +950,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = isStarButtonEnabled
+		const count = showStarAndPickerButtons
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -966,18 +975,18 @@ useTooltip(
 useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
-		// ★ボタンが有効かつリアクション一覧表示中の場合、何もしない
-		if (isStarButtonEnabled && isReactionListVisible) {
+		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
+		if (showStarAndPickerButtons && isReactionListVisible) {
 			return;
 		}
 
-		const type = isStarButtonEnabled
+		const type = showStarAndPickerButtons
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = isStarButtonEnabled
+		const excludeType = showStarAndPickerButtons
 			? instance.defaultReaction
 			: null;
 
@@ -991,7 +1000,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = isStarButtonEnabled
+		const count = showStarAndPickerButtons
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount

--- a/packages/client/src/components/MkNoteSub.vue
+++ b/packages/client/src/components/MkNoteSub.vue
@@ -492,6 +492,15 @@ const showUndoReactionButton = $computed(
 );
 
 /**
+ * ★ボタンとピッカー系ボタンが同時に表示されるかどうか
+ */
+const showStarAndPickerButtons = $computed(
+	() =>
+		showStarButtonNoEmoji &&
+		(showReactionPickerButton || showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -502,7 +511,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showReactionPickerButton) {
+	if (showStarAndPickerButtons) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -513,8 +522,8 @@ const countForStarButton = $computed(() => {
  * 絵文字ピッカーボタン（+）に表示するカウント
  */
 const countForPickerButton = $computed(() => {
-	// ★ボタンが有効な場合（リスト表示状態に関わらず）、ピッカーはデフォルト以外を表示
-	if (isStarButtonEnabled) {
+	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
+	if (showStarAndPickerButtons) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -526,9 +535,9 @@ const countForPickerButton = $computed(() => {
  */
 const showReactionCount = $computed(
 	() =>
-		// ★ボタンが有効なら、リアクション一覧が表示されているときはカウント不要（リストに表示されるため）
-		// ★ボタンが無効なら、リアクション一覧が表示されていても（他に表示場所がないので）カウント表示
-		!(isStarButtonEnabled && isReactionListVisible) &&
+		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
+		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
+		!(showStarAndPickerButtons && isReactionListVisible) &&
 		countForPickerButton > 0 &&
 		(showReactionPickerButton || showUndoReactionButton)
 );
@@ -587,20 +596,20 @@ useTooltip(
 useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
-		// ★ボタン有効かつリアクション一覧表示中の場合、何もしない
-		if (isStarButtonEnabled && isReactionListVisible) {
+		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
+		if (showStarAndPickerButtons && isReactionListVisible) {
 			return;
 		}
 
-		// ★ボタン有効なら、デフォルト以外のリアクション（excludeTypeで除外）
+		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = isStarButtonEnabled
+		const type = showStarAndPickerButtons
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = isStarButtonEnabled
+		const excludeType = showStarAndPickerButtons
 			? instance.defaultReaction
 			: null;
 
@@ -614,7 +623,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = isStarButtonEnabled
+		const count = showStarAndPickerButtons
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -638,18 +647,18 @@ useTooltip(
 useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
-		// ★ボタン有効かつリアクション一覧表示中の場合、何もしない
-		if (isStarButtonEnabled && isReactionListVisible) {
+		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
+		if (showStarAndPickerButtons && isReactionListVisible) {
 			return;
 		}
 
-		const type = isStarButtonEnabled
+		const type = showStarAndPickerButtons
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = isStarButtonEnabled
+		const excludeType = showStarAndPickerButtons
 			? instance.defaultReaction
 			: null;
 
@@ -663,7 +672,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = isStarButtonEnabled
+		const count = showStarAndPickerButtons
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount


### PR DESCRIPTION
### Motivation
- ★ボタン（デフォルトリアクション）とピッカーボタン（+ / -）を両方表示している場合、両方の横に総リアクション数が表示されてしまい意図と異なる表示になっていたため修正する。
- 期待挙動は、★ボタン横は「デフォルトリアクション数」、ピッカーボタン横は「それ以外のリアクション数」を表示することです。

### Description
- `packages/client/src/components/MkNoteSub.vue` に `showStarAndPickerButtons` の算出を追加して「★ボタンとピッカー系ボタンが同時に表示されるか」を明示的に判定しました（`$computed`）。
- `countForStarButton` を同時表示時は常に `defaultReactionCount` を返すよう変更し、単独時は従来どおりの文脈依存ロジックを維持しました。
- `countForPickerButton` と `showReactionCount` の判定を併用判定に合わせて調整し、併用時はピッカー側で非デフォルトのリアクション数（`nonDefaultReactionCount`）を表示するようにしました。
- ピッカー系のツールチップ取得ロジック（`useTooltip` の `type` / `excludeType`）と表示件数も上記の併用判定に合わせて統一しました。

### Testing
- 自動リンター実行（`pnpm -C packages/client exec eslint src/components/MkNoteSub.vue`）は ESLint 設定/環境の制約により失敗しました（ESLint 設定ファイル未検出）。
- パッケージのプロジェクト全体リンター実行（`pnpm -C packages/client run lint` → `rome check`）は依存 (`node_modules`) 未導入のため実行不可で失敗しました。 
- UI のスクリーンショット取得（Playwright）を試行しましたが、ローカルサーバーが起動しておらず `ERR_EMPTY_RESPONSE` で取得できませんでした。
- 上記の自動チェックは環境依存のため実行できませんでしたが、`packages/client/src/components/MkNoteSub.vue` のロジック差分を確認し、表示分離ロジックを導入して期待挙動を満たすように修正しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bff6dd9c883269c00f2c0db85ff0b)