### PR TITLE
投稿フォームがアップロード完了後に待機したままになる問題を修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -436,7 +436,7 @@ import {
 	getAccounts,
 	openAccountMenu as openAccountMenu_,
 } from "@/account";
-import { uploadFile } from "@/scripts/upload";
+import { uploadFile, uploads } from "@/scripts/upload";
 import type { UploadFileOptions } from "@/scripts/upload";
 import { deepClone } from "@/scripts/clone";
 import XDraft from "@/components/MkDraftDialog.vue";
@@ -2335,28 +2335,50 @@ async function resolvePostAccountToken(
 }
 
 async function waitForFileSelectingToBeFalse(backupDraftData) {
-        if (filePromises.length === 0) return;
+	if (filePromises.length === 0) return;
 
-        const addData = os.addQueue({
-                endpoint: "notes/create",
-                data: {},
-                comment: "ファイルのアップロードを待機中…",
-                draftData: { key: draftKey, ...backupDraftData },
-        });
+	const staleUploadWaitMs = 1000;
+	let noActiveUploadsSince: number | null = null;
 
-        try {
-                await Promise.all([...filePromises]);
-        } catch (err) {
-                throw new Error("アップロードに失敗しました。");
-        } finally {
-                if (addData) {
-                        os.removeQueue(addData.id);
-                }
-        }
+	const addData = os.addQueue({
+		endpoint: "notes/create",
+		data: {},
+		comment: "ファイルのアップロードを待機中…",
+		draftData: { key: draftKey, ...backupDraftData },
+	});
 
-        if (fileError) {
-                throw new Error("アップロードに失敗しました。");
-        }
+	try {
+		while (filePromises.length > 0) {
+			await Promise.allSettled([...filePromises]);
+
+			if (filePromises.length === 0) break;
+
+			if (uploads.value.length > 0) {
+				noActiveUploadsSince = null;
+				continue;
+			}
+
+			if (noActiveUploadsSince === null) {
+				noActiveUploadsSince = Date.now();
+				continue;
+			}
+
+			if (Date.now() - noActiveUploadsSince >= staleUploadWaitMs) {
+				filePromises = [];
+				break;
+			}
+		}
+	} catch (err) {
+		throw new Error("アップロードに失敗しました。");
+	} finally {
+		if (addData) {
+			os.removeQueue(addData.id);
+		}
+	}
+
+	if (fileError) {
+		throw new Error("アップロードに失敗しました。");
+	}
 }
 
 function cancel() {


### PR DESCRIPTION
### Motivation
- 投稿時に画像アップロードが完了しているにもかかわらず投稿処理が「ファイルのアップロードを待機中…」のまま進まないケースを回避するための修正です。 
- 原因はアップロード完了のタイミングと待機ロジックの競合で `filePromises` が残存してしまうことと推測されます。 

### Description
- `packages/client/src/components/MkPostForm.vue` に `uploads` を追加でインポートしてアップロードの実際の進行状況を参照できるようにしました（`import { uploadFile, uploads } from "@/scripts/upload"`）。
- 投稿前の待機処理 `waitForFileSelectingToBeFalse` を `Promise.all([...filePromises])` から `Promise.allSettled([...filePromises])` を使ったループ待機へ置き換え、ループ内で `uploads.value` を監視するように変更しました。 
- 実際のアップロードが存在しない状態が一定時間（1秒）続いた場合は残存している `filePromises` を破棄して処理を先に進める仕組みを追加しました（スタレート検出）。
- 既存の失敗時のエラーハンドリングとキューの後始末（`os.removeQueue`）は従来どおり維持しています。 

### Testing
- リント実行として `pnpm --filter client run lint` を実行しましたが、ローカル環境に `node_modules` が無く `rome` が見つからないため `spawn rome ENOENT` で失敗しました（依存未インストールによる失敗）。
- 変更はビルドや実行環境での統合テストはまだ実行しておらず、手元環境での動作確認では投稿フォームがアップロード完了後にハングするケースの緩和を期待しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c02aad6e08326adebc18a82f0ff3d)