### PR TITLE
リアクション2ボタン表示時のカウント分離ロジックを修正

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -295,7 +295,7 @@
                                                ></i>
                                                <i v-else class="ph-smiley ph-bold ph-lg"></i>
                                                <template v-if="showReactionCount">
-                                                       <p class="count">{{ countForPickerButton }}</p>
+                                                       <p class="count">{{ countForReactionPickerButton }}</p>
                                                </template>
                                        </button>
                                        <button
@@ -306,7 +306,7 @@
                                        >
                                                <i class="ph-minus ph-bold ph-lg" style="color: var(--accent);"></i>
                                                <template v-if="showReactionCount && showUndoReactionButton">
-                                                       <p class="count">{{ countForPickerButton }}</p>
+                                                       <p class="count">{{ countForUndoReactionButton }}</p>
                                                </template>
                                        </button>
 					<XQuoteButton
@@ -677,6 +677,17 @@ const showStarAndPickerButtons = $computed(
 );
 
 /**
+ * ★ボタンが非表示でも、★+ピッカーの2ボタンレイアウトとして扱うかどうか
+ */
+const useSplitReactionCounts = $computed(
+	() =>
+		showStarAndPickerButtons ||
+		(isStarButtonHandlesDefault &&
+			showReactionPickerButton &&
+			showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -687,7 +698,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -699,11 +710,31 @@ const countForStarButton = $computed(() => {
  */
 const countForPickerButton = $computed(() => {
 	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
 	}
+});
+
+/**
+ * リアクションピッカーボタン（+ / 禁止）に表示するカウント
+ */
+const countForReactionPickerButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return defaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+/**
+ * 取り消しボタン（-）に表示するカウント
+ */
+const countForUndoReactionButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return nonDefaultReactionCount;
+	}
+	return countForPickerButton;
 });
 
 /**
@@ -713,8 +744,8 @@ const showReactionCount = $computed(
 	() =>
 		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
 		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
-		!(showStarAndPickerButtons && isReactionListVisible) &&
-		countForPickerButton > 0 &&
+		!(useSplitReactionCounts && isReactionListVisible) &&
+		(countForReactionPickerButton > 0 || countForUndoReactionButton > 0) &&
 		(showReactionPickerButton || showUndoReactionButton)
 );
 const favButtonReactionIsFavorite =
@@ -924,19 +955,19 @@ useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
 		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -950,7 +981,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -976,17 +1007,17 @@ useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -1000,7 +1031,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount

--- a/packages/client/src/components/MkNoteSub.vue
+++ b/packages/client/src/components/MkNoteSub.vue
@@ -194,7 +194,7 @@
 						></i>
 						<i v-else class="ph-smiley ph-bold ph-lg"></i>
 						<template v-if="showReactionCount">
-							<p class="count">{{ countForPickerButton }}</p>
+							<p class="count">{{ countForReactionPickerButton }}</p>
 						</template>
 					</button>
 					<button
@@ -205,7 +205,7 @@
 					>
 						<i class="ph-minus ph-bold ph-lg" style="color: var(--accent);"></i>
 						<template v-if="showReactionCount && showUndoReactionButton">
-							<p class="count">{{ countForPickerButton }}</p>
+							<p class="count">{{ countForUndoReactionButton }}</p>
 						</template>
 					</button>
 					<XQuoteButton class="button" :note="appearNote" />
@@ -501,6 +501,17 @@ const showStarAndPickerButtons = $computed(
 );
 
 /**
+ * ★ボタンが非表示でも、★+ピッカーの2ボタンレイアウトとして扱うかどうか
+ */
+const useSplitReactionCounts = $computed(
+	() =>
+		showStarAndPickerButtons ||
+		(isStarButtonHandlesDefault &&
+			showReactionPickerButton &&
+			showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -511,7 +522,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -523,7 +534,7 @@ const countForStarButton = $computed(() => {
  */
 const countForPickerButton = $computed(() => {
 	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -533,12 +544,32 @@ const countForPickerButton = $computed(() => {
 /**
  * ピッカー/取り消しボタンの横にカウントを表示するかどうか
  */
+const countForReactionPickerButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return defaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+/**
+ * 取り消しボタン（-）に表示するカウント
+ */
+const countForUndoReactionButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return nonDefaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+/**
+ * ピッカー/取り消しボタンの横にカウントを表示するかどうか
+ */
 const showReactionCount = $computed(
 	() =>
 		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
 		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
-		!(showStarAndPickerButtons && isReactionListVisible) &&
-		countForPickerButton > 0 &&
+		!(useSplitReactionCounts && isReactionListVisible) &&
+		(countForReactionPickerButton > 0 || countForUndoReactionButton > 0) &&
 		(showReactionPickerButton || showUndoReactionButton)
 );
 
@@ -597,19 +628,19 @@ useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
 		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -623,7 +654,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -648,17 +679,17 @@ useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -672,7 +703,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount


### PR DESCRIPTION
### Motivation
- ★ボタンとピッカーボタンが両方表示される（あるいは★が禁止アイコンに置き換わる）状況で、リストが表示されていないときにボタン横のリアクション数が誤って表示される不具合を修正するため。期待動作は「★側がデフォルトリアクション数、ピッカー側がそれ以外のリアクション数」を出し分けることです。 

### Description
- `MkNote.vue` と `MkNoteSub.vue` に `useSplitReactionCounts` の算出プロパティを追加し、★ボタンが実質的に2ボタンレイアウトとして扱われる条件を統一しました。 
- ピッカー用と取り消し用で別のカウントを返す `countForReactionPickerButton` と `countForUndoReactionButton` を追加し、テンプレート側の表示をそれらに切り替えました。 
- ツールチップで取得する `type` / `excludeType` / `count` の判定を `useSplitReactionCounts` に合わせて統一し、表示/取得の整合性をとりました。 
- 変更ファイル: `packages/client/src/components/MkNote.vue` と `packages/client/src/components/MkNoteSub.vue` に同等の修正を反映しました。 

### Testing
- `pnpm --filter client lint` を実行しましたが、`rome` コマンドが見つからず `node_modules` が未展開のため実行失敗しました（自環境での lint は未完了）。 
- Playwright での画面キャプチャを試みましたがローカル開発サーバーが起動しておらず `ERR_EMPTY_RESPONSE` で取得に失敗しました。 
- コード変更はコミット済みで、差分は上記 2 ファイルに適用されています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0aab9dd48326882d6672f0690901)