### PR TITLE
リアクション2ボタン表示で0件カウントが表示される不具合を修正

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -294,9 +294,9 @@
                                                        class="ph-smiley-wink ph-bold ph-lg"
                                                ></i>
                                                <i v-else class="ph-smiley ph-bold ph-lg"></i>
-                                               <template v-if="showReactionCount">
-                                                       <p class="count">{{ countForPickerButton }}</p>
-                                               </template>
+						<template v-if="showReactionPickerCount">
+							<p class="count">{{ countForReactionPickerButton }}</p>
+						</template>
                                        </button>
                                        <button
                                                v-if="showUndoReactionButton"
@@ -305,9 +305,9 @@
                                                @click="undoReact(appearNote)"
                                        >
                                                <i class="ph-minus ph-bold ph-lg" style="color: var(--accent);"></i>
-                                               <template v-if="showReactionCount && showUndoReactionButton">
-                                                       <p class="count">{{ countForPickerButton }}</p>
-                                               </template>
+						<template v-if="showUndoReactionCount && showUndoReactionButton">
+							<p class="count">{{ countForUndoReactionButton }}</p>
+						</template>
                                        </button>
 					<XQuoteButton
 						class="button"
@@ -677,6 +677,17 @@ const showStarAndPickerButtons = $computed(
 );
 
 /**
+ * ★ボタンが非表示でも、★+ピッカーの2ボタンレイアウトとして扱うかどうか
+ */
+const useSplitReactionCounts = $computed(
+	() =>
+		showStarAndPickerButtons ||
+		(isStarButtonHandlesDefault &&
+			showReactionPickerButton &&
+			showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -687,7 +698,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -699,7 +710,7 @@ const countForStarButton = $computed(() => {
  */
 const countForPickerButton = $computed(() => {
 	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -707,15 +718,50 @@ const countForPickerButton = $computed(() => {
 });
 
 /**
- * ピッカー/取り消しボタンの横にカウントを表示するかどうか
+ * リアクションピッカーボタン（+ / 禁止）に表示するカウント
  */
-const showReactionCount = $computed(
+const countForReactionPickerButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return defaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+/**
+ * 取り消しボタン（-）に表示するカウント
+ */
+const countForUndoReactionButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return nonDefaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+const canShowReactionCount = $computed(
 	() =>
 		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
 		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
-		!(showStarAndPickerButtons && isReactionListVisible) &&
-		countForPickerButton > 0 &&
-		(showReactionPickerButton || showUndoReactionButton)
+		!(useSplitReactionCounts && isReactionListVisible)
+);
+
+/**
+ * ピッカーボタンの横にカウントを表示するかどうか
+ */
+const showReactionPickerCount = $computed(
+	() =>
+		canShowReactionCount &&
+		showReactionPickerButton &&
+		countForReactionPickerButton > 0
+);
+
+/**
+ * 取り消しボタンの横にカウントを表示するかどうか
+ */
+const showUndoReactionCount = $computed(
+	() =>
+		canShowReactionCount &&
+		showUndoReactionButton &&
+		countForUndoReactionButton > 0
 );
 const favButtonReactionIsFavorite =
         defaultStore.state.favButtonReaction === "favorite";
@@ -924,19 +970,19 @@ useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
 		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -950,7 +996,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -976,17 +1022,17 @@ useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -1000,7 +1046,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount

--- a/packages/client/src/components/MkNoteSub.vue
+++ b/packages/client/src/components/MkNoteSub.vue
@@ -193,8 +193,8 @@
 							class="ph-smiley-wink ph-bold ph-lg"
 						></i>
 						<i v-else class="ph-smiley ph-bold ph-lg"></i>
-						<template v-if="showReactionCount">
-							<p class="count">{{ countForPickerButton }}</p>
+						<template v-if="showReactionPickerCount">
+							<p class="count">{{ countForReactionPickerButton }}</p>
 						</template>
 					</button>
 					<button
@@ -204,8 +204,8 @@
 						@click="undoReact(appearNote)"
 					>
 						<i class="ph-minus ph-bold ph-lg" style="color: var(--accent);"></i>
-						<template v-if="showReactionCount && showUndoReactionButton">
-							<p class="count">{{ countForPickerButton }}</p>
+						<template v-if="showUndoReactionCount && showUndoReactionButton">
+							<p class="count">{{ countForUndoReactionButton }}</p>
 						</template>
 					</button>
 					<XQuoteButton class="button" :note="appearNote" />
@@ -501,6 +501,17 @@ const showStarAndPickerButtons = $computed(
 );
 
 /**
+ * ★ボタンが非表示でも、★+ピッカーの2ボタンレイアウトとして扱うかどうか
+ */
+const useSplitReactionCounts = $computed(
+	() =>
+		showStarAndPickerButtons ||
+		(isStarButtonHandlesDefault &&
+			showReactionPickerButton &&
+			showUndoReactionButton)
+);
+
+/**
  * デフォルトリアクション以外のリアクション数
  */
 const nonDefaultReactionCount = $computed(() => {
@@ -511,7 +522,7 @@ const nonDefaultReactionCount = $computed(() => {
  * ★ボタンに表示するカウント
  */
 const countForStarButton = $computed(() => {
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return defaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -523,7 +534,7 @@ const countForStarButton = $computed(() => {
  */
 const countForPickerButton = $computed(() => {
 	// ★ボタンと併用される場合、ピッカー側は常にデフォルト以外を表示
-	if (showStarAndPickerButtons) {
+	if (useSplitReactionCounts) {
 		return nonDefaultReactionCount;
 	} else {
 		return reactionCountToShow;
@@ -533,13 +544,48 @@ const countForPickerButton = $computed(() => {
 /**
  * ピッカー/取り消しボタンの横にカウントを表示するかどうか
  */
-const showReactionCount = $computed(
+const countForReactionPickerButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return defaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+/**
+ * 取り消しボタン（-）に表示するカウント
+ */
+const countForUndoReactionButton = $computed(() => {
+	if (!showStarButtonNoEmoji && useSplitReactionCounts) {
+		return nonDefaultReactionCount;
+	}
+	return countForPickerButton;
+});
+
+const canShowReactionCount = $computed(
 	() =>
 		// ★ボタンと併用時、リアクション一覧表示中はカウント不要（リストに表示されるため）
 		// ★ボタン単独時、リアクション一覧表示中でも（他に表示場所がないので）カウント表示
-		!(showStarAndPickerButtons && isReactionListVisible) &&
-		countForPickerButton > 0 &&
-		(showReactionPickerButton || showUndoReactionButton)
+		!(useSplitReactionCounts && isReactionListVisible)
+);
+
+/**
+ * ピッカーボタンの横にカウントを表示するかどうか
+ */
+const showReactionPickerCount = $computed(
+	() =>
+		canShowReactionCount &&
+		showReactionPickerButton &&
+		countForReactionPickerButton > 0
+);
+
+/**
+ * 取り消しボタンの横にカウントを表示するかどうか
+ */
+const showUndoReactionCount = $computed(
+	() =>
+		canShowReactionCount &&
+		showUndoReactionButton &&
+		countForUndoReactionButton > 0
 );
 
 const favButtonReactionIsFavorite =
@@ -597,19 +643,19 @@ useTooltip(
 	reactionPickerButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
 		// ★ボタン併用時は、デフォルト以外のリアクション（excludeTypeで除外）
 		// ★ボタン無効なら、一覧表示中はデフォルト、非表示中は全リアクション
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -623,7 +669,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount
@@ -648,17 +694,17 @@ useTooltip(
 	undoReactionButtonRef,
 	async (showing) => {
 		// ★ボタン併用かつリアクション一覧表示中の場合、何もしない
-		if (showStarAndPickerButtons && isReactionListVisible) {
+		if (useSplitReactionCounts && isReactionListVisible) {
 			return;
 		}
 
-		const type = showStarAndPickerButtons
+		const type = useSplitReactionCounts
 			? null
 			: isReactionListVisible
 			? instance.defaultReaction
 			: null;
 
-		const excludeType = showStarAndPickerButtons
+		const excludeType = useSplitReactionCounts
 			? instance.defaultReaction
 			: null;
 
@@ -672,7 +718,7 @@ useTooltip(
 		const users = reactions.map((x) => x.user);
 		if (users.length < 1) return;
 
-		const count = showStarAndPickerButtons
+		const count = useSplitReactionCounts
 			? nonDefaultReactionCount
 			: isReactionListVisible
 			? defaultReactionCount


### PR DESCRIPTION
### Motivation
- ★ボタン系とピッカーボタン系でカウントを分離する既存ロジックを維持しつつ、片側が `0` のときに `0` が表示されてしまう不具合を修正するため。 
- ボタン単位で「表示可否」を判定し、0件のときは数字を隠すことでユーザー表示を正しくするため。

### Description
- `packages/client/src/components/MkNote.vue` と `packages/client/src/components/MkNoteSub.vue` に対して、`useSplitReactionCounts` を用いた分離ロジックを整備しテンプレートの `v-if` をボタン単位の判定に切り替えました。 
- ピッカー側/取り消し側の表示用に `countForReactionPickerButton` と `countForUndoReactionButton` を追加し、テンプレートではそれぞれ `showReactionPickerCount` / `showUndoReactionCount` を使って `> 0` のときのみ表示するようにしました。 
- 共通の表示可否フラグとして `canShowReactionCount` を導入し、リアクション一覧表示時の挙動など共通条件を集約しました。 
- ツールチップ等で参照している判定も `useSplitReactionCounts` に合わせて更新し、表示・取得の整合性を保つようにしました。 

### Testing
- `pnpm --filter client lint` を実行しましたが、`rome` コマンド未検出（`node_modules` 未展開）のため実行は失敗しました。 
- Playwright を使って `http://127.0.0.1:5173` にアクセスしスクリーンショットを取得しようとしましたが、開発サーバーが起動しておらず `ERR_EMPTY_RESPONSE` で取得に失敗しました。 
- 上記自動テストは実行済みですが、環境依存で失敗しているため CI 等での再実行をお願いします。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0aab9dd48326882d6672f0690901)