### PR TITLE
MkPostForm のアップロード待機ループを改善し状態判定を分離

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -442,6 +442,11 @@ import { deepClone } from "@/scripts/clone";
 import XDraft from "@/components/MkDraftDialog.vue";
 import XCheatSheet from "@/components/MkCheatSheetDialog.vue";
 import { preprocess } from "@/scripts/preprocess";
+import {
+	FILE_SELECT_IDLE_WAIT_MS,
+	evaluateUploadWaitState,
+	sleepMs,
+} from "@/components/MkPostForm/uploadWaitState";
 import { id } from "date-fns/locale";
 
 const modal = inject("modal");
@@ -2351,21 +2356,33 @@ async function waitForFileSelectingToBeFalse(backupDraftData) {
 		while (filePromises.length > 0) {
 			await Promise.allSettled([...filePromises]);
 
-			if (filePromises.length === 0) break;
+			const waitState = evaluateUploadWaitState({
+				pendingPromiseCount: filePromises.length,
+				activeUploadCount: uploads.value.length,
+				now: Date.now(),
+				noActiveUploadsSince,
+				staleUploadWaitMs,
+			});
 
-			if (uploads.value.length > 0) {
-				noActiveUploadsSince = null;
-				continue;
-			}
+			noActiveUploadsSince = waitState.nextNoActiveUploadsSince;
 
-			if (noActiveUploadsSince === null) {
-				noActiveUploadsSince = Date.now();
-				continue;
-			}
-
-			if (Date.now() - noActiveUploadsSince >= staleUploadWaitMs) {
+			if (waitState.shouldForceResetPromises) {
+				// uploads には進行中タスクが存在しないのに filePromises が残り続けるケースを
+				// ハングとみなし、投稿処理を前に進めるために待機対象を明示的にクリアする。
+				console.debug(
+					"[MkPostForm] Reset stale upload wait promises to avoid infinite loop",
+					{
+						pendingPromiseCount: filePromises.length,
+						activeUploadCount: uploads.value.length,
+						staleUploadWaitMs,
+					},
+				);
 				filePromises = [];
 				break;
+			}
+
+			if (waitState.shouldWaitBeforeRetry) {
+				await sleepMs(FILE_SELECT_IDLE_WAIT_MS);
 			}
 		}
 	} catch (err) {

--- a/packages/client/src/components/MkPostForm/uploadWaitState.test.ts
+++ b/packages/client/src/components/MkPostForm/uploadWaitState.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateUploadWaitState } from "./uploadWaitState";
+
+test("pendingPromiseCount が 0 のとき待機を継続しない", () => {
+	const state = evaluateUploadWaitState({
+		pendingPromiseCount: 0,
+		activeUploadCount: 0,
+		now: 100,
+		noActiveUploadsSince: 10,
+		staleUploadWaitMs: 1000,
+	});
+
+	assert.equal(state.shouldWaitBeforeRetry, false);
+	assert.equal(state.shouldForceResetPromises, false);
+	assert.equal(state.nextNoActiveUploadsSince, null);
+});
+
+test("upload が進行中なら stale 判定をリセットする", () => {
+	const state = evaluateUploadWaitState({
+		pendingPromiseCount: 2,
+		activeUploadCount: 1,
+		now: 100,
+		noActiveUploadsSince: 10,
+		staleUploadWaitMs: 1000,
+	});
+
+	assert.equal(state.shouldWaitBeforeRetry, false);
+	assert.equal(state.shouldForceResetPromises, false);
+	assert.equal(state.nextNoActiveUploadsSince, null);
+});
+
+test("upload が止まった直後は時刻を記録して短時間 wait を返す", () => {
+	const state = evaluateUploadWaitState({
+		pendingPromiseCount: 2,
+		activeUploadCount: 0,
+		now: 150,
+		noActiveUploadsSince: null,
+		staleUploadWaitMs: 1000,
+	});
+
+	assert.equal(state.shouldWaitBeforeRetry, true);
+	assert.equal(state.shouldForceResetPromises, false);
+	assert.equal(state.nextNoActiveUploadsSince, 150);
+});
+
+test("staleUploadWaitMs を超過したら promise リセットを返す", () => {
+	const state = evaluateUploadWaitState({
+		pendingPromiseCount: 2,
+		activeUploadCount: 0,
+		now: 1201,
+		noActiveUploadsSince: 200,
+		staleUploadWaitMs: 1000,
+	});
+
+	assert.equal(state.shouldWaitBeforeRetry, false);
+	assert.equal(state.shouldForceResetPromises, true);
+	assert.equal(state.nextNoActiveUploadsSince, 200);
+});

--- a/packages/client/src/components/MkPostForm/uploadWaitState.ts
+++ b/packages/client/src/components/MkPostForm/uploadWaitState.ts
@@ -1,0 +1,67 @@
+export const FILE_SELECT_IDLE_WAIT_MS = 80;
+
+export type UploadWaitStateInput = {
+	pendingPromiseCount: number;
+	activeUploadCount: number;
+	now: number;
+	noActiveUploadsSince: number | null;
+	staleUploadWaitMs: number;
+};
+
+export type UploadWaitStateResult = {
+	nextNoActiveUploadsSince: number | null;
+	shouldForceResetPromises: boolean;
+	shouldWaitBeforeRetry: boolean;
+};
+
+export function evaluateUploadWaitState({
+	pendingPromiseCount,
+	activeUploadCount,
+	now,
+	noActiveUploadsSince,
+	staleUploadWaitMs,
+}: UploadWaitStateInput): UploadWaitStateResult {
+	if (pendingPromiseCount === 0) {
+		return {
+			nextNoActiveUploadsSince: null,
+			shouldForceResetPromises: false,
+			shouldWaitBeforeRetry: false,
+		};
+	}
+
+	if (activeUploadCount > 0) {
+		return {
+			nextNoActiveUploadsSince: null,
+			shouldForceResetPromises: false,
+			shouldWaitBeforeRetry: false,
+		};
+	}
+
+	if (noActiveUploadsSince === null) {
+		return {
+			nextNoActiveUploadsSince: now,
+			shouldForceResetPromises: false,
+			shouldWaitBeforeRetry: true,
+		};
+	}
+
+	if (now - noActiveUploadsSince >= staleUploadWaitMs) {
+		return {
+			nextNoActiveUploadsSince: noActiveUploadsSince,
+			shouldForceResetPromises: true,
+			shouldWaitBeforeRetry: false,
+		};
+	}
+
+	return {
+		nextNoActiveUploadsSince: noActiveUploadsSince,
+		shouldForceResetPromises: false,
+		shouldWaitBeforeRetry: true,
+	};
+}
+
+export function sleepMs(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}


### PR DESCRIPTION
### Motivation
- 投稿フォームの `waitForFileSelectingToBeFalse` がファイル選択中に高頻度でループを回し続ける問題を抑制し、アップロードの停滞時に無駄な反復を減らす目的で改良しました。
- `filePromises` と `uploads.value` の矛盾がループを長時間回し続ける原因になり得るため、終了条件と判定ロジックを一本化して振る舞いを明確化する必要がありました。

### Description
- `packages/client/src/components/MkPostForm.vue` の `waitForFileSelectingToBeFalse` を変更し、状態変化がない場合に短い待機（`FILE_SELECT_IDLE_WAIT_MS`、既定 80ms）を挟んでループ頻度を抑制するようにしました。
- 待機判定ロジックを小さな純粋関数 `evaluateUploadWaitState` に切り出し、`packages/client/src/components/MkPostForm/uploadWaitState.ts` を新規追加して `filePromises` を終了条件の一次ソースとしつつ `uploads.value` を進行中判定に利用する形に一本化しました。
- `staleUploadWaitMs` 到達時に `filePromises = []` で抜ける分岐に日本語の意図説明コメントと開発用ログ（`console.debug`）を追加して動作の意図を明示しました。
- 判定ロジックをユニットテストしやすくするため `sleepMs` と判定関数を分離し、`packages/client/src/components/MkPostForm/uploadWaitState.test.ts` を追加して主要分岐を検証するテストを実装しました。

### Testing
- `pnpm dlx tsx --test packages/client/src/components/MkPostForm/uploadWaitState.test.ts` を実行し、追加したユニットテスト 4 件がすべてパスしました（4 passed）。
- `pnpm --filter client run lint` はローカル `node_modules` が未導入のため `rome` が見つからず実行できないことを確認しました（依存未解決による実行失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c5818c104832681752707b564bb8e)