### PR TITLE
タイムライン初回表示の遅延改善とObserver閾値の副作用抑制

### DIFF
--- a/packages/client/src/components/MkPagination.vue
+++ b/packages/client/src/components/MkPagination.vue
@@ -255,11 +255,23 @@ const BACKGROUND_PAUSE_WAIT_SEC = 10;
 // https://qiita.com/mkataigi/items/0154aefd2223ce23398e
 let scrollObserver = $ref<IntersectionObserver>();
 
+const getObserverThreshold = (): number => {
+	const root = unref(scrollableElement);
+	const rootHeight =
+		root && root !== document.body
+			? root.clientHeight
+			: window.innerHeight;
+
+	return Math.max(
+		Math.min(0.02 / (Math.max(rootHeight, 1) / window.innerHeight), 0.01),
+		0.001
+	);
+};
+
 watch(
 	[
 		() => props.pagination.reversed,
 		$$(scrollableElement),
-		$$(scrollableElement?.scrollHeight),
 	],
 	() => {
 		if (scrollObserver) scrollObserver.disconnect();
@@ -273,13 +285,7 @@ watch(
 				rootMargin: props.pagination.reversed
 					? "-100% 0px 100% 0px"
 					: "100% 0px -100% 0px",
-				threshold: Math.min(
-					0.02 /
-						((unref(scrollableElement)?.scrollHeight ??
-							window.innerHeight) /
-							window.innerHeight),
-					0.01
-				),
+				threshold: getObserverThreshold(),
 			}
 		);
 	},


### PR DESCRIPTION
### Motivation
- 初回タイムライン描画時に `IntersectionObserver` が描画中の高さ変化に追従して頻繁に再生成されることで発生する遅延を軽減するための変更です。 
- 固定閾値 `0.01` のままでは感度差や副作用が出る懸念があるため、感度劣化を最小化しつつ副作用を抑えたい意図があります。

### Description
- `getObserverThreshold()` を追加し、閾値を `root.clientHeight`（または `window.innerHeight`）に基づいて計算し `0.001`〜`0.01` の範囲でクランプするようにしました。 
- `watch` の依存から `scrollableElement?.scrollHeight` を除外し、`IntersectionObserver` の再生成トリガーを `props.pagination.reversed` と `scrollableElement` の変更に限定しました。 
- `IntersectionObserver` の `threshold` を固定値から `getObserverThreshold()` へ差し替え、過剰な再生成を防止しつつ判定感度の極端な劣化を回避しています。 
- 変更は `packages/client/src/components/MkPagination.vue` のページネーション内部ロジックに限定され、API や取得順など外部仕様には影響しません。

### Testing
- 自動化されたリンター実行 `pnpm --filter client run lint` を試行しましたが、開発環境に `rome` 等の依存が導入されていないため実行に失敗しました（自動 lint は未通過）。
- そのほかの自動テストは実行しておらず、現状の自動化テストでは変更の実行確認は行えていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d18224e5c8326870d75dd235fb3d2)