### PR TITLE
backend: GitHub/Twitter OAuth セッションをTTL化しコールバックのJSON復元失敗を安全に扱う

### DIFF
--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -26,6 +26,40 @@ function compareOrigin(ctx: Koa.BaseContext): boolean {
 	return normalizeUrl(referer) === normalizeUrl(config.url);
 }
 
+function getRedisValue(key: string): Promise<string | null> {
+	return new Promise((resolve, reject) => {
+		redisClient.get(key, (err, value) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve(value);
+		});
+	});
+}
+
+function deleteRedisKey(key: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		redisClient.del(key, (err) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve();
+		});
+	});
+}
+
+function parseJsonSafely<T>(value: string): T | null {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return null;
+	}
+}
+
 // Init router
 const router = new Router();
 
@@ -105,7 +139,7 @@ router.get("/connect/github", async (ctx) => {
 		state: uuid(),
 	};
 
-	redisClient.set(userToken, JSON.stringify(params));
+	redisClient.set(userToken, JSON.stringify(params), "EX", 600);
 
 	const oauth2 = await getOath2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
@@ -126,7 +160,7 @@ router.get("/signin/github", async (ctx) => {
 		httpOnly: true,
 	});
 
-	redisClient.set(sessid, JSON.stringify(params));
+	redisClient.set(sessid, JSON.stringify(params), "EX", 600);
 
 	const oauth2 = await getOath2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
@@ -152,16 +186,31 @@ router.get("/gh/cb", async (ctx) => {
 			return;
 		}
 
-		const { redirect_uri, state } = await new Promise<any>((res, rej) => {
-			redisClient.get(sessid, async (_, state) => {
-				res(JSON.parse(state));
-			});
-		});
+		const savedState = await getRedisValue(sessid);
+
+		if (!savedState) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const savedStateObject = parseJsonSafely<{
+			redirect_uri: string;
+			state: string;
+		}>(savedState);
+
+		if (!savedStateObject) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const { redirect_uri, state } = savedStateObject;
 
 		if (ctx.query.state !== state) {
 			ctx.throw(400, "invalid session");
 			return;
 		}
+
+		await deleteRedisKey(sessid);
 
 		const { accessToken } = await new Promise<any>((res, rej) =>
 			oauth2!.getOAuthAccessToken(
@@ -220,16 +269,31 @@ router.get("/gh/cb", async (ctx) => {
 			return;
 		}
 
-		const { redirect_uri, state } = await new Promise<any>((res, rej) => {
-			redisClient.get(userToken, async (_, state) => {
-				res(JSON.parse(state));
-			});
-		});
+		const savedState = await getRedisValue(userToken);
+
+		if (!savedState) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const savedStateObject = parseJsonSafely<{
+			redirect_uri: string;
+			state: string;
+		}>(savedState);
+
+		if (!savedStateObject) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const { redirect_uri, state } = savedStateObject;
 
 		if (ctx.query.state !== state) {
 			ctx.throw(400, "invalid session");
 			return;
 		}
+
+		await deleteRedisKey(userToken);
 
 		const { accessToken } = await new Promise<any>((res, rej) =>
 			oauth2!.getOAuthAccessToken(

--- a/packages/backend/src/server/api/service/twitter.ts
+++ b/packages/backend/src/server/api/service/twitter.ts
@@ -32,6 +32,40 @@ function compareOrigin(ctx: Koa.BaseContext): boolean {
 // Init router
 const router = new Router();
 
+function getRedisValue(key: string): Promise<string | null> {
+	return new Promise((resolve, reject) => {
+		redisClient.get(key, (err, value) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve(value);
+		});
+	});
+}
+
+function deleteRedisKey(key: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		redisClient.del(key, (err) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve();
+		});
+	});
+}
+
+function parseJsonSafely<T>(value: string): T | null {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return null;
+	}
+}
+
 router.get("/disconnect/twitter", async (ctx) => {
 	if (!compareOrigin(ctx)) {
 		ctx.throw(400, "invalid origin");
@@ -102,7 +136,7 @@ router.get("/connect/twitter", async (ctx) => {
 
 	const twAuth = await getTwAuth();
 	const twCtx = await twAuth!.begin();
-	redisClient.set(userToken, JSON.stringify(twCtx));
+	redisClient.set(userToken, JSON.stringify(twCtx), "EX", 600);
 	ctx.redirect(twCtx.url);
 });
 
@@ -112,7 +146,7 @@ router.get("/signin/twitter", async (ctx) => {
 
 	const sessid = uuid();
 
-	redisClient.set(sessid, JSON.stringify(twCtx));
+	redisClient.set(sessid, JSON.stringify(twCtx), "EX", 600);
 
 	ctx.cookies.set("signin_with_twitter_sid", sessid, {
 		path: "/",
@@ -136,13 +170,12 @@ router.get("/tw/cb", async (ctx) => {
 			return;
 		}
 
-		const get = new Promise<any>((res, rej) => {
-			redisClient.get(sessid, async (_, twCtx) => {
-				res(twCtx);
-			});
-		});
+		const twCtx = await getRedisValue(sessid);
 
-		const twCtx = await get;
+		if (!twCtx) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
 
 		const verifier = ctx.query.oauth_verifier;
 		if (!verifier || typeof verifier !== "string") {
@@ -150,7 +183,16 @@ router.get("/tw/cb", async (ctx) => {
 			return;
 		}
 
-		const result = await twAuth!.done(JSON.parse(twCtx), verifier);
+		await deleteRedisKey(sessid);
+
+		const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
+
+		if (!parsedTwCtx) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const result = await twAuth!.done(parsedTwCtx, verifier);
 
 		const link = await UserProfiles.createQueryBuilder()
 			.where("\"integrations\"->'twitter'->>'userId' = :id", {
@@ -180,15 +222,23 @@ router.get("/tw/cb", async (ctx) => {
 			return;
 		}
 
-		const get = new Promise<any>((res, rej) => {
-			redisClient.get(userToken, async (_, twCtx) => {
-				res(twCtx);
-			});
-		});
+		const twCtx = await getRedisValue(userToken);
 
-		const twCtx = await get;
+		if (!twCtx) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
 
-		const result = await twAuth!.done(JSON.parse(twCtx), verifier);
+		await deleteRedisKey(userToken);
+
+		const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
+
+		if (!parsedTwCtx) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const result = await twAuth!.done(parsedTwCtx, verifier);
 
 		const user = await Users.findOneByOrFail({
 			host: IsNull(),


### PR DESCRIPTION
### Motivation
- Redis に保存した OAuth 一時セッション情報が再利用される／破損した JSON によって 500 系エラーが発生する問題を防止するためです。 
- コールバック処理で未存在・破損データを明示的に `invalid session` として扱い、認証フローの堅牢性を高める必要がありました。

### Description
- `packages/backend/src/server/api/service/github.ts` と `packages/backend/src/server/api/service/twitter.ts` に共通ヘルパーとして `getRedisValue`、`deleteRedisKey`、`parseJsonSafely` を追加しました。 
- OAuth 開始処理（`/connect/*` と `/signin/*`）で `redisClient.set(...)` に有効期限を付与して `EX 600` とし、一時セッションを期限付きにしました（GitHub/Twitter 両方）。
- コールバック（`/gh/cb` と `/tw/cb`）では直接 `JSON.parse` せずに `getRedisValue` で値を取得して存在チェックを行い、`parseJsonSafely` で復元できない場合は `ctx.throw(400, "invalid session")` として処理するように変更しました。 
- コールバック成功時にはキーを削除して（`deleteRedisKey`）使い捨て化し、再利用を防止するようにしました。

### Testing
- `pnpm --filter backend run lint` を実行しましたが、作業環境に `node_modules` が無く `rome` が見つからないため `ENOENT` で失敗しました（ローカル依存をインストールすれば lint は実行可能です）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d939cc5048326a799d8be2eb10813)