### PR TITLE
backend: user-cache を L1/L2 構成に変更（短TTL + Redis read-through）

### DIFF
--- a/packages/backend/src/remote/activitypub/db-resolver.ts
+++ b/packages/backend/src/remote/activitypub/db-resolver.ts
@@ -15,7 +15,11 @@ import {
 	MessagingMessages,
 } from "@/models/index.js";
 import { Cache } from "@/misc/cache.js";
-import { uriPersonCache, userByIdCache } from "@/services/user-cache.js";
+import {
+	fetchUriPersonCache,
+	fetchUserByIdCache,
+	fetchUserByIdCacheMaybe,
+} from "@/services/user-cache.js";
 import type { IObject } from "./type.js";
 import { getApId } from "./type.js";
 import { resolvePerson, updatePerson } from "./models/person.js";
@@ -109,14 +113,14 @@ export default class DbResolver {
 			if (parsed.type !== "users") return null;
 
 			return (
-				(await userByIdCache.fetchMaybe(parsed.id, () =>
+				(await fetchUserByIdCacheMaybe(parsed.id, () =>
 					Users.findOneBy({
 						id: parsed.id,
 					}).then((x) => x ?? undefined),
 				)) ?? null
 			);
 		} else {
-			return await uriPersonCache.fetch(parsed.uri, () =>
+			return await fetchUriPersonCache(parsed.uri, () =>
 				Users.findOneBy({
 					uri: parsed.uri,
 				}),
@@ -148,7 +152,7 @@ export default class DbResolver {
 		if (key == null) return null;
 
 		return {
-			user: (await userByIdCache.fetch(key.userId, () =>
+			user: (await fetchUserByIdCache(key.userId, () =>
 				Users.findOneByOrFail({ id: key.userId }),
 			)) as CacheableRemoteUser,
 			key,

--- a/packages/backend/src/server/api/authenticate.ts
+++ b/packages/backend/src/server/api/authenticate.ts
@@ -5,8 +5,8 @@ import type { AccessToken } from "@/models/entities/access-token.js";
 import { Cache } from "@/misc/cache.js";
 import type { App } from "@/models/entities/app.js";
 import {
-	localUserByIdCache,
-	localUserByNativeTokenCache,
+	fetchLocalUserByIdCache,
+	fetchLocalUserByNativeTokenCache,
 } from "@/services/user-cache.js";
 
 const appCache = new Cache<App>(Infinity);
@@ -46,7 +46,7 @@ export default async (
 	}
 
 	if (isNativeToken(token)) {
-		const user = await localUserByNativeTokenCache.fetch(
+		const user = await fetchLocalUserByNativeTokenCache(
 			token,
 			() => Users.findOneBy({ token }) as Promise<ILocalUser | null>,
 		);
@@ -76,7 +76,7 @@ export default async (
 			lastUsedAt: new Date(),
 		});
 
-		const user = await localUserByIdCache.fetch(
+		const user = await fetchLocalUserByIdCache(
 			accessToken.userId,
 			() =>
 				Users.findOneBy({

--- a/packages/backend/src/services/user-cache.ts
+++ b/packages/backend/src/services/user-cache.ts
@@ -3,17 +3,143 @@ import type {
 	CacheableUser,
 	ILocalUser,
 } from "@/models/entities/user.js";
-import { User } from "@/models/entities/user.js";
 import { Users } from "@/models/index.js";
 import { Cache } from "@/misc/cache.js";
-import { subscriber } from "@/db/redis.js";
+import { redisClient, subscriber } from "@/db/redis.js";
 
-export const userByIdCache = new Cache<CacheableUser>(Infinity);
+const LOCAL_MAP_TTL_MS = 30 * 1000;
+const USER_CACHE_REDIS_TTL_SEC = 60;
+
+const USER_BY_ID_REDIS_KEY_PREFIX = "user-cache:user-by-id";
+const LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX =
+	"user-cache:local-user-by-native-token";
+const LOCAL_USER_BY_ID_REDIS_KEY_PREFIX = "user-cache:local-user-by-id";
+const URI_PERSON_REDIS_KEY_PREFIX = "user-cache:uri-person";
+
+function createRedisKey(prefix: string, key: string | null): string {
+	return `${prefix}:${key ?? "__null__"}`;
+}
+
+async function cacheSetWithRedis<T>(
+	cache: Cache<T>,
+	redisKeyPrefix: string,
+	key: string | null,
+	value: T,
+): Promise<void> {
+	cache.set(key, value);
+	await redisClient.set(
+		createRedisKey(redisKeyPrefix, key),
+		JSON.stringify(value),
+		"EX",
+		USER_CACHE_REDIS_TTL_SEC,
+	);
+}
+
+async function cacheDeleteWithRedis(
+	cache: Cache<unknown>,
+	redisKeyPrefix: string,
+	key: string | null,
+): Promise<void> {
+	cache.delete(key);
+	await redisClient.del(createRedisKey(redisKeyPrefix, key));
+}
+
+async function fetchThroughRedis<T>(
+	cache: Cache<T>,
+	redisKeyPrefix: string,
+	key: string | null,
+	fetcher: () => Promise<T | undefined>,
+	validator?: (cachedValue: T) => boolean,
+): Promise<T | undefined> {
+	const localCached = cache.get(key);
+	if (localCached !== undefined && (validator == null || validator(localCached))) {
+		return localCached;
+	}
+
+	const redisKey = createRedisKey(redisKeyPrefix, key);
+	const redisCached = await redisClient.get(redisKey);
+	if (redisCached != null) {
+		const parsed = JSON.parse(redisCached) as T;
+		if (validator == null || validator(parsed)) {
+			cache.set(key, parsed);
+			return parsed;
+		}
+	}
+
+	const fetched = await fetcher();
+	if (fetched !== undefined) {
+		await cacheSetWithRedis(cache, redisKeyPrefix, key, fetched);
+	}
+
+	return fetched;
+}
+
+export const userByIdCache = new Cache<CacheableUser>(LOCAL_MAP_TTL_MS);
 export const localUserByNativeTokenCache = new Cache<CacheableLocalUser | null>(
-	Infinity,
+	LOCAL_MAP_TTL_MS,
 );
-export const localUserByIdCache = new Cache<CacheableLocalUser>(Infinity);
-export const uriPersonCache = new Cache<CacheableUser | null>(Infinity);
+export const localUserByIdCache = new Cache<CacheableLocalUser>(LOCAL_MAP_TTL_MS);
+export const uriPersonCache = new Cache<CacheableUser | null>(LOCAL_MAP_TTL_MS);
+
+export async function fetchUserByIdCacheMaybe(
+	id: string,
+	fetcher: () => Promise<CacheableUser | undefined>,
+): Promise<CacheableUser | undefined> {
+	return await fetchThroughRedis(
+		userByIdCache,
+		USER_BY_ID_REDIS_KEY_PREFIX,
+		id,
+		fetcher,
+	);
+}
+
+export async function fetchUserByIdCache(
+	id: string,
+	fetcher: () => Promise<CacheableUser>,
+): Promise<CacheableUser> {
+	return (await fetchThroughRedis(
+		userByIdCache,
+		USER_BY_ID_REDIS_KEY_PREFIX,
+		id,
+		fetcher,
+	)) as CacheableUser;
+}
+
+export async function fetchLocalUserByNativeTokenCache(
+	token: string,
+	fetcher: () => Promise<CacheableLocalUser | null>,
+): Promise<CacheableLocalUser | null> {
+	return (await fetchThroughRedis(
+		localUserByNativeTokenCache,
+		LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
+		token,
+		fetcher,
+	)) as CacheableLocalUser | null;
+}
+
+export async function fetchLocalUserByIdCache(
+	id: string,
+	fetcher: () => Promise<CacheableLocalUser>,
+): Promise<CacheableLocalUser> {
+	return (await fetchThroughRedis(
+		localUserByIdCache,
+		LOCAL_USER_BY_ID_REDIS_KEY_PREFIX,
+		id,
+		fetcher,
+	)) as CacheableLocalUser;
+}
+
+export async function fetchUriPersonCache(
+	uri: string,
+	fetcher: () => Promise<CacheableUser | null>,
+): Promise<CacheableUser | null> {
+	return (await fetchThroughRedis(
+		uriPersonCache,
+		URI_PERSON_REDIS_KEY_PREFIX,
+		uri,
+		fetcher,
+	)) as CacheableUser | null;
+}
 
 subscriber.on("message", async (_, data) => {
 	const obj = JSON.parse(data);
@@ -22,13 +148,17 @@ subscriber.on("message", async (_, data) => {
 		const { type, body } = obj.message;
 		switch (type) {
 			case "localUserUpdated": {
-				userByIdCache.delete(body.id);
-				localUserByIdCache.delete(body.id);
-				localUserByNativeTokenCache.cache.forEach((v, k) => {
+				await cacheDeleteWithRedis(userByIdCache, USER_BY_ID_REDIS_KEY_PREFIX, body.id);
+				await cacheDeleteWithRedis(localUserByIdCache, LOCAL_USER_BY_ID_REDIS_KEY_PREFIX, body.id);
+				for (const [k, v] of localUserByNativeTokenCache.cache.entries()) {
 					if (v.value?.id === body.id) {
-						localUserByNativeTokenCache.delete(k);
+						await cacheDeleteWithRedis(
+							localUserByNativeTokenCache,
+							LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
+							k,
+						);
 					}
-				});
+				}
 				break;
 			}
 			case "userChangeSuspendedState":
@@ -36,15 +166,25 @@ subscriber.on("message", async (_, data) => {
 			case "userChangeModeratorState":
 			case "remoteUserUpdated": {
 				const user = await Users.findOneByOrFail({ id: body.id });
-				userByIdCache.set(user.id, user);
+				await cacheSetWithRedis(userByIdCache, USER_BY_ID_REDIS_KEY_PREFIX, user.id, user);
 				for (const [k, v] of uriPersonCache.cache.entries()) {
 					if (v.value?.id === user.id) {
-						uriPersonCache.set(k, user);
+						await cacheSetWithRedis(uriPersonCache, URI_PERSON_REDIS_KEY_PREFIX, k, user);
 					}
 				}
 				if (Users.isLocalUser(user)) {
-					localUserByNativeTokenCache.set(user.token, user);
-					localUserByIdCache.set(user.id, user);
+					await cacheSetWithRedis(
+						localUserByNativeTokenCache,
+						LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
+						user.token,
+						user,
+					);
+					await cacheSetWithRedis(
+						localUserByIdCache,
+						LOCAL_USER_BY_ID_REDIS_KEY_PREFIX,
+						user.id,
+						user,
+					);
 				}
 				break;
 			}
@@ -52,8 +192,17 @@ subscriber.on("message", async (_, data) => {
 				const user = (await Users.findOneByOrFail({
 					id: body.id,
 				})) as ILocalUser;
-				localUserByNativeTokenCache.delete(body.oldToken);
-				localUserByNativeTokenCache.set(body.newToken, user);
+				await cacheDeleteWithRedis(
+					localUserByNativeTokenCache,
+					LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
+					body.oldToken,
+				);
+				await cacheSetWithRedis(
+					localUserByNativeTokenCache,
+					LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
+					body.newToken,
+					user,
+				);
 				break;
 			}
 			default:


### PR DESCRIPTION
### Motivation
- `packages/backend/src/services/user-cache.ts` で `Cache(...Infinity)` を使っていたユーザー系キャッシュを列挙し、ローカル無期限キャッシュによる stale データやメモリ滞留を防ぐため TTL 短縮と L2 Redis の導入が必要だった。
- 読み取り経路を `GET -> miss なら DB -> SET EX` の read-through にしてキャッシュヒット率と一貫性を改善したかった。
- 既存の `subscriber.on("message")` による無効化イベント発生時に Redis 側のキーも削除/更新して L1/L2 を同期する必要があった。

### Description
- 対象の 4 つのキャッシュ（`userByIdCache`, `localUserByNativeTokenCache`, `localUserByIdCache`, `uriPersonCache`）の L1 を `Infinity` から `LOCAL_MAP_TTL_MS = 30 * 1000`（30 秒）へ短縮した。 
- L2 Redis を追加して `fetchThroughRedis` を実装し、`L1 Map GET -> miss 時 Redis GET -> miss 時 DB fetcher -> Redis SET EX + L1 SET` の read-through を提供する専用関数群（`fetchUserByIdCache`, `fetchUserByIdCacheMaybe`, `fetchLocalUserByNativeTokenCache`, `fetchLocalUserByIdCache`, `fetchUriPersonCache`）を追加した。 
- Redis 用のキー prefix（例: `user-cache:user-by-id` 等）と Redis TTL を `USER_CACHE_REDIS_TTL_SEC = 60`（60 秒）で導入し、`cacheSetWithRedis` / `cacheDeleteWithRedis` を追加して L1/L2 双方を更新/削除するようにした。 
- `subscriber.on("message")` の既存イベント処理（`localUserUpdated`, `remoteUserUpdated`, `userTokenRegenerated` 等）を更新して、ローカル Map の削除/更新に加え Redis の `DEL` / `SET EX` を実行するように変更し、呼び出し側の参照は `authenticate.ts` と `db-resolver.ts` で新しい read-through 関数を使うよう差し替えた。 

### Testing
- 自動テストとして `pnpm --filter backend run lint` を実行したが、環境に `node_modules` が存在しないため `rome` が見つからず `ENOENT` で失敗した（実行不可）。
- 他の自動テストや CI 実行は行っておらず、動作確認はローカル静的確認と差分レビューに依存している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d93a4bd9c8326881b64da4304f75d)