### PR TITLE
リアクション正規化のRedisキャッシュ導入と無効化フロー追加

### DIFF
--- a/packages/backend/src/misc/reaction-normalize-cache.ts
+++ b/packages/backend/src/misc/reaction-normalize-cache.ts
@@ -1,0 +1,71 @@
+import { redisClient } from "@/db/redis.js";
+
+const REACTION_NORMALIZE_CACHE_VERSION_KEY = "reaction-normalize:version";
+const REACTION_NORMALIZE_CACHE_TTL_SEC = 60;
+
+function encodeCachePart(value: string): string {
+	return encodeURIComponent(value);
+}
+
+export function buildReactionNormalizeCacheKey(
+	version: number,
+	userHost: string | null | undefined,
+	noteUserHost: string | null | undefined,
+	rawReaction: string | null | undefined,
+): string {
+	return [
+		"reaction-normalize",
+		`v${version}`,
+		encodeCachePart(userHost ?? "_local"),
+		encodeCachePart(noteUserHost ?? "_local"),
+		encodeCachePart(rawReaction ?? "_empty"),
+	].join(":");
+}
+
+export async function getReactionNormalizeCacheVersion(): Promise<number> {
+	const cachedVersion = await redisClient.get(REACTION_NORMALIZE_CACHE_VERSION_KEY);
+	const version = Number(cachedVersion);
+	if (Number.isInteger(version) && version > 0) {
+		return version;
+	}
+
+	await redisClient.set(REACTION_NORMALIZE_CACHE_VERSION_KEY, "1");
+	return 1;
+}
+
+export async function getCachedNormalizedReaction(
+	userHost: string | null | undefined,
+	noteUserHost: string | null | undefined,
+	rawReaction: string | null | undefined,
+): Promise<string | null> {
+	const version = await getReactionNormalizeCacheVersion();
+	const cacheKey = buildReactionNormalizeCacheKey(
+		version,
+		userHost,
+		noteUserHost,
+		rawReaction,
+	);
+
+	return await redisClient.get(cacheKey);
+}
+
+export async function setCachedNormalizedReaction(
+	userHost: string | null | undefined,
+	noteUserHost: string | null | undefined,
+	rawReaction: string | null | undefined,
+	normalizedReaction: string,
+): Promise<void> {
+	const version = await getReactionNormalizeCacheVersion();
+	const cacheKey = buildReactionNormalizeCacheKey(
+		version,
+		userHost,
+		noteUserHost,
+		rawReaction,
+	);
+
+	await redisClient.set(cacheKey, normalizedReaction, "EX", REACTION_NORMALIZE_CACHE_TTL_SEC);
+}
+
+export async function bumpReactionNormalizeCacheVersion(): Promise<void> {
+	await redisClient.incr(REACTION_NORMALIZE_CACHE_VERSION_KEY);
+}

--- a/packages/backend/src/server/api/endpoints/admin/emoji/add-aliases-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/add-aliases-bulk.ts
@@ -4,6 +4,7 @@ import { In } from "typeorm";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -55,4 +56,5 @@ export default define(meta, paramDef, async (ps) => {
         });
 
         await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/emoji/add.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/add.ts
@@ -7,6 +7,7 @@ import { ApiError } from "../../../error.js";
 import rndstr from "rndstr";
 import { publishBroadcastStream } from "@/services/stream.js";
 import { db } from "@/db/postgre.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -113,6 +114,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	}).then((x) => Emojis.findOneByOrFail(x.identifiers[0]));
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 
 	publishBroadcastStream("emojiAdded", {
 		emoji: await Emojis.pack(emoji.id),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/copy.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/copy.ts
@@ -7,6 +7,7 @@ import type { DriveFile } from "@/models/entities/drive-file.js";
 import { uploadFromUrl } from "@/services/drive/upload-from-url.js";
 import { publishBroadcastStream } from "@/services/stream.js";
 import { db } from "@/db/postgre.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -111,6 +112,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	}).then((x) => Emojis.findOneByOrFail(x.identifiers[0]));
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 
 	publishBroadcastStream("emojiAdded", {
 		emoji: await Emojis.pack(copied.id),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/delete-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/delete-bulk.ts
@@ -5,6 +5,7 @@ import { insertModerationLog } from "@/services/insert-moderation-log.js";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -43,6 +44,7 @@ export default define(meta, paramDef, async (ps, me) => {
         );
 
         await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 
         publishBroadcastStream("emojiDeleted", {
                 emojis: await Emojis.packMany(emojis),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/delete.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/delete.ts
@@ -4,6 +4,7 @@ import { insertModerationLog } from "@/services/insert-moderation-log.js";
 import { ApiError } from "../../../error.js";
 import { publishBroadcastStream } from "@/services/stream.js";
 import { db } from "@/db/postgre.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -43,6 +44,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	await Emojis.delete(emoji.id);
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 
 	insertModerationLog(me, "deleteEmoji", {
 		emoji: emoji,

--- a/packages/backend/src/server/api/endpoints/admin/emoji/remove-aliases-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/remove-aliases-bulk.ts
@@ -4,6 +4,7 @@ import { In } from "typeorm";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -55,4 +56,5 @@ export default define(meta, paramDef, async (ps) => {
         });
 
         await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/emoji/set-aliases-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/set-aliases-bulk.ts
@@ -4,6 +4,7 @@ import { In } from "typeorm";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -52,4 +53,5 @@ export default define(meta, paramDef, async (ps) => {
 	});
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/emoji/set-category-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/set-category-bulk.ts
@@ -4,6 +4,7 @@ import { In } from "typeorm";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -51,4 +52,5 @@ export default define(meta, paramDef, async (ps) => {
 	});
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/emoji/set-license-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/set-license-bulk.ts
@@ -4,6 +4,7 @@ import { In } from "typeorm";
 import { ApiError } from "../../../error.js";
 import { db } from "@/db/postgre.js";
 import { publishBroadcastStream } from "@/services/stream.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -68,4 +69,5 @@ export default define(meta, paramDef, async (ps) => {
 	});
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -4,6 +4,7 @@ import { Emojis } from "@/models/index.js";
 import { ApiError } from "../../../error.js";
 import { publishBroadcastStream } from "@/services/stream.js";
 import { db } from "@/db/postgre.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -104,4 +105,5 @@ export default define(meta, paramDef, async (ps) => {
 	}
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
+	await bumpReactionNormalizeCacheVersion();
 });

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -3,6 +3,7 @@ import { insertModerationLog } from "@/services/insert-moderation-log.js";
 import { DB_MAX_NOTE_TEXT_LENGTH } from "@/misc/hard-limits.js";
 import { db } from "@/db/postgre.js";
 import define from "../../define.js";
+import { bumpReactionNormalizeCacheVersion } from "@/misc/reaction-normalize-cache.js";
 
 export const meta = {
 	tags: ["admin"],
@@ -176,6 +177,7 @@ export const paramDef = {
 
 export default define(meta, paramDef, async (ps, me) => {
 	const set = {} as Partial<Meta>;
+	let shouldBumpReactionNormalizeCacheVersion = false;
 
 	if (typeof ps.disableRegistration === "boolean") {
 		set.disableRegistration = ps.disableRegistration;
@@ -195,6 +197,7 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	if (typeof ps.defaultReaction === "string") {
 		set.defaultReaction = ps.defaultReaction;
+		shouldBumpReactionNormalizeCacheVersion = true;
 	}
 
 	if (Array.isArray(ps.pinnedUsers)) {
@@ -574,4 +577,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	});
 
 	insertModerationLog(me, "updateMeta");
+	if (shouldBumpReactionNormalizeCacheVersion) {
+		await bumpReactionNormalizeCacheVersion();
+	}
 });

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -29,7 +29,10 @@ import { IdentifiableError } from "@/misc/identifiable-error.js";
 import { webhookDeliver } from "@/queue/index.js";
 import { getActiveWebhooks } from "@/misc/webhook-cache.js";
 import { MAX_REACTION_PER_ACCOUNT } from "@/const.js";
-import { Cache } from "@/misc/cache.js";
+import {
+	getCachedNormalizedReaction,
+	setCachedNormalizedReaction,
+} from "@/misc/reaction-normalize-cache.js";
 import type { UserProfile } from "@/models/entities/user-profile.js";
 import { checkReactionMute } from "@/misc/check-word-mute.js";
 import { buildReactionDeliverManager } from "./deliver.js";
@@ -101,14 +104,30 @@ export default async (
 	// Await all initial checks concurrently
 	await Promise.all([blockPromise, visibilityPromise, relationPromise, noteDeletedCheckPromise]);
 
-	// TODO: cache
-	try {
-		reaction = await toDbReaction(reaction, user.host, note.userHost);
-	} catch (err) {
-		throw new IdentifiableError(
-			"770a3ede-67d2-fc9d-f2e2-6163ba0443af",
-			"指定された絵文字が存在しません。",
-		);
+	const rawReaction = reaction;
+	const cachedReaction = await getCachedNormalizedReaction(
+		user.host,
+		note.userHost,
+		rawReaction,
+	);
+
+	if (cachedReaction != null) {
+		reaction = cachedReaction;
+	} else {
+		try {
+			reaction = await toDbReaction(rawReaction, user.host, note.userHost);
+			await setCachedNormalizedReaction(
+				user.host,
+				note.userHost,
+				rawReaction,
+				reaction,
+			);
+		} catch (err) {
+			throw new IdentifiableError(
+				"770a3ede-67d2-fc9d-f2e2-6163ba0443af",
+				"指定された絵文字が存在しません。",
+			);
+		}
 	}
 
 	let isMutedReaction: boolean | { muted: boolean; reject?: boolean | undefined } = false;


### PR DESCRIPTION
### Motivation
- `packages/backend/src/services/note/reaction/create.ts` の `// TODO: cache` 相当箇所では `toDbReaction` や絵文字関連の再計算・再参照が多く、高負荷になるため正規化結果を短時間キャッシュして再計算を回避する目的で変更しました。

### Description
- `packages/backend/src/misc/reaction-normalize-cache.ts` を新規追加し、キー形式を `reaction-normalize:v{version}:{userHost}:{noteUserHost}:{rawReaction}` （各要素は URL エンコード）とし、TTL を 60 秒に設定してキャッシュの取得・保存・バージョンインクリメントを提供します。
- `packages/backend/src/services/note/reaction/create.ts` を変更し、まずキャッシュを参照して `hit` なら再計算をスキップし、`miss` の場合のみ既存の `toDbReaction` を実行して成功結果のみをキャッシュするようにしました（不正絵文字時の `IdentifiableError` の挙動は維持）。
- 絵文字や関連設定の更新時にキャッシュを無効化するため、prefix version 更新用の `bumpReactionNormalizeCacheVersion()` を導入し、管理用絵文字 API（`add`, `copy`, `delete`, `delete-bulk`, `update`, `add-aliases-bulk`, `remove-aliases-bulk`, `set-aliases-bulk`, `set-category-bulk`, `set-license-bulk`）と、`admin/update-meta` の `defaultReaction` 更新時に呼び出すようにしました。
- ネガティブキャッシュ（不正絵文字等）は今回導入せず、必要なら負荷状況を見て短TTLで後続実装できる設計にしています。

### Testing
- 自動テストとして `pnpm --filter backend run lint` を実行しましたが、開発環境に依存する `rome` が未インストールのため実行失敗しました（`spawn rome ENOENT`）。
- ユニットテストやビルドはこの変更内で追加・実行しておらず、TypeScript コンパイルや統合テストは未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d93a9c9a88326a770efabae8a6109)