### PR TITLE
タイムライン系Renoteフィルタの条件共通化とpoll判定の軽量化

### DIFF
--- a/packages/backend/src/server/api/common/note-content-condition.ts
+++ b/packages/backend/src/server/api/common/note-content-condition.ts
@@ -1,0 +1,12 @@
+import type { WhereExpressionBuilder } from "typeorm";
+
+const noteHasContentCondition = (noteAlias: string): string => {
+	return `(${noteAlias}.text IS NOT NULL OR CARDINALITY(${noteAlias}."fileIds") > 0 OR ${noteAlias}."hasPoll" = TRUE)`;
+};
+
+export const applyOrWhereNoteHasContent = (
+	qb: WhereExpressionBuilder,
+	noteAlias: string,
+): void => {
+	qb.orWhere(noteHasContentCondition(noteAlias));
+};

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -13,6 +13,7 @@ import { generateChannelQuery } from "../../common/generate-channel-query.js";
 import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
 import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
+import { applyOrWhereNoteHasContent } from "../../common/note-content-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -121,11 +122,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserId != note.userId");
 				qb.orWhere("note.userId = :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -135,11 +132,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.userId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -149,11 +142,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.renoteUserId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -163,11 +152,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.renoteUserHost IS NOT NULL");
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -12,6 +12,7 @@ import { generateBlockedUserQuery } from "../../common/generate-block-query.js";
 import { generateMutedUserRenotesQueryForNotes } from "../../common/generated-muted-renote-query.js";
 import { ApiError } from "../../error.js";
 import { createFollowingExistsCondition } from "../../common/following-exists-condition.js";
+import { applyOrWhereNoteHasContent } from "../../common/note-content-condition.js";
 
 export const meta = {
 	tags: ["notes"],
@@ -110,11 +111,7 @@ export default define(meta, paramDef, async (ps, user) => {
 				qb.orWhere("note.renoteUserId != note.userId");
 				qb.orWhere("note.userId = :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -124,11 +121,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.userId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -138,11 +131,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.renoteUserId != :meId", { meId: user.id });
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}
@@ -152,11 +141,7 @@ export default define(meta, paramDef, async (ps, user) => {
 			new Brackets((qb) => {
 				qb.orWhere("note.renoteUserHost IS NOT NULL");
 				qb.orWhere("note.renoteId IS NULL");
-				qb.orWhere("note.text IS NOT NULL");
-                                qb.orWhere('CARDINALITY(note."fileIds") > 0');
-				qb.orWhere(
-					'0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)',
-				);
+				applyOrWhereNoteHasContent(qb, "note");
 			}),
 		);
 	}


### PR DESCRIPTION
このPRは、タイムライン系エンドポイントで重複していたRenoteフィルタ条件を共通化し、poll の存在判定コストを下げる変更です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da1bb597c8326b6e354b5cf9cd2cf)