### PR TITLE
packMany キャッシュの失効経路を強化しフォロー・リアクション・お気に入り更新時の整合性を改善

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -27,6 +27,8 @@ import {
 	prefetchEmojis,
 } from "@/misc/populate-emojis.js";
 import { db } from "@/db/postgre.js";
+import { subscriber } from "@/db/redis.js";
+import { Cache } from "@/misc/cache.js";
 import { IdentifiableError } from "@/misc/identifiable-error.js";
 
 export async function populatePoll(note: Note, meId: User["id"] | null) {
@@ -93,6 +95,70 @@ type NotePackHint = {
         me?: User;
         followings?: Map<User["id"], boolean>;
 };
+
+const NOTE_PACK_CACHE_TTL_MS = 30 * 1000;
+
+const meUserCache = new Cache<User>(NOTE_PACK_CACHE_TTL_MS);
+const followingsMapCache = new Cache<Map<User["id"], boolean>>(NOTE_PACK_CACHE_TTL_MS);
+const myReactionPointCache = new Cache<NoteReaction[]>(NOTE_PACK_CACHE_TTL_MS);
+const favoritePointCache = new Cache<boolean>(NOTE_PACK_CACHE_TTL_MS);
+
+function getUserNoteCacheKey(userId: User["id"], noteId: Note["id"]): string {
+	return `${userId}:${noteId}`;
+}
+
+function invalidateNotePackViewerCache(viewerId: User["id"]): void {
+	meUserCache.delete(viewerId);
+	followingsMapCache.delete(viewerId);
+}
+
+subscriber.on("message", (_, data) => {
+	const message = JSON.parse(data) as {
+		channel: string;
+		message: { type: string; body: { id?: User["id"]; userId?: User["id"]; noteId?: Note["id"] } | null };
+	};
+
+	if (message.channel === "internal") {
+		switch (message.message.type) {
+			case "localUserUpdated":
+			case "remoteUserUpdated":
+			case "userChangeSuspendedState":
+			case "userChangeSilencedState":
+			case "userChangeModeratorState": {
+				const userId = message.message.body?.id;
+				if (userId != null) {
+					invalidateNotePackViewerCache(userId);
+				}
+				break;
+			}
+			case "notePackFollowingUpdated": {
+				const userId = message.message.body?.userId;
+				if (userId != null) {
+					invalidateNotePackViewerCache(userId);
+				}
+				break;
+			}
+			case "notePackReactionUpdated": {
+				const userId = message.message.body?.userId;
+				const noteId = message.message.body?.noteId;
+				if (userId != null && noteId != null) {
+					myReactionPointCache.delete(getUserNoteCacheKey(userId, noteId));
+				}
+				break;
+			}
+			case "notePackFavoriteUpdated": {
+				const userId = message.message.body?.userId;
+				const noteId = message.message.body?.noteId;
+				if (userId != null && noteId != null) {
+					favoritePointCache.delete(getUserNoteCacheKey(userId, noteId));
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	}
+});
 
 async function populateMyReaction(
         note: Note,
@@ -540,29 +606,68 @@ export const NoteRepository = db.getRepository(Note).extend({
                         const targets = Array.from(
                                 new Set([...notes.map((n) => n.id), ...renoteIds]),
                         );
-                        const myReactions = await NoteReactions.findBy({
-                                userId: meId,
-                                noteId: In(targets),
-                        });
-
-                        const myReactionsByNoteId = new Map<Note["id"], NoteReaction[]>();
-                        for (const reaction of myReactions) {
-                                const reactions = myReactionsByNoteId.get(reaction.noteId) ?? [];
-                                reactions.push(reaction);
-                                myReactionsByNoteId.set(reaction.noteId, reactions);
-                        }
-
+                        const reactionMissTargets: Note["id"][] = [];
                         for (const target of targets) {
-                                myReactionsMap.set(target, myReactionsByNoteId.get(target) ?? []);
-                        }
+				const cached = myReactionPointCache.get(getUserNoteCacheKey(meId, target));
+				if (cached === undefined) {
+					reactionMissTargets.push(target);
+				} else {
+					myReactionsMap.set(target, cached);
+				}
+			}
 
-                        const favorites = await NoteFavorites.findBy({
-                                userId: meId,
-                                noteId: In(targets),
-                        });
-                        favoritedNoteIds = new Set(favorites.map((favorite) => favorite.noteId));
+			if (reactionMissTargets.length > 0) {
+				const myReactions = await NoteReactions.findBy({
+					userId: meId,
+					noteId: In(reactionMissTargets),
+				});
 
-                        meUser = await Users.findOneByOrFail({ id: meId });
+				const myReactionsByNoteId = new Map<Note["id"], NoteReaction[]>();
+				for (const reaction of myReactions) {
+					const reactions = myReactionsByNoteId.get(reaction.noteId) ?? [];
+					reactions.push(reaction);
+					myReactionsByNoteId.set(reaction.noteId, reactions);
+				}
+
+				for (const noteId of reactionMissTargets) {
+					const reactions = myReactionsByNoteId.get(noteId) ?? [];
+					myReactionPointCache.set(getUserNoteCacheKey(meId, noteId), reactions);
+					myReactionsMap.set(noteId, reactions);
+				}
+			}
+
+			favoritedNoteIds = new Set();
+			const favoriteMissTargets: Note["id"][] = [];
+			for (const target of targets) {
+				const cached = favoritePointCache.get(getUserNoteCacheKey(meId, target));
+				if (cached === undefined) {
+					favoriteMissTargets.push(target);
+					continue;
+				}
+				if (cached) {
+					favoritedNoteIds.add(target);
+				}
+			}
+
+			if (favoriteMissTargets.length > 0) {
+				const favorites = await NoteFavorites.findBy({
+					userId: meId,
+					noteId: In(favoriteMissTargets),
+				});
+				const favoriteSet = new Set(favorites.map((favorite) => favorite.noteId));
+
+				for (const noteId of favoriteMissTargets) {
+					const isFavorited = favoriteSet.has(noteId);
+					favoritePointCache.set(getUserNoteCacheKey(meId, noteId), isFavorited);
+					if (isFavorited) {
+						favoritedNoteIds.add(noteId);
+					}
+				}
+			}
+
+			meUser = await meUserCache.fetch(meId, async () => {
+				return await Users.findOneByOrFail({ id: meId });
+			});
                 }
 
                 await prefetchEmojis(aggregateNoteEmojis(notes));
@@ -579,22 +684,30 @@ export const NoteRepository = db.getRepository(Note).extend({
                         }
 
                         if (userIds.size > 0) {
-                                const followeeIds = Array.from(userIds);
-                                followingsMap = new Map(
-                                        followeeIds.map((id) => [id, false] as [User["id"], boolean]),
-                                );
+				const followeeIds = Array.from(userIds);
+				followingsMap = await followingsMapCache.fetch(
+					meId,
+					async () => {
+						const resolvedMap = new Map(
+							followeeIds.map((id) => [id, false] as [User["id"], boolean]),
+						);
 
-                                const followings = await Followings.findBy({
-                                        followerId: meId,
-                                        followeeId: In(followeeIds),
-                                });
+						const followings = await Followings.findBy({
+							followerId: meId,
+							followeeId: In(followeeIds),
+						});
 
-                                for (const following of followings) {
-                                        followingsMap.set(following.followeeId, true);
-                                }
-                        } else {
-                                followingsMap = new Map();
-                        }
+						for (const following of followings) {
+							resolvedMap.set(following.followeeId, true);
+						}
+
+						return resolvedMap;
+					},
+					(cachedMap) => followeeIds.every((id) => cachedMap.has(id)),
+				);
+			} else {
+				followingsMap = new Map();
+			}
                 }
 
                 const hint: NotePackHint = {

--- a/packages/backend/src/server/api/endpoints/notes/favorites/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/favorites/create.ts
@@ -3,6 +3,7 @@ import { genId } from "@/misc/gen-id.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
 import { getNote } from "../../../common/getters.js";
+import { publishInternalEvent } from "@/services/stream.js";
 
 export const meta = {
 	tags: ["notes", "favorites"],
@@ -58,5 +59,10 @@ export default define(meta, paramDef, async (ps, user) => {
 		createdAt: new Date(),
 		noteId: note.id,
 		userId: user.id,
+	});
+
+	publishInternalEvent("notePackFavoriteUpdated", {
+		userId: user.id,
+		noteId: note.id,
 	});
 });

--- a/packages/backend/src/server/api/endpoints/notes/favorites/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/favorites/delete.ts
@@ -2,6 +2,7 @@ import { NoteFavorites } from "@/models/index.js";
 import define from "../../../define.js";
 import { ApiError } from "../../../error.js";
 import { getNote } from "../../../common/getters.js";
+import { publishInternalEvent } from "@/services/stream.js";
 
 export const meta = {
 	tags: ["notes", "favorites"],
@@ -46,4 +47,9 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	// Delete favorite
 	await NoteFavorites.delete(exist.id);
+
+	publishInternalEvent("notePackFavoriteUpdated", {
+		userId: user.id,
+		noteId: ps.noteId,
+	});
 });

--- a/packages/backend/src/server/api/stream/types.ts
+++ b/packages/backend/src/server/api/stream/types.ts
@@ -41,6 +41,17 @@ export interface InternalStreamTypes {
 	remoteUserUpdated: {
 		id: User["id"];
 	};
+	notePackFollowingUpdated: {
+		userId: User["id"];
+	};
+	notePackReactionUpdated: {
+		userId: User["id"];
+		noteId: Note["id"];
+	};
+	notePackFavoriteUpdated: {
+		userId: User["id"];
+		noteId: Note["id"];
+	};
 	webhookCreated: Webhook;
 	webhookDeleted: Webhook;
 	webhookUpdated: Webhook;

--- a/packages/backend/src/services/blocking/create.ts
+++ b/packages/backend/src/services/blocking/create.ts
@@ -1,4 +1,8 @@
-import { publishMainStream, publishUserEvent } from "@/services/stream.js";
+import {
+	publishInternalEvent,
+	publishMainStream,
+	publishUserEvent,
+} from "@/services/stream.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import renderFollow from "@/remote/activitypub/renderer/follow.js";
 import renderUndo from "@/remote/activitypub/renderer/undo.js";
@@ -125,6 +129,12 @@ async function unFollow(follower: User, followee: User) {
 		Users.decrement({ id: followee.id }, "followersCount", 1),
 		perUserFollowingChart.update(follower, followee, false),
 	]);
+
+	if (Users.isLocalUser(follower)) {
+		publishInternalEvent("notePackFollowingUpdated", {
+			userId: follower.id,
+		});
+	}
 
 	// Publish unfollow event
 	if (Users.isLocalUser(follower)) {

--- a/packages/backend/src/services/following/create.ts
+++ b/packages/backend/src/services/following/create.ts
@@ -1,4 +1,8 @@
-import { publishMainStream, publishUserEvent } from "@/services/stream.js";
+import {
+	publishInternalEvent,
+	publishMainStream,
+	publishUserEvent,
+} from "@/services/stream.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import renderFollow from "@/remote/activitypub/renderer/follow.js";
 import renderAccept from "@/remote/activitypub/renderer/accept.js";
@@ -143,6 +147,9 @@ export async function insertFollowingDoc(
 
 	// Publish follow event
 	if (Users.isLocalUser(follower)) {
+		publishInternalEvent("notePackFollowingUpdated", {
+			userId: follower.id,
+		});
 		Users.pack(followee.id, follower, {
 			detail: true,
 		}).then(async (packed) => {

--- a/packages/backend/src/services/following/delete.ts
+++ b/packages/backend/src/services/following/delete.ts
@@ -1,4 +1,8 @@
-import { publishMainStream, publishUserEvent } from "@/services/stream.js";
+import {
+	publishInternalEvent,
+	publishMainStream,
+	publishUserEvent,
+} from "@/services/stream.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import renderFollow from "@/remote/activitypub/renderer/follow.js";
 import renderUndo from "@/remote/activitypub/renderer/undo.js";
@@ -49,6 +53,12 @@ export default async function (
 	await Followings.delete(following.id);
 
 	decrementFollowing(follower, followee);
+
+	if (Users.isLocalUser(follower)) {
+		publishInternalEvent("notePackFollowingUpdated", {
+			userId: follower.id,
+		});
+	}
 
 	// Publish unfollow event
 	if (!silent && Users.isLocalUser(follower)) {

--- a/packages/backend/src/services/following/reject.ts
+++ b/packages/backend/src/services/following/reject.ts
@@ -2,7 +2,11 @@ import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import renderFollow from "@/remote/activitypub/renderer/follow.js";
 import renderReject from "@/remote/activitypub/renderer/reject.js";
 import { deliver, webhookDeliver } from "@/queue/index.js";
-import { publishMainStream, publishUserEvent } from "@/services/stream.js";
+import {
+	publishInternalEvent,
+	publishMainStream,
+	publishUserEvent,
+} from "@/services/stream.js";
 import type { ILocalUser, IRemoteUser } from "@/models/entities/user.js";
 import { User } from "@/models/entities/user.js";
 import { Users, FollowRequests, Followings } from "@/models/index.js";
@@ -92,6 +96,12 @@ async function removeFollow(followee: Both, follower: Both) {
 
 	await Followings.delete(following.id);
 	decrementFollowing(follower, followee);
+
+	if (Users.isLocalUser(follower)) {
+		publishInternalEvent("notePackFollowingUpdated", {
+			userId: follower.id,
+		});
+	}
 }
 
 /**

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -1,4 +1,4 @@
-import { publishNoteStream } from "@/services/stream.js";
+import { publishInternalEvent, publishNoteStream } from "@/services/stream.js";
 import { renderLike } from "@/remote/activitypub/renderer/like.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import {
@@ -286,6 +286,11 @@ export default async (
 			host: decodedReaction.host ?? IsNull(),
 		},
 		select: ["name", "host", "originalUrl", "publicUrl", "license"],
+	});
+
+	publishInternalEvent("notePackReactionUpdated", {
+		userId: user.id,
+		noteId: note.id,
 	});
 
 	publishNoteStream(note.id, "reacted", {

--- a/packages/backend/src/services/note/reaction/delete.ts
+++ b/packages/backend/src/services/note/reaction/delete.ts
@@ -1,4 +1,4 @@
-import { publishNoteStream } from "@/services/stream.js";
+import { publishInternalEvent, publishNoteStream } from "@/services/stream.js";
 import { renderLike } from "@/remote/activitypub/renderer/like.js";
 import renderUndo from "@/remote/activitypub/renderer/undo.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
@@ -108,6 +108,11 @@ export default async (
 		}
 	}
 	
+	publishInternalEvent("notePackReactionUpdated", {
+		userId: user.id,
+		noteId: note.id,
+	});
+
 	publishNoteStream(note.id, "unreacted", {
 		reaction: decodeReaction(exist.reaction).reaction,
 		userId: user.id,


### PR DESCRIPTION
## 概要

`packages/backend/src/models/repositories/note.ts` の `NoteRepository.packMany` に導入したキャッシュ最適化（viewer単位 + userId:noteId 点キャッシュ）をベースに、会話全体で挙がった懸念（副作用・失効漏れ・結合度）へ対応しました。

本PRでは、`pack` / `packMany` の戻り値仕様や `_hint_` の構築方針は維持しつつ、内部データ取得経路とキャッシュ失効経路を改善しています。

## 変更の背景（会話全体）

- `packMany` 内の以下呼び出しコストを削減したい
  - `Users.findOneByOrFail({ id: meId })`
  - `Followings.findBy(...)`
  - `NoteReactions.findBy(...)`
  - `NoteFavorites.findBy(...)`
- ただし、キャッシュ導入後に以下の懸念が発生
  - フォロー更新時の失効トリガーが `mainStream:*` 解釈依存で結合度が高い
  - `silent` unfollow で失効されない可能性
  - リアクション/お気に入り点キャッシュがTTL依存のみで、更新直後に短時間古くなる可能性

## 変更内容

### 1. `packMany` のキャッシュ導入（既存方針を維持）
`packages/backend/src/models/repositories/note.ts`

- 取得経路をキャッシュ化
  - viewer単位: `meUserCache`, `followingsMapCache`
  - 点キャッシュ: `myReactionPointCache`, `favoritePointCache`（キーは `userId:noteId`）
- `In(targets)` クエリを「キャッシュミス分のみ」に限定
- `_hint_` の組み立て・利用と戻り値仕様は変更なし

### 2. フォロー失効トリガーを内部イベント化
`packages/backend/src/server/api/stream/types.ts`  
`packages/backend/src/services/following/create.ts`  
`packages/backend/src/services/following/delete.ts`  
`packages/backend/src/models/repositories/note.ts`

- `InternalStreamTypes` に `notePackFollowingUpdated` を定義
- follow/unfollow 時に `publishInternalEvent("notePackFollowingUpdated", { userId })` を発行
- `note.ts` の購読側で viewer キャッシュ失効を実行
- `mainStream:*` 解析依存を排除し、失効経路を明示化

### 3. `silent` unfollow でも失効するよう修正
`packages/backend/src/services/following/delete.ts`

- `publishInternalEvent("notePackFollowingUpdated", { userId: follower.id })` を `silent` 条件外へ移動
- `silent` はストリーム通知（`publishUserEvent` / `publishMainStream`）抑制専用に整理

### 4. リアクション/お気に入り更新の点キャッシュ失効を追加
`packages/backend/src/server/api/stream/types.ts`  
`packages/backend/src/services/note/reaction/create.ts`  
`packages/backend/src/services/note/reaction/delete.ts`  
`packages/backend/src/server/api/endpoints/notes/favorites/create.ts`  
`packages/backend/src/server/api/endpoints/notes/favorites/delete.ts`  
`packages/backend/src/models/repositories/note.ts`

- `InternalStreamTypes` に以下イベントを追加
  - `notePackReactionUpdated: { userId, noteId }`
  - `notePackFavoriteUpdated: { userId, noteId }`
- 反応作成/削除時に `notePackReactionUpdated` を発火
- お気に入り作成/削除時に `notePackFavoriteUpdated` を発火
- `note.ts` 側で該当 `userId:noteId` キーの点キャッシュを `delete`

### 5. TTLの見直し
`packages/backend/src/models/repositories/note.ts`

- `NOTE_PACK_CACHE_TTL_MS` を `10s -> 30s` に調整
- 更新イベント連動の明示失効を追加したうえで、ヒット率改善を狙う設定に変更

## 期待される効果

- `packMany` の連続呼び出し時に DB クエリ数を削減
- フォロー/リアクション/お気に入り更新直後のキャッシュ整合性を改善
- `mainStream` 仕様への依存を減らし、失効ロジックの追跡性を向上

## 互換性

- `pack` / `packMany` の API レスポンス仕様は不変
- `_hint_` の構築方針も不変
- 変更は内部の取得経路・失効経路に限定


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da1d4dc108326ab4705e5476a5d1e)