### PR TITLE
認証の token→user 解決をハッシュキー付き Redis キャッシュへ移行

### DIFF
--- a/packages/backend/src/server/api/authenticate.ts
+++ b/packages/backend/src/server/api/authenticate.ts
@@ -4,10 +4,7 @@ import { Users, AccessTokens, Apps } from "@/models/index.js";
 import type { AccessToken } from "@/models/entities/access-token.js";
 import { Cache } from "@/misc/cache.js";
 import type { App } from "@/models/entities/app.js";
-import {
-	fetchLocalUserByIdCache,
-	fetchLocalUserByNativeTokenCache,
-} from "@/services/user-cache.js";
+import { fetchAuthUserByTokenCache } from "@/services/user-cache.js";
 
 const appCache = new Cache<App>(Infinity);
 
@@ -17,6 +14,15 @@ export class AuthenticationError extends Error {
 		this.name = "AuthenticationError";
 	}
 }
+
+const AUTH_USER_SELECT = {
+	id: true,
+	host: true,
+	isSuspended: true,
+	isAdmin: true,
+	isModerator: true,
+	onlineStatus: true,
+} as const;
 
 export default async (
 	authorization: string | null | undefined,
@@ -46,10 +52,13 @@ export default async (
 	}
 
 	if (isNativeToken(token)) {
-		const user = await fetchLocalUserByNativeTokenCache(
-			token,
-			() => Users.findOneBy({ token }) as Promise<ILocalUser | null>,
-		);
+		const user = await fetchAuthUserByTokenCache(token, async () => {
+			const authUser = await Users.findOne({
+				where: { token },
+				select: AUTH_USER_SELECT,
+			});
+			return authUser as ILocalUser | null;
+		});
 
 		if (user == null) {
 			throw new AuthenticationError("unknown token");
@@ -76,13 +85,19 @@ export default async (
 			lastUsedAt: new Date(),
 		});
 
-		const user = await fetchLocalUserByIdCache(
-			accessToken.userId,
-			() =>
-				Users.findOneBy({
+		const user = await fetchAuthUserByTokenCache(token, async () => {
+			const authUser = await Users.findOne({
+				where: {
 					id: accessToken.userId,
-				}) as Promise<ILocalUser>,
-		);
+				},
+				select: AUTH_USER_SELECT,
+			});
+			return authUser as CacheableLocalUser | null;
+		});
+
+		if (user == null) {
+			throw new AuthenticationError("unknown token");
+		}
 
 		if (accessToken.appId) {
 			const app = await appCache.fetch(accessToken.appId, () =>

--- a/packages/backend/src/services/user-cache.ts
+++ b/packages/backend/src/services/user-cache.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
 	CacheableLocalUser,
 	CacheableUser,
@@ -13,11 +14,16 @@ const USER_CACHE_REDIS_TTL_SEC = 60;
 const USER_BY_ID_REDIS_KEY_PREFIX = "user-cache:user-by-id";
 const LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX =
 	"user-cache:local-user-by-native-token";
+const AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX = "auth:userByToken";
 const LOCAL_USER_BY_ID_REDIS_KEY_PREFIX = "user-cache:local-user-by-id";
 const URI_PERSON_REDIS_KEY_PREFIX = "user-cache:uri-person";
 
 function createRedisKey(prefix: string, key: string | null): string {
 	return `${prefix}:${key ?? "__null__"}`;
+}
+
+function createTokenHash(token: string): string {
+	return createHash("sha256").update(token).digest("hex");
 }
 
 async function cacheSetWithRedis<T>(
@@ -78,6 +84,9 @@ export const userByIdCache = new Cache<CacheableUser>(LOCAL_MAP_TTL_MS);
 export const localUserByNativeTokenCache = new Cache<CacheableLocalUser | null>(
 	LOCAL_MAP_TTL_MS,
 );
+export const authUserByTokenCache = new Cache<CacheableLocalUser | null>(
+	LOCAL_MAP_TTL_MS,
+);
 export const localUserByIdCache = new Cache<CacheableLocalUser>(LOCAL_MAP_TTL_MS);
 export const uriPersonCache = new Cache<CacheableUser | null>(LOCAL_MAP_TTL_MS);
 
@@ -117,6 +126,38 @@ export async function fetchLocalUserByNativeTokenCache(
 	)) as CacheableLocalUser | null;
 }
 
+export async function fetchAuthUserByTokenCache(
+	token: string,
+	fetcher: () => Promise<CacheableLocalUser | null>,
+): Promise<CacheableLocalUser | null> {
+	const tokenHash = createTokenHash(token);
+	const localCached = authUserByTokenCache.get(tokenHash);
+	if (localCached !== undefined) {
+		return localCached;
+	}
+
+	const redisKey = createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, tokenHash);
+	const redisCached = await redisClient.get(redisKey);
+	if (redisCached != null) {
+		const parsed = JSON.parse(redisCached) as CacheableLocalUser | null;
+		authUserByTokenCache.set(tokenHash, parsed);
+		return parsed;
+	}
+
+	const fetched = await fetcher();
+	if (fetched !== undefined) {
+		authUserByTokenCache.set(tokenHash, fetched);
+		await redisClient.set(
+			redisKey,
+			JSON.stringify(fetched),
+			"EX",
+			USER_CACHE_REDIS_TTL_SEC,
+		);
+	}
+
+	return fetched;
+}
+
 export async function fetchLocalUserByIdCache(
 	id: string,
 	fetcher: () => Promise<CacheableLocalUser>,
@@ -150,12 +191,28 @@ subscriber.on("message", async (_, data) => {
 			case "localUserUpdated": {
 				await cacheDeleteWithRedis(userByIdCache, USER_BY_ID_REDIS_KEY_PREFIX, body.id);
 				await cacheDeleteWithRedis(localUserByIdCache, LOCAL_USER_BY_ID_REDIS_KEY_PREFIX, body.id);
+				const localUser = (await Users.findOneBy({ id: body.id })) as ILocalUser | null;
+				if (localUser?.token) {
+					const tokenHash = createTokenHash(localUser.token);
+					authUserByTokenCache.delete(tokenHash);
+					await redisClient.del(
+						createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, tokenHash),
+					);
+				}
 				for (const [k, v] of localUserByNativeTokenCache.cache.entries()) {
 					if (v.value?.id === body.id) {
 						await cacheDeleteWithRedis(
 							localUserByNativeTokenCache,
 							LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,
 							k,
+						);
+					}
+				}
+				for (const [k, v] of authUserByTokenCache.cache.entries()) {
+					if (v.value?.id === body.id) {
+						authUserByTokenCache.delete(k);
+						await redisClient.del(
+							createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, k),
 						);
 					}
 				}
@@ -192,6 +249,16 @@ subscriber.on("message", async (_, data) => {
 				const user = (await Users.findOneByOrFail({
 					id: body.id,
 				})) as ILocalUser;
+				const oldTokenHash = createTokenHash(body.oldToken);
+				authUserByTokenCache.delete(oldTokenHash);
+				await redisClient.del(
+					createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, oldTokenHash),
+				);
+				const newTokenHash = createTokenHash(body.newToken);
+				authUserByTokenCache.delete(newTokenHash);
+				await redisClient.del(
+					createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, newTokenHash),
+				);
 				await cacheDeleteWithRedis(
 					localUserByNativeTokenCache,
 					LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX,


### PR DESCRIPTION
### Motivation
- 認証ホットパスでの DB 負荷を下げるために、token→user 解決を先に Redis 参照するフローへ変更しました。 
- Redis 上で平文トークンが露出しないようにキー化をハッシュ化（SHA-256）で行いセキュリティを向上させます。 
- 認証時に返すユーザー情報を最小フィールドに限定して、認証初期段階のデータ取得量を削減します。

### Description
- `packages/backend/src/services/user-cache.ts` に `auth:userByToken:{tokenHash}` キー空間と `createTokenHash`（SHA-256）を追加し、`fetchAuthUserByTokenCache` を実装してローカルキャッシュ -> Redis GET -> miss時 DB -> Redis SET(EX) の流れを実現しました。 
- `packages/backend/src/server/api/authenticate.ts` を修正して、ネイティブトークン／アクセストークン双方の token→user 解決を `fetchAuthUserByTokenCache` 経由に統一し、認証で取得するユーザーは `AUTH_USER_SELECT`（`id`, `host`, `isSuspended`, `isAdmin`, `isModerator`, `onlineStatus`）の最小フィールドに限定しました。 
- 既存の subscriber 経路に連携し、`localUserUpdated` イベントと `userTokenRegenerated` イベントで該当する auth キャッシュキー（ハッシュ）を `DEL` して整合性を保つ invalidation を追加しました。 
- 既存の `localUserByNativeTokenCache` 等は併存させつつ、認証用にはハッシュ化キャッシュを優先する形にしています。

### Testing
- `git diff -- packages/backend/src/services/user-cache.ts packages/backend/src/server/api/authenticate.ts` を確認して差分を検査しました（成功）。 
- 型チェックで `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行したところ環境に `@types/node` が無く `TS2688` が発生して失敗しました。 
- `git status --short` と `git rev-parse --abbrev-ref HEAD && git show --stat --oneline HEAD` による変更確認とコミットは正常に行われました（コミット `5a1b1f7`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da69d01008326826cf8be38136633)