### PR TITLE
リアクション作成処理の参照最適化・上限制御抽出とテスト追加

### DIFF
--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -36,6 +36,61 @@ import {
 import type { UserProfile } from "@/models/entities/user-profile.js";
 import { checkReactionMute } from "@/misc/check-word-mute.js";
 import { buildReactionDeliverManager } from "./deliver.js";
+import { Cache } from "@/misc/cache.js";
+
+const INSTANCE_MAX_REACTIONS_CACHE_TTL_MS = 30 * 1000;
+const instanceMaxReactionsPerAccountCache = new Cache<number>(
+	INSTANCE_MAX_REACTIONS_CACHE_TTL_MS,
+);
+
+export function normalizeReactionMuteResult(
+	muteResult: boolean | { muted: boolean; reject?: boolean | undefined },
+	defaultReject: boolean,
+): { isMutedReaction: boolean; shouldReject: boolean } {
+	const normalized =
+		typeof muteResult === "boolean" ? { muted: muteResult } : muteResult;
+	const shouldReject =
+		normalized.muted && (normalized.reject ?? defaultReject);
+
+	return {
+		isMutedReaction: normalized.muted,
+		shouldReject,
+	};
+}
+
+export function evaluateReactionLimit(params: {
+	existCount: number;
+	maxReactions: number;
+	reaction: string;
+	existingReaction?: string;
+}): "allow" | "replace" | "duplicate_error" | "limit_error" {
+	if (params.existCount < params.maxReactions) {
+		return "allow";
+	}
+
+	if (params.maxReactions !== 1) {
+		return "limit_error";
+	}
+
+	if (params.existingReaction == null || params.existingReaction === params.reaction) {
+		return "duplicate_error";
+	}
+
+	return "replace";
+}
+
+async function getMaxReactionsPerAccountByHost(host: string): Promise<number> {
+	return await instanceMaxReactionsPerAccountCache.fetch(
+		host,
+		async () => {
+			const instance = await Instances.findOne({
+				where: { host },
+				select: ["maxReactionsPerAccount"],
+			});
+			return instance?.maxReactionsPerAccount ?? 1;
+		},
+	);
+}
 
 export default async (
 	user: {
@@ -140,30 +195,25 @@ export default async (
 		select: ["userId", "reactionMutedWords", "rejectMuteReaction"],
 	});
 	if (muteInfo) {
-    isMutedReaction = checkReactionMute(
-        reaction,
-        note,
-        user,
-        muteInfo.reactionMutedWords,
-    );
-    console.log('isMutedReaction after checkReactionMute:', isMutedReaction);
+		const muteResult = checkReactionMute(
+			reaction,
+			note,
+			user,
+			muteInfo.reactionMutedWords,
+		);
+		const normalizedMute = normalizeReactionMuteResult(
+			muteResult,
+			muteInfo.rejectMuteReaction,
+		);
 
-    if (typeof isMutedReaction === "boolean") {
-        isMutedReaction = { muted: isMutedReaction };
-    }
-    console.log('isMutedReaction after type check:', isMutedReaction);
+		if (normalizedMute.shouldReject) {
+			throw new IdentifiableError(
+				"119b8757-2ba5-385e-82cf-7fa4bc73c4d1",
+				"投稿者のリアクションミュート設定の為、リアクションが拒否されました。",
+			);
+		}
 
-    if (
-        isMutedReaction.muted &&
-        (isMutedReaction.reject ?? muteInfo.rejectMuteReaction)
-    ) {
-        throw new IdentifiableError(
-            "119b8757-2ba5-385e-82cf-7fa4bc73c4d1",
-            "投稿者のリアクションミュート設定の為、リアクションが拒否されました。",
-        );
-    }
-    isMutedReaction = isMutedReaction.muted;
-    console.log('Final isMutedReaction:', isMutedReaction);
+		isMutedReaction = normalizedMute.isMutedReaction;
 	}
 
 
@@ -175,12 +225,15 @@ export default async (
 		reaction,
 	};
 
-	const existCount = await NoteReactions.count({
+	const existingReactions = await NoteReactions.find({
 		where: {
 			noteId: note.id,
 			userId: user.id,
 		},
+		select: ["reaction"],
 	});
+	const existCount = existingReactions.length;
+	const existingReaction = existingReactions[0]?.reaction;
 
 	if (existCount !== 0) {
 		let maxReactionsPerAccount = 1;
@@ -191,18 +244,14 @@ export default async (
 					? MAX_REACTION_PER_ACCOUNT
 					: 1;
 		} else {
-			const instance = await Instances.findOneBy({ host: user.host });
-			maxReactionsPerAccount = instance?.maxReactionsPerAccount ?? 1;
+			maxReactionsPerAccount = await getMaxReactionsPerAccountByHost(user.host);
 		}
 
 		if (maxReactionsPerAccount >= 2) {
-			const noteUser = await Users.findOneBy({ id: note.userId });
-
-			if (!noteUser?.host) {
+			if (!note.userHost) {
 				maxReactionsNote = maxReactionsPerAccount;
 			} else {
-				const instance = await Instances.findOneBy({ host: noteUser.host });
-				maxReactionsNote = instance?.maxReactionsPerAccount ?? 1;
+				maxReactionsNote = await getMaxReactionsPerAccountByHost(note.userHost);
 				if (!user.host) maxReactionsPerAccount = maxReactionsNote;
 			}
 		}
@@ -212,24 +261,25 @@ export default async (
 			64,
 		);
 
-		if (existCount >= maxReactions) {
-			if (maxReactions === 1) {
-				const exists = await NoteReactions.findOneByOrFail({
-					noteId: note.id,
-					userId: user.id,
-				});
+		const limitResult = evaluateReactionLimit({
+			existCount,
+			maxReactions,
+			reaction,
+			existingReaction,
+		});
 
-				if (exists.reaction !== reaction) {
-					// 別のリアクションがすでにされていたら置き換える
-					await deleteReaction(user, note, exists.reaction);
-				} else {
-					// 同じリアクションがすでにされていたらエラー
-					throw new IdentifiableError("51c42bb4-931a-456b-bff7-e5a8a70dd298");
-				}
-			} else {
-				// 絵文字上限超過エラー
-				throw new IdentifiableError("058b5325-c56c-99d1-9677-6eaeedd9f3f4");
+		if (limitResult === "replace") {
+			// 別のリアクションがすでにされていたら置き換える
+			if (existingReaction == null) {
+				throw new IdentifiableError("51c42bb4-931a-456b-bff7-e5a8a70dd298");
 			}
+			await deleteReaction(user, note, existingReaction);
+		} else if (limitResult === "duplicate_error") {
+			// 同じリアクションがすでにされていたらエラー
+			throw new IdentifiableError("51c42bb4-931a-456b-bff7-e5a8a70dd298");
+		} else if (limitResult === "limit_error") {
+			// 絵文字上限超過エラー
+			throw new IdentifiableError("058b5325-c56c-99d1-9677-6eaeedd9f3f4");
 		}
 	}
 

--- a/packages/backend/test/reaction-create.ts
+++ b/packages/backend/test/reaction-create.ts
@@ -1,0 +1,86 @@
+process.env.NODE_ENV = "test";
+
+import * as assert from "assert";
+import {
+	evaluateReactionLimit,
+	normalizeReactionMuteResult,
+} from "../src/services/note/reaction/create.js";
+
+describe("Reaction create service helper", () => {
+	describe("normalizeReactionMuteResult", () => {
+		it("booleanのmute結果を拒否設定付きで正規化できる", () => {
+			const result = normalizeReactionMuteResult(true, true);
+
+			assert.deepStrictEqual(result, {
+				isMutedReaction: true,
+				shouldReject: true,
+			});
+		});
+
+		it("reject指定がないobjectはdefaultRejectを利用する", () => {
+			const result = normalizeReactionMuteResult({ muted: true }, false);
+
+			assert.deepStrictEqual(result, {
+				isMutedReaction: true,
+				shouldReject: false,
+			});
+		});
+
+		it("reject指定があるobjectはdefaultRejectより優先される", () => {
+			const result = normalizeReactionMuteResult(
+				{ muted: true, reject: false },
+				true,
+			);
+
+			assert.deepStrictEqual(result, {
+				isMutedReaction: true,
+				shouldReject: false,
+			});
+		});
+	});
+
+	describe("evaluateReactionLimit", () => {
+		it("既存数が上限未満なら許可される", () => {
+			const result = evaluateReactionLimit({
+				existCount: 0,
+				maxReactions: 1,
+				reaction: "like",
+			});
+
+			assert.strictEqual(result, "allow");
+		});
+
+		it("上限1件で同一リアクションの場合はduplicate_error", () => {
+			const result = evaluateReactionLimit({
+				existCount: 1,
+				maxReactions: 1,
+				reaction: "like",
+				existingReaction: "like",
+			});
+
+			assert.strictEqual(result, "duplicate_error");
+		});
+
+		it("上限1件で別リアクションの場合はreplace", () => {
+			const result = evaluateReactionLimit({
+				existCount: 1,
+				maxReactions: 1,
+				reaction: "like",
+				existingReaction: "love",
+			});
+
+			assert.strictEqual(result, "replace");
+		});
+
+		it("上限複数件を超えた場合はlimit_error", () => {
+			const result = evaluateReactionLimit({
+				existCount: 2,
+				maxReactions: 2,
+				reaction: "like",
+				existingReaction: "love",
+			});
+
+			assert.strictEqual(result, "limit_error");
+		});
+	});
+});


### PR DESCRIPTION
### Motivation
- 同一ホスト/同一ユーザーに対するDB参照を削減して負荷を下げるため、既存リアクション取得とインスタンス設定参照の順序／回数を見直した。 
- デバッグ用の`console.log`を除去またはロジック化して本番I/O負荷を低減するため。 
- 既存のリアクション正規化キャッシュとの整合を崩さずに、ミュート拒否（reject）や上限制御（1件→置換/重複/複数上限）の挙動を明確に保つため。 

### Description
- `packages/backend/src/services/note/reaction/create.ts`に短TTL（30秒）のメモリキャッシュを追加し、`instance.maxReactionsPerAccount` の取得を`getMaxReactionsPerAccountByHost`経由で共通化してDBアクセスを低減した。 
- 既存リアクションの参照を`count`＋`findOneByOrFail`の重複から`NoteReactions.find(..., select: ["reaction"])`へ集約して`existCount`と`existingReaction`を同時に取得するよう変更した。 
- ミュート判定の正規化ロジックを`normalizeReactionMuteResult`として切り出し、`checkReactionMute`の結果（boolean / {muted, reject?}）を統一的に扱うようにした。 
- 上限制御の分岐を`evaluateReactionLimit`に抽出して振る舞いを明確化し、1件上限時の置換/重複エラー・複数上限超過エラーの既存挙動を維持した。 
- 不要な`console.log`を削除し、以前はあった`Users.findOneBy({ id: note.userId })`による参照を`note.userHost`の利用により除去した。 
- 単体テストを追加し、`packages/backend/test/reaction-create.ts`でミュート正規化と上限制御のケース（`allow`/`replace`/`duplicate_error`/`limit_error`）を検証するテストを実装した。 

### Testing
- 追加したユニットテストファイル`packages/backend/test/reaction-create.ts`を作成しローカルで`mocha`実行を試みたが、`pnpm --filter backend mocha test/reaction-create.ts`は環境に`cross-env`が存在しないため失敗した。 
- `pnpm install`で依存解決を試したところ、直接依存先の`git+ssh://git@github.com/emtkmkk/mfm.js.git`へSSH接続できず（ネットワーク環境制約）インストールが失敗したためテスト実行は完了していない。 
- 現状の変更はコードベース上で静的に検証済みで、テストは環境依存の問題が解決でき次第`mocha`で実行可能である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da1eb40bc83268f7dfd88a1c87087)