### PR TITLE
backend: note/read の未読件数取得を集約クエリ化し、アンテナ未読集計を一括取得に改善

### DIFF
--- a/packages/backend/src/services/note/read.ts
+++ b/packages/backend/src/services/note/read.ts
@@ -8,12 +8,93 @@ import {
 	Followings,
 	ChannelFollowings,
 } from "@/models/index.js";
-import { Not, IsNull, In } from "typeorm";
+import { In } from "typeorm";
 import type { Channel } from "@/models/entities/channel.js";
 import { checkHitAntenna } from "@/misc/check-hit-antenna.js";
 import { getAntennas } from "@/misc/antenna-cache.js";
 import { readNotificationByQuery } from "@/server/api/common/read-notification.js";
 import type { Packed } from "@/misc/schema.js";
+
+type NoteUnreadCounts = {
+	mentions: number;
+	specified: number;
+	channel: number;
+};
+
+export function getNoteUnreadClearEvents(counts: NoteUnreadCounts) {
+	const events: Array<
+		"readAllUnreadMentions" | "readAllUnreadSpecifiedNotes" | "readAllChannels"
+	> = [];
+
+	if (counts.mentions === 0) {
+		events.push("readAllUnreadMentions");
+	}
+
+	if (counts.specified === 0) {
+		events.push("readAllUnreadSpecifiedNotes");
+	}
+
+	if (counts.channel === 0) {
+		events.push("readAllChannels");
+	}
+
+	return events;
+}
+
+export function getReadAntennaIds(
+	countsByAntennaId: Map<string, number>,
+	antennaIds: string[],
+) {
+	return antennaIds.filter((antennaId) =>
+		(countsByAntennaId.get(antennaId) ?? 0) === 0,
+	);
+}
+
+async function countUnreadNotes(userId: User["id"]): Promise<NoteUnreadCounts> {
+	const rawCounts = await NoteUnreads.createQueryBuilder("noteUnread")
+		.select(
+			"SUM(CASE WHEN noteUnread.isMentioned = true THEN 1 ELSE 0 END)",
+			"mentions",
+		)
+		.addSelect(
+			"SUM(CASE WHEN noteUnread.isSpecified = true THEN 1 ELSE 0 END)",
+			"specified",
+		)
+		.addSelect(
+			"SUM(CASE WHEN noteUnread.noteChannelId IS NOT NULL THEN 1 ELSE 0 END)",
+			"channel",
+		)
+		.where("noteUnread.userId = :userId", { userId })
+		.getRawOne<{ mentions: string | null; specified: string | null; channel: string | null }>();
+
+	return {
+		mentions: Number(rawCounts?.mentions ?? 0),
+		specified: Number(rawCounts?.specified ?? 0),
+		channel: Number(rawCounts?.channel ?? 0),
+	};
+}
+
+async function countUnreadAntennaNotesByAntennaId(antennaIds: string[]) {
+	const countsByAntennaId = new Map<string, number>();
+
+	if (antennaIds.length === 0) {
+		return countsByAntennaId;
+	}
+
+	const rawCounts = await AntennaNotes.createQueryBuilder("antennaNote")
+		.select("antennaNote.antennaId", "antennaId")
+		.addSelect("COUNT(*)", "count")
+		.where("antennaNote.antennaId IN (:...antennaIds)", { antennaIds })
+		.andWhere("antennaNote.read = :read", { read: false })
+		.groupBy("antennaNote.antennaId")
+		.getRawMany<{ antennaId: string; count: string }>();
+
+	for (const rawCount of rawCounts) {
+		countsByAntennaId.set(rawCount.antennaId, Number(rawCount.count));
+	}
+
+	return countsByAntennaId;
+}
 
 /**
  * Mark notes as read
@@ -52,12 +133,12 @@ export default async function (
 		  );
 
 	const myAntennas = (await getAntennas()).filter((a) => a.userId === userId);
-        const readMentions: (Note | Packed<"Note">)[] = [];
-        const readSpecifiedNotes: (Note | Packed<"Note">)[] = [];
-        const readChannelNotes: (Note | Packed<"Note">)[] = [];
-        const readAntennaNotes: (Note | Packed<"Note">)[] = [];
-        const readAntennaNoteIds = new Set<Note["id"]>();
-        const followingArray = Array.from(following);
+	const readMentions: (Note | Packed<"Note">)[] = [];
+	const readSpecifiedNotes: (Note | Packed<"Note">)[] = [];
+	const readChannelNotes: (Note | Packed<"Note">)[] = [];
+	const readAntennaNotes: (Note | Packed<"Note">)[] = [];
+	const readAntennaNoteIds = new Set<Note["id"]>();
+	const followingArray = Array.from(following);
 
 	for (const note of notes) {
 		if (note.mentions?.includes(userId)) {
@@ -70,26 +151,26 @@ export default async function (
 			readChannelNotes.push(note);
 		}
 
-                if (note.user != null && myAntennas.length > 0) {
-                        // たぶんnullになることは無いはずだけど一応
-                        const results = await Promise.all(
-                                myAntennas.map((antenna) =>
-                                        checkHitAntenna(
-                                                antenna,
-                                                note,
-                                                note.user!,
-                                                undefined,
-                                                followingArray,
-                                        ),
-                                ),
-                        );
+		if (note.user != null && myAntennas.length > 0) {
+			// たぶんnullになることは無いはずだけど一応
+			const results = await Promise.all(
+				myAntennas.map((antenna) =>
+					checkHitAntenna(
+						antenna,
+						note,
+						note.user!,
+						undefined,
+						followingArray,
+					),
+				),
+			);
 
-                        if (results.some(Boolean) && !readAntennaNoteIds.has(note.id)) {
-                                readAntennaNoteIds.add(note.id);
-                                readAntennaNotes.push(note);
-                        }
-                }
-        }
+			if (results.some(Boolean) && !readAntennaNoteIds.has(note.id)) {
+				readAntennaNoteIds.add(note.id);
+				readAntennaNotes.push(note);
+			}
+		}
+	}
 
 	if (
 		readMentions.length > 0 ||
@@ -106,37 +187,11 @@ export default async function (
 			]),
 		});
 
-		// TODO: ↓まとめてクエリしたい
+		const unreadCounts = await countUnreadNotes(userId);
 
-		NoteUnreads.countBy({
-			userId: userId,
-			isMentioned: true,
-		}).then((mentionsCount) => {
-			if (mentionsCount === 0) {
-				// 全て既読になったイベントを発行
-				publishMainStream(userId, "readAllUnreadMentions");
-			}
-		});
-
-		NoteUnreads.countBy({
-			userId: userId,
-			isSpecified: true,
-		}).then((specifiedCount) => {
-			if (specifiedCount === 0) {
-				// 全て既読になったイベントを発行
-				publishMainStream(userId, "readAllUnreadSpecifiedNotes");
-			}
-		});
-
-		NoteUnreads.countBy({
-			userId: userId,
-			noteChannelId: Not(IsNull()),
-		}).then((channelNoteCount) => {
-			if (channelNoteCount === 0) {
-				// 全て既読になったイベントを発行
-				publishMainStream(userId, "readAllChannels");
-			}
-		});
+		for (const event of getNoteUnreadClearEvents(unreadCounts)) {
+			publishMainStream(userId, event);
+		}
 
 		readNotificationByQuery(userId, {
 			noteId: In([
@@ -147,9 +202,11 @@ export default async function (
 	}
 
 	if (readAntennaNotes.length > 0) {
+		const myAntennaIds = myAntennas.map((a) => a.id);
+
 		await AntennaNotes.update(
 			{
-				antennaId: In(myAntennas.map((a) => a.id)),
+				antennaId: In(myAntennaIds),
 				noteId: In(readAntennaNotes.map((n) => n.id)),
 			},
 			{
@@ -157,22 +214,16 @@ export default async function (
 			},
 		);
 
-                // TODO: まとめてクエリしたい
-                const antennaCounts = await Promise.all(
-                        myAntennas.map(async (antenna) => ({
-                                antenna,
-                                count: await AntennaNotes.countBy({
-                                        antennaId: antenna.id,
-                                        read: false,
-                                }),
-                        })),
-                );
+		const unreadAntennaCountsById = await countUnreadAntennaNotesByAntennaId(
+			myAntennaIds,
+		);
 
-                for (const { antenna, count } of antennaCounts) {
-                        if (count === 0) {
-                                publishMainStream(userId, "readAntenna", antenna);
-                        }
-                }
+		for (const antennaId of getReadAntennaIds(unreadAntennaCountsById, myAntennaIds)) {
+			const antenna = myAntennas.find((a) => a.id === antennaId);
+			if (antenna != null) {
+				publishMainStream(userId, "readAntenna", antenna);
+			}
+		}
 
 		Users.getHasUnreadAntenna(userId).then((unread) => {
 			if (!unread) {

--- a/packages/backend/test/note-read.ts
+++ b/packages/backend/test/note-read.ts
@@ -1,0 +1,72 @@
+import * as assert from "assert";
+
+import {
+	getNoteUnreadClearEvents,
+	getReadAntennaIds,
+} from "../src/services/note/read.js";
+
+describe("services/note/read", () => {
+	describe("getNoteUnreadClearEvents", () => {
+		it("全ての未読が残っているとイベントを発行しない", () => {
+			assert.deepStrictEqual(
+				getNoteUnreadClearEvents({
+					mentions: 1,
+					specified: 1,
+					channel: 1,
+				}),
+				[],
+			);
+		});
+
+		it("それぞれの未読が0件のときに従来どおりのイベントを返す", () => {
+			assert.deepStrictEqual(
+				getNoteUnreadClearEvents({
+					mentions: 0,
+					specified: 2,
+					channel: 0,
+				}),
+				["readAllUnreadMentions", "readAllChannels"],
+			);
+
+			assert.deepStrictEqual(
+				getNoteUnreadClearEvents({
+					mentions: 2,
+					specified: 0,
+					channel: 3,
+				}),
+				["readAllUnreadSpecifiedNotes"],
+			);
+
+			assert.deepStrictEqual(
+				getNoteUnreadClearEvents({
+					mentions: 0,
+					specified: 0,
+					channel: 0,
+				}),
+				[
+					"readAllUnreadMentions",
+					"readAllUnreadSpecifiedNotes",
+					"readAllChannels",
+				],
+			);
+		});
+	});
+
+	describe("getReadAntennaIds", () => {
+		it("未読0件のアンテナのみ readAntenna 対象として返す", () => {
+			const countsByAntennaId = new Map<string, number>([
+				["antennaA", 2],
+				["antennaB", 0],
+			]);
+
+			assert.deepStrictEqual(
+				getReadAntennaIds(countsByAntennaId, [
+					"antennaA",
+					"antennaB",
+					"antennaC",
+				]),
+				["antennaB", "antennaC"],
+			);
+		});
+	});
+});


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da2084a0483269329e9214b3ff1c9)