### PR TITLE
me API の base/volatile 分離と Redis キャッシュ導入

### DIFF
--- a/packages/backend/src/models/repositories/user.ts
+++ b/packages/backend/src/models/repositories/user.ts
@@ -57,6 +57,10 @@ import {
 } from "../index.js";
 import type { Instance } from "../entities/instance.js";
 import { resolveUser } from "@/remote/resolve-user.js";
+import { redisClient } from "@/db/redis.js";
+
+const ME_DETAILED_BASE_CACHE_TTL_SEC = 60 * 10;
+const ME_DETAILED_VOLATILE_CACHE_TTL_SEC = 30;
 
 const userInstanceCache = new Cache<Instance | null>(1000 * 60 * 60 * 3);
 
@@ -86,6 +90,17 @@ export type UserRelation = {
         isRenoteMuted: boolean;
         isFollowBlocking: boolean;
         isInviter: boolean;
+};
+
+export type MeDetailedVolatile = {
+	hasUnreadSpecifiedNotes: boolean;
+	hasUnreadMentions: boolean;
+	hasUnreadAnnouncement: boolean;
+	hasUnreadAntenna: boolean;
+	hasUnreadChannel: boolean;
+	hasUnreadMessagingMessage: boolean;
+	hasUnreadNotification: boolean;
+	hasPendingReceivedFollowRequest: boolean;
 };
 
 const ajv = new Ajv();
@@ -498,6 +513,71 @@ export const UserRepository = db.getRepository(User).extend({
 		return count > 0;
 	},
 
+	getMeDetailedBaseCacheKey(
+		userId: User["id"],
+		includeSecrets: boolean,
+	): string {
+		return `me:detailed:base:${userId}:${includeSecrets ? "secure" : "public"}`;
+	},
+
+	getMeDetailedVolatileCacheKey(userId: User["id"]): string {
+		return `me:detailed:volatile:${userId}`;
+	},
+
+	async invalidateMeDetailedBaseCache(userId: User["id"]): Promise<void> {
+		await redisClient.del(
+			this.getMeDetailedBaseCacheKey(userId, true),
+			this.getMeDetailedBaseCacheKey(userId, false),
+		);
+	},
+
+	getMeDetailedBaseCacheTtlSec(): number {
+		return ME_DETAILED_BASE_CACHE_TTL_SEC;
+	},
+
+	getMeDetailedVolatileCacheTtlSec(): number {
+		return ME_DETAILED_VOLATILE_CACHE_TTL_SEC;
+	},
+
+	async getMeDetailedVolatile(userId: User["id"]): Promise<MeDetailedVolatile> {
+		const [
+			hasUnreadSpecifiedNotes,
+			hasUnreadMentions,
+			hasUnreadAnnouncement,
+			hasUnreadAntenna,
+			hasUnreadChannel,
+			hasUnreadMessagingMessage,
+			hasUnreadNotification,
+			hasPendingReceivedFollowRequest,
+		] = await Promise.all([
+			NoteUnreads.count({
+				where: { userId, isSpecified: true },
+				take: 1,
+			}).then((count) => count > 0),
+			NoteUnreads.count({
+				where: { userId, isMentioned: true },
+				take: 1,
+			}).then((count) => count > 0),
+			this.getHasUnreadAnnouncement(userId),
+			this.getHasUnreadAntenna(userId),
+			this.getHasUnreadChannel(userId),
+			this.getHasUnreadMessagingMessage(userId),
+			this.getHasUnreadNotification(userId),
+			this.getHasPendingReceivedFollowRequest(userId),
+		]);
+
+		return {
+			hasUnreadSpecifiedNotes,
+			hasUnreadMentions,
+			hasUnreadAnnouncement,
+			hasUnreadAntenna,
+			hasUnreadChannel,
+			hasUnreadMessagingMessage,
+			hasUnreadNotification,
+			hasPendingReceivedFollowRequest,
+		};
+	},
+
         async getOnlineStatus(
                 user: User,
                 meId?: string | null,
@@ -643,12 +723,15 @@ export const UserRepository = db.getRepository(User).extend({
 		const meId = me ? me.id : null;
 		const isMe = meId === user.id;
 
-                const relationHintProvided = hints != null && "relation" in hints;
-                const relation = relationHintProvided
-                        ? hints?.relation ?? null
-                        : meId && !isMe && (opts.detail || opts.relation)
-                        ? await this.getRelation(meId, user.id, user)
-                        : null;
+		const relationHintProvided = hints != null && "relation" in hints;
+		const relation = relationHintProvided
+			? hints?.relation ?? null
+			: meId && !isMe && (opts.detail || opts.relation)
+			? await this.getRelation(meId, user.id, user)
+			: null;
+		const meDetailedVolatile = opts.detail && isMe
+			? await this.getMeDetailedVolatile(user.id)
+			: null;
 		const pins = opts.detail
 			? await UserNotePinings.createQueryBuilder("pin")
 					.where("pin.userId = :userId", { userId: user.id })
@@ -1009,23 +1092,16 @@ export const UserRepository = db.getRepository(User).extend({
 						isRemoteExplorable: user.isRemoteExplorable,
 						isDeleted: user.isDeleted,
 						hideOnlineStatus: user.hideOnlineStatus,
-						hasUnreadSpecifiedNotes: NoteUnreads.count({
-							where: { userId: user.id, isSpecified: true },
-							take: 1,
-						}).then((count) => count > 0),
-						hasUnreadMentions: NoteUnreads.count({
-							where: { userId: user.id, isMentioned: true },
-							take: 1,
-						}).then((count) => count > 0),
-						hasUnreadAnnouncement: this.getHasUnreadAnnouncement(user.id),
-						hasUnreadAntenna: this.getHasUnreadAntenna(user.id),
-						hasUnreadChannel: this.getHasUnreadChannel(user.id),
-						hasUnreadMessagingMessage: this.getHasUnreadMessagingMessage(
-							user.id,
-						),
-						hasUnreadNotification: this.getHasUnreadNotification(user.id),
+						hasUnreadSpecifiedNotes: meDetailedVolatile!.hasUnreadSpecifiedNotes,
+						hasUnreadMentions: meDetailedVolatile!.hasUnreadMentions,
+						hasUnreadAnnouncement: meDetailedVolatile!.hasUnreadAnnouncement,
+						hasUnreadAntenna: meDetailedVolatile!.hasUnreadAntenna,
+						hasUnreadChannel: meDetailedVolatile!.hasUnreadChannel,
+						hasUnreadMessagingMessage:
+							meDetailedVolatile!.hasUnreadMessagingMessage,
+						hasUnreadNotification: meDetailedVolatile!.hasUnreadNotification,
 						hasPendingReceivedFollowRequest:
-							this.getHasPendingReceivedFollowRequest(user.id),
+							meDetailedVolatile!.hasPendingReceivedFollowRequest,
 						integrations: profile!.integrations,
 						mutedWords: profile!.mutedWords,
 						rejectMuteReaction: profile!.rejectMuteReaction,

--- a/packages/backend/src/server/api/endpoints/i.ts
+++ b/packages/backend/src/server/api/endpoints/i.ts
@@ -1,5 +1,18 @@
+import { redisClient } from "@/db/redis.js";
 import { Users } from "@/models/index.js";
+import type { MeDetailedVolatile } from "@/models/repositories/user.js";
 import define from "../define.js";
+
+const meDetailedVolatileKeys = [
+	"hasUnreadSpecifiedNotes",
+	"hasUnreadMentions",
+	"hasUnreadAnnouncement",
+	"hasUnreadAntenna",
+	"hasUnreadChannel",
+	"hasUnreadMessagingMessage",
+	"hasUnreadNotification",
+	"hasPendingReceivedFollowRequest",
+] as const;
 
 export const meta = {
 	tags: ["account"],
@@ -20,12 +33,79 @@ export const paramDef = {
 	required: [],
 } as const;
 
+function extractMeDetailedVolatile(src: Record<string, unknown>): MeDetailedVolatile {
+	return {
+		hasUnreadSpecifiedNotes: Boolean(src.hasUnreadSpecifiedNotes),
+		hasUnreadMentions: Boolean(src.hasUnreadMentions),
+		hasUnreadAnnouncement: Boolean(src.hasUnreadAnnouncement),
+		hasUnreadAntenna: Boolean(src.hasUnreadAntenna),
+		hasUnreadChannel: Boolean(src.hasUnreadChannel),
+		hasUnreadMessagingMessage: Boolean(src.hasUnreadMessagingMessage),
+		hasUnreadNotification: Boolean(src.hasUnreadNotification),
+		hasPendingReceivedFollowRequest: Boolean(src.hasPendingReceivedFollowRequest),
+	};
+}
+
+function createMeDetailedBase(src: Record<string, unknown>): Record<string, unknown> {
+	const base = { ...src };
+
+	for (const key of meDetailedVolatileKeys) {
+		delete base[key];
+	}
+
+	return base;
+}
+
 export default define(meta, paramDef, async (ps, user, token) => {
 	const isSecure = token == null;
+	const userId = user.id;
 
-	// ここで渡ってきている user はキャッシュされていて古い可能性もあるので id だけ渡す
-	return await Users.pack<true, true>(user.id, user, {
-		detail: true,
-		includeSecrets: isSecure,
-	});
+	const baseCacheKey = Users.getMeDetailedBaseCacheKey(userId, isSecure);
+	const volatileCacheKey = Users.getMeDetailedVolatileCacheKey(userId);
+
+	let base: Record<string, unknown> | null = null;
+	const baseCache = await redisClient.get(baseCacheKey);
+
+	if (baseCache != null) {
+		base = JSON.parse(baseCache) as Record<string, unknown>;
+	}
+
+	if (base == null) {
+		const me = (await Users.pack<true, true>(userId, user, {
+			detail: true,
+			includeSecrets: isSecure,
+		})) as unknown as Record<string, unknown>;
+		base = createMeDetailedBase(me);
+
+		await redisClient.set(
+			baseCacheKey,
+			JSON.stringify(base),
+			"EX",
+			Users.getMeDetailedBaseCacheTtlSec(),
+		);
+	}
+
+	let volatile: MeDetailedVolatile | null = null;
+	const volatileCache = await redisClient.get(volatileCacheKey);
+
+	if (volatileCache != null) {
+		volatile = extractMeDetailedVolatile(
+			JSON.parse(volatileCache) as Record<string, unknown>,
+		);
+	}
+
+	if (volatile == null) {
+		volatile = await Users.getMeDetailedVolatile(userId);
+		await redisClient.set(
+			volatileCacheKey,
+			JSON.stringify(volatile),
+			"EX",
+			Users.getMeDetailedVolatileCacheTtlSec(),
+		);
+	}
+
+	return {
+		...base,
+		...volatile,
+	};
 });

--- a/packages/backend/src/server/api/endpoints/i/update.ts
+++ b/packages/backend/src/server/api/endpoints/i/update.ts
@@ -487,6 +487,8 @@ export default define(meta, paramDef, async (ps, _user, token) => {
 		verifiedLinks: [],
 	});
 
+	await Users.invalidateMeDetailedBaseCache(user.id);
+
 	const updatedProfile = await UserProfiles.findOneByOrFail({ userId: user.id });
 
 	const iObj = await Users.pack<true, true>(user.id, user, {


### PR DESCRIPTION
### Motivation

- `me`（`/api/i`）レスポンスを更新頻度の低い `base` と高頻度で変化する `volatile` に分離して、`base` を長めTTL、`volatile` を短めTTLで Redis に保存・合成することで再計算コストと DB 負荷を下げるための変更です。 
- `includeSecrets` 別に `base` キャッシュキーを分離して権限差による混在を防止する意図です。 
- 段階導入を想定しつつ、まず `base` の Redis キャッシュ化を行い、`volatile` は短TTLで別途算出・キャッシュする方式を採っています（今回の実装は両方の扱いを含みます）。

### Description

- `packages/backend/src/models/repositories/user.ts` に以下を追加・変更しました。  
  - `MeDetailedVolatile` 型を追加し、未読等の高頻度項目をまとめた型を定義。  
  - Redis 利用のために `redisClient` を取り込み、`ME_DETAILED_BASE_CACHE_TTL_SEC`（600秒）と `ME_DETAILED_VOLATILE_CACHE_TTL_SEC`（30秒）定数を追加。  
  - `me` 用ユーティリティを追加：`getMeDetailedBaseCacheKey` / `getMeDetailedVolatileCacheKey` / `getMeDetailedBaseCacheTtlSec` / `getMeDetailedVolatileCacheTtlSec` / `invalidateMeDetailedBaseCache` / `getMeDetailedVolatile` を実装。  
  - `Users.pack` 内で自分（`me`）向け詳細生成時に既存の個別未読クエリを直接呼ぶのではなく、`getMeDetailedVolatile`（共通ロジック）を用いて volatile 値を組み込むように切り替えました。

- `packages/backend/src/server/api/endpoints/i.ts`（`/api/i` の `me` エンドポイント）を変更しました。  
  - レスポンスを `base`（更新頻度低、長TTL）と `volatile`（未読等、高頻度、短TTL）に分け、処理フローは `base` を Redis から取得（なければ `Users.pack` で生成して Redis に保存）、`volatile` を Redis から取得（なければ `Users.getMeDetailedVolatile` で生成して保存）、最後に合成して返却するようにしました。  
  - `base` からは `volatile` に該当するキー群を取り除いて保存するようにしています。

- `packages/backend/src/server/api/endpoints/i/update.ts`（プロフィール更新）を変更しました。  
  - プロフィール更新後に `await Users.invalidateMeDetailedBaseCache(user.id)` を呼び、`base` キャッシュを明示的に無効化するようにしました。

### Testing

- 自動チェックとして `pnpm -C packages/backend run lint -- src/models/repositories/user.ts src/server/api/endpoints/i.ts src/server/api/endpoints/i/update.ts` を実行しましたが、CI 環境側のローカル `node_modules` 未展開により `rome` が見つからず実行できませんでした（実行不可／環境要因で失敗）。
- そのほか、変更はローカルでビルドや統合テストは実行していません（今回の差分は Redis 依存・ランタイム動作に関わるため、実運用前にステージ環境での動作確認を推奨します）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da89289e4832698ff8058095a4fb7)