### PR TITLE
fix(backend): 認証での存在しない `onlineStatus` 選択を削除

### DIFF
--- a/packages/backend/src/server/api/authenticate.ts
+++ b/packages/backend/src/server/api/authenticate.ts
@@ -21,7 +21,6 @@ const AUTH_USER_SELECT = {
 	isSuspended: true,
 	isAdmin: true,
 	isModerator: true,
-	onlineStatus: true,
 } as const;
 
 export default async (


### PR DESCRIPTION
### Motivation
- `Users.findOne` の `select` に存在しない `onlineStatus` が含まれており、`EntityPropertyNotFoundError: Property "onlineStatus" was not found in "User"` を発生させていたため修正します。

### Description
- `packages/backend/src/server/api/authenticate.ts` の `AUTH_USER_SELECT` から `onlineStatus` を削除し、既存の `id`, `host`, `isSuspended`, `isAdmin`, `isModerator` は維持しました。

### Testing
- `pnpm --filter backend run build` を実行しましたが、環境に依存する `napi` が見つからず `napi: not found` によりビルドは失敗しました（依存未導入による失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db397281c8326a919437365ffbca6)