### PR TITLE
RedisキャッシュTTLの見直し（未設定キーの期限追加とuser-cache延長）

### DIFF
--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -35,7 +35,7 @@ export async function readAllNotifications(
 	userId: User["id"],
 	latestNotificationId: Notification["id"],
 ) {
-	await redisClient.set(`latestReadNotification:${userId}`, latestNotificationId);
+	await redisClient.set(`latestReadNotification:${userId}`, latestNotificationId, "EX", 86400);
 
 	const result = await Notifications.update(
 		{

--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -102,7 +102,7 @@ router.get("/connect/discord", async (ctx) => {
 		response_type: "code",
 	};
 
-	redisClient.set(userToken, JSON.stringify(params));
+	redisClient.set(userToken, JSON.stringify(params), "EX", 600);
 
 	const oauth2 = await getOAuth2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
@@ -124,7 +124,7 @@ router.get("/signin/discord", async (ctx) => {
 		httpOnly: true,
 	});
 
-	redisClient.set(sessid, JSON.stringify(params));
+	redisClient.set(sessid, JSON.stringify(params), "EX", 600);
 
 	const oauth2 = await getOAuth2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));

--- a/packages/backend/src/services/user-cache.ts
+++ b/packages/backend/src/services/user-cache.ts
@@ -9,7 +9,7 @@ import { Cache } from "@/misc/cache.js";
 import { redisClient, subscriber } from "@/db/redis.js";
 
 const LOCAL_MAP_TTL_MS = 30 * 1000;
-const USER_CACHE_REDIS_TTL_SEC = 60;
+const USER_CACHE_REDIS_TTL_SEC = 120;
 
 const USER_BY_ID_REDIS_KEY_PREFIX = "user-cache:user-by-id";
 const LOCAL_USER_BY_NATIVE_TOKEN_REDIS_KEY_PREFIX =


### PR DESCRIPTION
### Motivation
- RedisにTTLが設定されていなかった一時キーの自動削除と、`user-cache` 系TTLの調整による運用安定化とキャッシュヒット率向上を目的としています。

### Description
- `packages/backend/src/services/user-cache.ts` で `USER_CACHE_REDIS_TTL_SEC` を `60` 秒から `120` 秒に変更しました。
- `packages/backend/src/server/api/service/discord.ts` で Discord OAuth 用の一時キー保存に `EX 600`（600秒）を追加して期限未設定を解消しました（`userToken` と `sessid`）。
- `packages/backend/src/server/api/common/read-notification.ts` で `latestReadNotification:{userId}` 保存時に `EX 86400`（24時間）を追加して永続化を防止しました。

### Testing
- `git diff` で対象ファイルの差分を確認済み（変更は 3 ファイル、TTL の追加と定数の更新）。
- 変更をコミット済み（コミットメッセージ: `Adjust Redis TTLs for user cache and temporary keys`）。
- `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが、環境側で `@types/node` が見つからず型チェックが失敗しました（テスト実行環境依存のためプロジェクト構成に問題は無い想定）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db5976f4c8326bb88990ec0e16b7f)