### PR TITLE
AP配信をノート作成APIから非同期ジョブへ移管し、配信メトリクスを分離

### DIFF
--- a/packages/backend/src/queue/index.ts
+++ b/packages/backend/src/queue/index.ts
@@ -14,6 +14,7 @@ import processObjectStorage from "./processors/object-storage/index.js";
 import processSystemQueue from "./processors/system/index.js";
 import processWebhookDeliver from "./processors/webhook-deliver.js";
 import processBackground from "./processors/background/index.js";
+import processNoteApDeliver from "./processors/note-ap-deliver.js";
 import { endedPollNotification } from "./processors/ended-poll-notification.js";
 import { queueLogger } from "./logger.js";
 import { getJobInfo } from "./get-job-info.js";
@@ -26,8 +27,9 @@ import {
 	endedPollNotificationQueue,
 	webhookDeliverQueue,
 	backgroundQueue,
+	noteApDeliverQueue,
 } from "./queues.js";
-import type { ThinUser } from "./types.js";
+import type { NoteApDeliverJobData, ThinUser } from "./types.js";
 
 function renderError(e: Error): any {
 	return {
@@ -43,6 +45,7 @@ const webhookLogger = queueLogger.createSubLogger("webhook");
 const inboxLogger = queueLogger.createSubLogger("inbox");
 const dbLogger = queueLogger.createSubLogger("db");
 const objectStorageLogger = queueLogger.createSubLogger("objectStorage");
+const noteApDeliverLogger = queueLogger.createSubLogger("noteApDeliver");
 
 systemQueue
 	.on("waiting", (jobId) => systemLogger.debug(`waiting id=${jobId}`))
@@ -155,6 +158,24 @@ webhookDeliverQueue
 	)
 	.on("stalled", (job) =>
 		webhookLogger.warn(`stalled ${getJobInfo(job)} to=${job.data.to}`),
+	);
+
+noteApDeliverQueue
+	.on("waiting", (jobId) => noteApDeliverLogger.debug(`waiting id=${jobId}`))
+	.on("active", (job) =>
+		noteApDeliverLogger.debug(`active ${getJobInfo(job, true)}`),
+	)
+	.on("completed", (job, result) =>
+		noteApDeliverLogger.debug(`completed(${result}) ${getJobInfo(job, true)}`),
+	)
+	.on("failed", (job, err) =>
+		noteApDeliverLogger.warn(`failed(${err}) ${getJobInfo(job)}`),
+	)
+	.on("error", (job: any, err: Error) =>
+		noteApDeliverLogger.error(`error ${err}`, { job, e: renderError(err) }),
+	)
+	.on("stalled", (job) =>
+		noteApDeliverLogger.warn(`stalled ${getJobInfo(job)}`),
 	);
 
 export function deliver(
@@ -447,6 +468,18 @@ export function createIndexAllNotesJob(data = {}) {
 	});
 }
 
+export function createNoteApDeliverJob(data: NoteApDeliverJobData) {
+	return noteApDeliverQueue.add(data, {
+		attempts: config.deliverJobMaxAttempts || 12,
+		timeout: 1 * 60 * 1000,
+		backoff: {
+			type: "apBackoff",
+		},
+		removeOnComplete: true,
+		removeOnFail: true,
+	});
+}
+
 export function webhookDeliver(
 	webhook: Webhook,
 	type: typeof webhookEventTypes[number],
@@ -481,6 +514,7 @@ export default function () {
 	inboxQueue.process(config.inboxJobConcurrency || 16, processInbox);
 	endedPollNotificationQueue.process(endedPollNotification);
 	webhookDeliverQueue.process(64, processWebhookDeliver);
+	noteApDeliverQueue.process(config.deliverJobConcurrency || 128, processNoteApDeliver);
 	processDb(dbQueue);
 	processObjectStorage(objectStorageQueue);
 	processBackground(backgroundQueue);

--- a/packages/backend/src/queue/processors/note-ap-deliver.ts
+++ b/packages/backend/src/queue/processors/note-ap-deliver.ts
@@ -1,0 +1,10 @@
+import type Bull from "bull";
+import type { NoteApDeliverJobData } from "../types.js";
+import { processNoteApDeliverJob } from "@/services/note/ap-deliver.js";
+
+export default async function processNoteApDeliver(
+	job: Bull.Job<NoteApDeliverJobData>,
+) {
+	await processNoteApDeliverJob(job.data);
+	return "Success";
+}

--- a/packages/backend/src/queue/queues.ts
+++ b/packages/backend/src/queue/queues.ts
@@ -7,6 +7,7 @@ import type {
 	ObjectStorageJobData,
 	EndedPollNotificationJobData,
 	WebhookDeliverJobData,
+	NoteApDeliverJobData,
 } from "./types.js";
 
 export const systemQueue = initializeQueue<Record<string, unknown>>("system");
@@ -28,6 +29,9 @@ export const webhookDeliverQueue = initializeQueue<WebhookDeliverJobData>(
 	32,
 );
 export const backgroundQueue = initializeQueue<Record<string, unknown>>("bg");
+export const noteApDeliverQueue = initializeQueue<NoteApDeliverJobData>(
+	"noteApDeliver",
+);
 
 export const queues = [
 	systemQueue,
@@ -38,4 +42,5 @@ export const queues = [
 	objectStorageQueue,
 	webhookDeliverQueue,
 	backgroundQueue,
+	noteApDeliverQueue,
 ];

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -74,6 +74,7 @@ export type WebhookDeliverJobData = {
 export type NoteApDeliverJobData = {
 	noteId: Note["id"];
 	queuedAt: number;
+	sameRenoteCount?: number | null;
 };
 
 export type ThinUser = {

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -71,6 +71,11 @@ export type WebhookDeliverJobData = {
 	eventId: string;
 };
 
+export type NoteApDeliverJobData = {
+	noteId: Note["id"];
+	queuedAt: number;
+};
+
 export type ThinUser = {
 	id: User["id"];
 };

--- a/packages/backend/src/services/note/ap-deliver.ts
+++ b/packages/backend/src/services/note/ap-deliver.ts
@@ -1,0 +1,245 @@
+import DeliverManager, { deliverToInboxes } from "@/remote/activitypub/deliver-manager.js";
+import renderNote from "@/remote/activitypub/renderer/note.js";
+import renderCreate from "@/remote/activitypub/renderer/create.js";
+import renderAnnounce from "@/remote/activitypub/renderer/announce.js";
+import { renderLike } from "@/remote/activitypub/renderer/like.js";
+import { renderActivity } from "@/remote/activitypub/renderer/index.js";
+import config from "@/config/index.js";
+import { countSameRenotes } from "@/misc/count-same-renotes.js";
+import { deliverToRelays } from "./relay.js";
+import { decodeReaction, resolveApReaction } from "@/misc/reaction-lib.js";
+import { buildReactionDeliverManager } from "@/services/note/reaction/deliver.js";
+import { Emojis, NoteReactions, Notes, Users } from "@/models/index.js";
+import { IsNull } from "typeorm";
+import type { ILocalUser, User } from "@/models/entities/user.js";
+import type { NoteReaction } from "@/models/entities/note-reaction.js";
+import type { Note } from "@/models/entities/note.js";
+import type { NoteApDeliverJobData } from "@/queue/types.js";
+
+export async function processNoteApDeliverJob(data: NoteApDeliverJobData) {
+	const startedAt = Date.now();
+	console.log(
+		`[note-deliver-metric] queue_delay_ms=${startedAt - data.queuedAt} note=${data.noteId}`,
+	);
+
+	const note = await Notes.findOne({
+		where: { id: data.noteId },
+		relations: ["user", "reply", "renote"],
+	});
+	if (!note || !note.user || !Users.isLocalUser(note.user)) return;
+
+	const noteActivity = await renderNoteOrRenoteActivityFromNote(note);
+	if (!noteActivity) {
+		console.log(`[reaction-resend] skip: noteActivity is null (note=${note.id})`);
+		return;
+	}
+
+	const dm = new DeliverManager(note.user, noteActivity);
+	await addNoteActivityDeliveryRecipes(dm, note);
+
+	const noteInboxes = await dm.collectInboxes();
+	console.log(
+		`[reaction-resend] noteInboxes collected: ${noteInboxes.size} (note=${note.id})`,
+	);
+	await deliverToInboxes(note.user, noteActivity, noteInboxes);
+
+	if (note.renote) {
+		const sameRenoteCount = await countSameRenotes(
+			note.user.id,
+			note.renote.id,
+			note.id,
+		);
+		console.log(
+			`[reaction-resend] renote detected: countSameRenotes=${sameRenoteCount} (note=${note.id}, renote=${note.renote.id})`,
+		);
+		if (sameRenoteCount === 0) {
+			await delayReactionResend();
+			await resendLocalReactionsForRenote(note.renote, noteInboxes);
+		} else {
+			console.log(
+				`[reaction-resend] skip: countSameRenotes is not zero (note=${note.id}, renote=${note.renote.id})`,
+			);
+		}
+	}
+
+	if (["public"].includes(note.visibility)) {
+		deliverToRelays(note.user, noteActivity);
+	}
+
+	console.log(
+		`[note-deliver-metric] deliver_duration_ms=${Date.now() - startedAt} note=${note.id}`,
+	);
+}
+
+async function renderNoteOrRenoteActivityFromNote(note: Note) {
+	if (note.localOnly && note.channelId) return null;
+	if (note.renote?.userId !== note.userId && note.renote?.localOnly) return null;
+
+	const content =
+		note.renote &&
+		note.text == null &&
+		!note.hasPoll &&
+		note.fileIds.length === 0
+			? renderAnnounce(
+					note.renote.uri
+						? note.renote.uri
+						: `${config.url}/notes/${note.renote.id}`,
+					note,
+			  )
+			: renderCreate(await renderNote(note, false), note);
+
+	return renderActivity(content);
+}
+
+async function addNoteActivityDeliveryRecipes(dm: DeliverManager, note: Note) {
+	if (note.visibility === "specified") {
+		for (const u of await Users.findBy({ id: note.visibleUserIds as User["id"][] })) {
+			if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+		}
+	}
+
+	const mentionedUsers = await Users.findBy({ id: note.mentions as User["id"][] });
+	for (const u of mentionedUsers) {
+		if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	}
+
+	if (note.reply && note.reply.userHost !== null) {
+		const u = await Users.findOneBy({ id: note.reply.userId });
+		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	}
+
+	if (note.renote && note.renote.userHost !== null) {
+		const u = await Users.findOneBy({ id: note.renote.userId });
+		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	}
+
+	if (["public", "home", "followers"].includes(note.visibility)) {
+		if (note.reply && note.reply.userId === note.userId && note.reply.replyId) {
+			if (
+				note.reply.replyUserId !== note.userId &&
+				note.reply.replyUserHost === null
+			) {
+				console.log(`reReply deliver : ${note.reply.replyId}`);
+				const u = await Users.findOneBy({ id: note.reply.replyUserId });
+				dm.addFollowersRecipe(u as ILocalUser);
+			} else {
+				console.log(`reReply deliver : ${note.reply.replyId}`);
+				dm.addFollowersRecipe();
+			}
+		} else if (
+			note.reply &&
+			note.reply.userId !== note.userId &&
+			note.reply.userHost === null
+		) {
+			console.log(`reply deliver : ${note.reply.id}`);
+			const u = await Users.findOneBy({ id: note.reply.userId });
+			dm.addFollowersRecipe(u as ILocalUser);
+		} else {
+			dm.addFollowersRecipe();
+		}
+	}
+}
+
+async function getReactionEmojiMap(reactions: NoteReaction[]) {
+	const emojiKeys = new Map<string, { name: string; host: string | null }>();
+
+	for (const reaction of reactions) {
+		const decoded = decodeReaction(reaction.reaction);
+		if (!decoded.name) continue;
+		const host = decoded.host ?? null;
+		const key = `${decoded.name}@${host ?? ""}`;
+		if (!emojiKeys.has(key)) {
+			emojiKeys.set(key, { name: decoded.name, host });
+		}
+	}
+
+	if (emojiKeys.size === 0) return new Map();
+
+	const emojis = await Emojis.find({
+		where: Array.from(emojiKeys.values()).map((entry) => ({
+			name: entry.name,
+			host: entry.host ?? IsNull(),
+		})),
+		select: ["name", "host", "license"],
+	});
+
+	return new Map(emojis.map((emoji) => [`${emoji.name}@${emoji.host ?? ""}`, emoji]));
+}
+
+async function resendLocalReactionsForRenote(
+	renote: Note,
+	noteInboxes: Map<string, boolean>,
+) {
+	if (noteInboxes.size === 0) {
+		console.log(
+			`[reaction-resend] skip: noteInboxes is empty (renote=${renote.id})`,
+		);
+		return;
+	}
+
+	const reactions = await NoteReactions.createQueryBuilder("reaction")
+		.leftJoinAndSelect("reaction.user", "user")
+		.where("reaction.noteId = :noteId", { noteId: renote.id })
+		.andWhere("user.host IS NULL")
+		.orderBy("reaction.createdAt", "DESC")
+		.addOrderBy("reaction.id", "DESC")
+		.getMany();
+
+	if (reactions.length === 0) {
+		console.log(
+			`[reaction-resend] skip: no local reactions (renote=${renote.id})`,
+		);
+		return;
+	}
+	const latestReactionsByUser = new Map<string, NoteReaction>();
+	for (const reaction of reactions) {
+		if (!latestReactionsByUser.has(reaction.userId)) {
+			latestReactionsByUser.set(reaction.userId, reaction);
+		}
+	}
+
+	const latestReactions = Array.from(latestReactionsByUser.values());
+	console.log(
+		`[reaction-resend] local reactions: ${latestReactions.length} (renote=${renote.id})`,
+	);
+
+	const emojiMap = await getReactionEmojiMap(latestReactions);
+
+	for (const reaction of latestReactions) {
+		const reactionUser = reaction.user;
+		if (!reactionUser || reactionUser.host !== null) continue;
+
+		const decoded = decodeReaction(reaction.reaction);
+		const emojiKey = decoded.name
+			? `${decoded.name}@${decoded.host ?? ""}`
+			: null;
+		const emoji = emojiKey ? emojiMap.get(emojiKey) : null;
+		const deliverReaction = await resolveApReaction(reaction.reaction, emoji);
+		const deliverRecord = {
+			...reaction,
+			reaction: deliverReaction,
+		} as NoteReaction;
+
+		const activity = renderActivity(await renderLike(deliverRecord, renote));
+		const dm = await buildReactionDeliverManager(
+			reactionUser,
+			renote,
+			activity,
+			{ disableUnion: true },
+		);
+		const reactionInboxes = await dm.collectInboxes();
+		console.log(
+			`[reaction-resend] deliver reaction: reactionInboxes=${reactionInboxes.size} (renote=${renote.id}, reaction=${reaction.id})`,
+		);
+
+		await deliverToInboxes(
+			reactionUser as ILocalUser,
+			activity,
+			reactionInboxes,
+		);
+	}
+}
+
+async function delayReactionResend() {
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+}

--- a/packages/backend/src/services/note/ap-deliver.ts
+++ b/packages/backend/src/services/note/ap-deliver.ts
@@ -44,11 +44,13 @@ export async function processNoteApDeliverJob(data: NoteApDeliverJobData) {
 	await deliverToInboxes(note.user, noteActivity, noteInboxes);
 
 	if (note.renote) {
-		const sameRenoteCount = await countSameRenotes(
-			note.user.id,
-			note.renote.id,
-			note.id,
-		);
+		const sameRenoteCount =
+			data.sameRenoteCount ??
+			(await countSameRenotes(
+				note.user.id,
+				note.renote.id,
+				note.id,
+			));
 		console.log(
 			`[reaction-resend] renote detected: countSameRenotes=${sameRenoteCount} (note=${note.id}, renote=${note.renote.id})`,
 		);

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -1006,13 +1006,14 @@ export default async (
 			saveReply(data.reply, note);
 		}
 
+		let sameRenoteCount: number | null = null;
+
 		// この投稿を除く指定したユーザーによる指定したノートのリノートが存在しないとき
-		if (
-			data.renote &&
-			!user.isBot &&
-			(await countSameRenotes(user.id, data.renote.id, note.id)) === 0
-		) {
-			incRenoteCount(data.renote, user.host);
+		if (data.renote && !user.isBot) {
+			sameRenoteCount = await countSameRenotes(user.id, data.renote.id, note.id);
+			if (sameRenoteCount === 0) {
+				incRenoteCount(data.renote, user.host);
+			}
 		}
 
 		if (data.poll?.expiresAt) {
@@ -1162,7 +1163,11 @@ export default async (
 
 			//#region AP deliver
 			if (Users.isLocalUser(user) && !dontFederateInitially) {
-				createNoteApDeliverJob({ noteId: note.id, queuedAt: Date.now() });
+				createNoteApDeliverJob({
+					noteId: note.id,
+					queuedAt: Date.now(),
+					sameRenoteCount,
+				});
 			}
 			//#endregion
 		}

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -7,13 +7,8 @@ import {
 	publishNoteStream,
 } from "@/services/stream.js";
 import DeliverManager, {
-	deliverToInboxes,
 	deliverToUser,
 } from "@/remote/activitypub/deliver-manager.js";
-import renderNote from "@/remote/activitypub/renderer/note.js";
-import renderCreate from "@/remote/activitypub/renderer/create.js";
-import renderAnnounce from "@/remote/activitypub/renderer/announce.js";
-import { renderLike } from "@/remote/activitypub/renderer/like.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import { resolveUser } from "@/remote/resolve-user.js";
 import config from "@/config/index.js";
@@ -32,7 +27,7 @@ import {
         Users,
         NoteWatchings,
 	Notes,
-	NoteReactions,
+
 	Instances,
 	UserProfiles,
 	Antennas,
@@ -42,7 +37,7 @@ import {
 	ChannelFollowings,
 	Blockings,
 	NoteThreadMutings,
-	Emojis,
+
 } from "@/models/index.js";
 import type { DriveFile } from "@/models/entities/drive-file.js";
 import type { App } from "@/models/entities/app.js";
@@ -62,14 +57,12 @@ import { isDuplicateKeyValueError } from "@/misc/is-duplicate-key-value-error.js
 import { checkHitAntenna } from "@/misc/check-hit-antenna.js";
 import { getWordHardMute } from "@/misc/check-word-mute.js";
 import { addNoteToAntenna } from "../add-note-to-antenna.js";
-import { countSameRenotes } from "@/misc/count-same-renotes.js";
-import { deliverToRelays } from "../relay.js";
 import { isIncludeNgWordIsNote } from "@/misc/is-include-ng-word.js";
 import type { Channel } from "@/models/entities/channel.js";
 import { normalizeForSearch } from "@/misc/normalize-for-search.js";
 import { getAntennas } from "@/misc/antenna-cache.js";
 import { endedPollNotificationQueue } from "@/queue/queues.js";
-import { webhookDeliver } from "@/queue/index.js";
+import { createNoteApDeliverJob, webhookDeliver } from "@/queue/index.js";
 import { Cache } from "@/misc/cache.js";
 import type { UserProfile } from "@/models/entities/user-profile.js";
 import { db } from "@/db/postgre.js";
@@ -79,9 +72,6 @@ import renderDelete from "@/remote/activitypub/renderer/delete.js";
 import renderTombstone from "@/remote/activitypub/renderer/tombstone.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import { StatusError } from "@/misc/fetch.js";
-import { decodeReaction, resolveApReaction } from "@/misc/reaction-lib.js";
-import { buildReactionDeliverManager } from "@/services/note/reaction/deliver.js";
-import type { NoteReaction } from "@/models/entities/note-reaction.js";
 
 const mutedWordsCache = new Cache<
 	{ userId: UserProfile["userId"]; mutedWords: UserProfile["mutedWords"] }[]
@@ -219,6 +209,8 @@ export default async (
 ) =>
 	// rome-ignore lint/suspicious/noAsyncPromiseExecutor: FIXME
 	new Promise<Note>(async (res, rej) => {
+		const apiStartedAt = Date.now();
+
 		// 最初に投稿時刻を確定させる
 		if (data.createdAt == null) data.createdAt = new Date();
 
@@ -919,6 +911,7 @@ export default async (
 		}
 
 		if (firstVisibility != note.visibility) console.log(`${note.id}:可視性変更 ${firstVisibility} -> ${note.visibility}`);
+		console.log(`[note-deliver-metric] api_response_ms=${Date.now() - apiStartedAt} note=${note.id}`);
 
 		res(note);
 
@@ -1169,53 +1162,7 @@ export default async (
 
 			//#region AP deliver
 			if (Users.isLocalUser(user) && !dontFederateInitially) {
-				(async () => {
-					const noteActivity = await renderNoteOrRenoteActivity(data, note);
-					if (!noteActivity) {
-						console.log(
-							`[reaction-resend] skip: noteActivity is null (note=${note.id})`,
-						);
-						return;
-					}
-
-					const dm = new DeliverManager(user, noteActivity);
-					await addNoteActivityDeliveryRecipes(dm, {
-						data,
-						note,
-						mentionedUsers,
-						user,
-					});
-
-					const noteInboxes = await dm.collectInboxes();
-					console.log(
-						`[reaction-resend] noteInboxes collected: ${noteInboxes.size} (note=${note.id})`,
-					);
-					await deliverToInboxes(user, noteActivity, noteInboxes);
-
-					if (data.renote) {
-						const sameRenoteCount = await countSameRenotes(
-							user.id,
-							data.renote.id,
-							note.id,
-						);
-						console.log(
-							`[reaction-resend] renote detected: countSameRenotes=${sameRenoteCount} (note=${note.id}, renote=${data.renote.id})`,
-						);
-						if (sameRenoteCount === 0) {
-							await delayReactionResend();
-							await resendLocalReactionsForRenote(data.renote, noteInboxes);
-						} else {
-							console.log(
-								`[reaction-resend] skip: countSameRenotes is not zero (note=${note.id}, renote=${data.renote.id})`,
-							);
-						}
-					}
-
-					//リレーに配送
-					if (["public"].includes(note.visibility)) {
-						deliverToRelays(user, noteActivity);
-					}
-				})();
+				createNoteApDeliverJob({ noteId: note.id, queuedAt: Date.now() });
 			}
 			//#endregion
 		}
@@ -1274,194 +1221,6 @@ export async function appendNoteVisibleUser(
 	// ストリームに流す
 	const noteObj = await Notes.pack(note, null);
 	publishNotesStream(noteObj);
-}
-
-async function addNoteActivityDeliveryRecipes(
-	dm: DeliverManager,
-	params: {
-		data: Option;
-		note: Note;
-		mentionedUsers: MinimumUser[];
-		user: { id: User["id"]; host: User["host"] };
-	},
-) {
-	const { data, note, mentionedUsers, user } = params;
-
-	// メンションされたリモートユーザーに配送
-	for (const u of mentionedUsers.filter((u) => Users.isRemoteUser(u))) {
-		dm.addDirectRecipe(u as IRemoteUser);
-	}
-
-	// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
-	if (data.reply && data.reply.userHost !== null) {
-		const u = await Users.findOneBy({ id: data.reply.userId });
-		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
-	}
-
-	// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
-	if (data.renote && data.renote.userHost !== null) {
-		const u = await Users.findOneBy({ id: data.renote.userId });
-		if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
-	}
-
-	// フォロワーに配送
-	if (["public", "home", "followers"].includes(note.visibility)) {
-		if (data.reply && data.reply.userId === user.id && data.reply.replyId) {
-			// 自己リプライでリプライのリプライがある場合
-			// リプライのリプライが自分ではない場合
-			if (data.reply.replyUserId !== user.id && data.reply.replyUserHost === null) {
-				console.log(`reReply deliver : ${data.reply.replyId}`);
-				const u = await Users.findOneBy({ id: data.reply.replyUserId });
-				dm.addFollowersRecipe(u as ILocalUser);
-			} else {
-				console.log(`reReply deliver : ${data.reply.replyId}`);
-				// リプライのリプライが自分の場合
-				dm.addFollowersRecipe();
-			}
-		} else if (
-			data.reply &&
-			data.reply.userId !== user.id &&
-			data.reply.userHost === null
-		) {
-			console.log(`reply deliver : ${data.reply.id}`);
-			// 他人宛のリプライがある場合
-			const u = await Users.findOneBy({ id: data.reply.userId });
-			dm.addFollowersRecipe(u as ILocalUser);
-		} else {
-			dm.addFollowersRecipe();
-		}
-	}
-}
-
-async function getReactionEmojiMap(reactions: NoteReaction[]) {
-	const emojiKeys = new Map<string, { name: string; host: string | null }>();
-
-	for (const reaction of reactions) {
-		const decoded = decodeReaction(reaction.reaction);
-		if (!decoded.name) continue;
-		const host = decoded.host ?? null;
-		const key = `${decoded.name}@${host ?? ""}`;
-		if (!emojiKeys.has(key)) {
-			emojiKeys.set(key, { name: decoded.name, host });
-		}
-	}
-
-	if (emojiKeys.size === 0) return new Map();
-
-	const emojis = await Emojis.find({
-		where: Array.from(emojiKeys.values()).map((entry) => ({
-			name: entry.name,
-			host: entry.host ?? IsNull(),
-		})),
-		select: ["name", "host", "license"],
-	});
-
-	return new Map(
-		emojis.map((emoji) => [
-			`${emoji.name}@${emoji.host ?? ""}`,
-			emoji,
-		]),
-	);
-}
-
-async function resendLocalReactionsForRenote(
-	renote: Note,
-	noteInboxes: Map<string, boolean>,
-) {
-	if (noteInboxes.size === 0) {
-		console.log(
-			`[reaction-resend] skip: noteInboxes is empty (renote=${renote.id})`,
-		);
-		return;
-	}
-
-	const reactions = await NoteReactions.createQueryBuilder("reaction")
-		.leftJoinAndSelect("reaction.user", "user")
-		.where("reaction.noteId = :noteId", { noteId: renote.id })
-		.andWhere("user.host IS NULL")
-		.orderBy("reaction.createdAt", "DESC")
-		.addOrderBy("reaction.id", "DESC")
-		.getMany();
-
-	if (reactions.length === 0) {
-		console.log(
-			`[reaction-resend] skip: no local reactions (renote=${renote.id})`,
-		);
-		return;
-	}
-	const latestReactionsByUser = new Map<string, NoteReaction>();
-	for (const reaction of reactions) {
-		if (!latestReactionsByUser.has(reaction.userId)) {
-			latestReactionsByUser.set(reaction.userId, reaction);
-		}
-	}
-
-	const latestReactions = Array.from(latestReactionsByUser.values());
-	console.log(
-		`[reaction-resend] local reactions: ${latestReactions.length} (renote=${renote.id})`,
-	);
-
-	const emojiMap = await getReactionEmojiMap(latestReactions);
-
-	for (const reaction of latestReactions) {
-		const reactionUser = reaction.user;
-		if (!reactionUser || reactionUser.host !== null) continue;
-
-		const decoded = decodeReaction(reaction.reaction);
-		const emojiKey = decoded.name
-			? `${decoded.name}@${decoded.host ?? ""}`
-			: null;
-		const emoji = emojiKey ? emojiMap.get(emojiKey) : null;
-		const deliverReaction = await resolveApReaction(reaction.reaction, emoji);
-		const deliverRecord = {
-			...reaction,
-			reaction: deliverReaction,
-		} as NoteReaction;
-
-		const activity = renderActivity(await renderLike(deliverRecord, renote));
-		const dm = await buildReactionDeliverManager(
-			reactionUser,
-			renote,
-			activity,
-			{ disableUnion: true },
-		);
-		const reactionInboxes = await dm.collectInboxes();
-		console.log(
-			`[reaction-resend] deliver reaction: reactionInboxes=${reactionInboxes.size} (renote=${renote.id}, reaction=${reaction.id})`,
-		);
-
-		await deliverToInboxes(
-			reactionUser as ILocalUser,
-			activity,
-			reactionInboxes,
-		);
-	}
-}
-
-async function delayReactionResend() {
-	await new Promise((resolve) => setTimeout(resolve, 1000));
-}
-
-async function renderNoteOrRenoteActivity(data: Option, note: Note) {
-	if (data.localOnly && data.channel) return null;
-	// リモートでRT出来ないはずの投稿がRTされている場合、連合しない
-	if (data.renote?.userId !== note.userId && data.renote?.localOnly)
-		return null;
-
-	const content =
-		data.renote &&
-		data.text == null &&
-		data.poll == null &&
-		(data.files == null || data.files.length === 0)
-			? renderAnnounce(
-					data.renote.uri
-						? data.renote.uri
-						: `${config.url}/notes/${data.renote.id}`,
-					note,
-			  )
-			: renderCreate(await renderNote(note, false), note);
-
-	return renderActivity(content);
 }
 
 function incRenoteCount(renote: Note, userHost?: string) {


### PR DESCRIPTION
### Motivation
- 投稿 API の応答時間を悪化させていた ActivityPub 配信処理（Activity生成・配送先収集・配送・renote時の reaction 再送・relay 配信）を非同期化して API 応答と切り離すため。 
- renote の reaction 再送など配送順序は維持したまま、配送失敗時はジョブのリトライで安定化させるため。 
- API 応答時間と配信遅延／配信処理時間を別々に計測できるようにして観測性を改善するため。 

### Description
- ノート作成処理内の AP 配信ブロック（`//#region AP deliver`）を削除し、投稿成功直後に `createNoteApDeliverJob({ noteId, queuedAt })` をキュー投入するよう変更した（`packages/backend/src/services/note/create.ts`）。
- 配信本体を新サービス `packages/backend/src/services/note/ap-deliver.ts` に移設し、ジョブ内で順序を保って `renderActivity` 相当 → `DeliverManager` で配送先収集 → `deliverToInboxes` → renote 時の `countSameRenotes` 判定 + `resendLocalReactionsForRenote` → relay 配信 を実行するようにした。 
- キュー周りに `NoteApDeliverJobData` 型・`noteApDeliver` キュー・`createNoteApDeliverJob` を追加し、プロセッサ `note-ap-deliver` を登録して `processNoteApDeliverJob` を実行するようにした（`packages/backend/src/queue/types.ts` / `queues.ts` / `index.ts` / `processors/note-ap-deliver.ts`）。
- ジョブは既存の deliver ジョブに合わせたリトライ方針を使用（`attempts: config.deliverJobMaxAttempts || 12`、`backoff: { type: 'apBackoff' }`、`timeout: 1min`）。
- メトリクス出力を分離し、API 側で `api_response_ms`（ノート作成応答時間）を出力、ジョブ側で `queue_delay_ms`（投入→開始遅延）と `deliver_duration_ms`（配信処理時間）を出力するようにした。 
- 配信ロジックの移設で `renderNoteOrRenoteActivity` 相当、配送先レシピ作成、reaction 再送ロジック等を ap-deliver 側へ移し、従来と同等のふるまい・順序を保持している。 

### Testing
- リント実行を試みたが `rome` が見つからず失敗したため自動 lint は未実行（`pnpm --filter backend run lint` が ENOENT で失敗）。
- ビルド実行を試みたが環境に `napi` 等の依存がないため失敗したためビルドは未完了（`pnpm --filter backend run build` が ENOENT で失敗）。
- 変更箇所の静的確認としてファイル差分・grep による参照更新は実施済みで、作業ツール上で関連ファイルの追加・移動・参照解決を確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbf99b304832694a7deb2013176c8)