### PR TITLE
fix: specified 可視性ノートのリアクション配送で配列未定義エラーを回避

### DIFF
--- a/packages/backend/src/services/note/reaction/deliver.ts
+++ b/packages/backend/src/services/note/reaction/deliver.ts
@@ -35,14 +35,16 @@ export async function buildReactionDeliverManager(
 				dm.addFollowersRecipe();
 			}
 		} else if (note.visibility === "specified") {
+			const visibleUserIds = note.visibleUserIds ?? [];
 			const visibleUsers = await Promise.all(
-				note.visibleUserIds.map((id) => Users.findOneBy({ id })),
+				visibleUserIds.map((id) => Users.findOneBy({ id })),
 			);
 			for (const u of visibleUsers.filter((u) => u && Users.isRemoteUser(u))) {
 				dm.addDirectRecipe(u as IRemoteUser);
 			}
+			const ccUserIds = note.ccUserIds ?? [];
 			const ccUsers = await Promise.all(
-				note.ccUserIds.map((id) => Users.findOneBy({ id })),
+				ccUserIds.map((id) => Users.findOneBy({ id })),
 			);
 			for (const u of ccUsers.filter((u) => u && Users.isRemoteUser(u))) {
 				dm.addDirectRecipe(u as IRemoteUser);


### PR DESCRIPTION
### Motivation
- `notes/reactions/create` 実行時に稀に発生する `Cannot read properties of undefined (reading 'map')` を、防御的に回避するための修正です。 

### Description
- `packages/backend/src/services/note/reaction/deliver.ts` の `note.visibility === "specified"` ブロックで `note.visibleUserIds` と `note.ccUserIds` に対して `?? []` フォールバックを追加し、`map` をローカル変数 (`visibleUserIds` / `ccUserIds`) に対して実行するように変更しました。 

### Testing
- `pnpm --filter backend run mocha -- --grep "notes/reactions/create"` を実行しようとしましたが、作業環境に `node_modules` が無く `cross-env: not found` のためテストは実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcb3bdfac8326b11aeedb71b75bc2)