### PR TITLE
fix: notes/reactions/createでノート配列を正規化し、deliverでのmap参照を防御

### DIFF
--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -108,6 +108,14 @@ export default async (
 	note: Note,
 	reaction?: string,
 ) => {
+	note.visibleUserIds ??= [];
+	note.ccUserIds ??= [];
+	note.mentions ??= [];
+	note.emojis ??= [];
+	note.tags ??= [];
+	note.fileIds ??= [];
+	note.referenceIds ??= [];
+
 	// Check blocking
 	const blockPromise = (async () => {
 		if (note.userId !== user.id) {

--- a/packages/backend/src/services/note/reaction/deliver.ts
+++ b/packages/backend/src/services/note/reaction/deliver.ts
@@ -35,14 +35,16 @@ export async function buildReactionDeliverManager(
 				dm.addFollowersRecipe();
 			}
 		} else if (note.visibility === "specified") {
+			const visibleUserIds = note.visibleUserIds ?? [];
 			const visibleUsers = await Promise.all(
-				note.visibleUserIds.map((id) => Users.findOneBy({ id })),
+				visibleUserIds.map((id) => Users.findOneBy({ id })),
 			);
 			for (const u of visibleUsers.filter((u) => u && Users.isRemoteUser(u))) {
 				dm.addDirectRecipe(u as IRemoteUser);
 			}
+			const ccUserIds = note.ccUserIds ?? [];
 			const ccUsers = await Promise.all(
-				note.ccUserIds.map((id) => Users.findOneBy({ id })),
+				ccUserIds.map((id) => Users.findOneBy({ id })),
 			);
 			for (const u of ccUsers.filter((u) => u && Users.isRemoteUser(u))) {
 				dm.addDirectRecipe(u as IRemoteUser);


### PR DESCRIPTION
### Motivation
- `/endpoints/notes/reactions/create.js:62:5` で表面化していた `Cannot read properties of undefined (reading 'map')` を防ぐため、リアクション処理の入口でノートの配列系フィールドを正規化し広範にクラッシュを防止します。
- また、配信処理側でも `note` の配列が未定義になり得る箇所をローカル変数に取り `?? []` を適用して防御的に処理します。

### Description
- `packages/backend/src/services/note/reaction/create.ts` の処理冒頭で `note.visibleUserIds ??= []; note.ccUserIds ??= []; note.mentions ??= []; note.emojis ??= []; note.tags ??= []; note.fileIds ??= []; note.referenceIds ??= [];` を追加して配列系フィールド欠損を吸収しました。 
- `packages/backend/src/services/note/reaction/deliver.ts` の `visibility === "specified"` ブロックで `visibleUserIds` / `ccUserIds` をローカルに取り `?? []` フォールバックを用いて `map` を実行するように変更しました。 
- これによりエンドポイント側で捕捉される前段（リアクション作成フロー）での配列前提処理のクラッシュを広く防ぎます。

### Testing
- `pnpm --filter backend run mocha -- --grep "notes/reactions/create"` を実行しましたが、実行環境に `node_modules` が無いため `cross-env: not found` によりテストは実行できませんでした（失敗）。
- 他の自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcb3bdfac8326b11aeedb71b75bc2)