### PR TITLE
fix(backend): notes/reactions/createのエラーログ強化と word-mute の null 安全化

### DIFF
--- a/packages/backend/src/misc/check-word-mute.ts
+++ b/packages/backend/src/misc/check-word-mute.ts
@@ -15,9 +15,10 @@ type UserLike = {
 
 function checkWordMute(
 	note: NoteLike,
-	mutedWords: Array<string | string[]>,
+	mutedWords: Array<string | string[]> | null | undefined,
 ): boolean {
 	if (note == null) return false;
+	if (!Array.isArray(mutedWords) || mutedWords.length === 0) return false;
 
 	const text = `${note.cw ?? ""} ${note.text ?? ""}`.trim();
 	if (text === "") return false;
@@ -60,14 +61,14 @@ function checkWordMute(
 export async function getWordHardMute(
 	note: NoteLike,
 	me: UserLike | null | undefined,
-	mutedWords: Array<string | string[]>,
+	mutedWords: Array<string | string[]> | null | undefined,
 ): Promise<boolean> {
 	// 自分自身
 	if (me && note.userId === me.id) {
 		return false;
 	}
 
-	if (mutedWords.length > 0) {
+	if (Array.isArray(mutedWords) && mutedWords.length > 0) {
 		return (
 			checkWordMute(note, mutedWords) ||
 			checkWordMute(note.reply, mutedWords) ||
@@ -82,9 +83,10 @@ export function checkReactionMute(
 	reaction: string,
 	note: Note,
 	user: User,
-	mutedWords: Array<string | string[]>,
+	mutedWords: Array<string | string[]> | null | undefined,
 ): boolean | { muted: boolean; reject?: boolean } {
 	if (!reaction) return false;
+	if (!Array.isArray(mutedWords) || mutedWords.length === 0) return false;
 
 	const text = reaction.trim();
 	if (text === "") return false;

--- a/packages/backend/src/server/api/endpoints/notes/reactions/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions/create.ts
@@ -2,6 +2,7 @@ import createReaction from "@/services/note/reaction/create.js";
 import define from "../../../define.js";
 import { getNote } from "../../../common/getters.js";
 import { ApiError } from "../../../error.js";
+import { apiLogger } from "../../../logger.js";
 
 export const meta = {
 	tags: ["reactions", "notes"],
@@ -66,10 +67,34 @@ export default define(meta, paramDef, async (ps, user) => {
 			throw new ApiError(meta.errors.alreadyReacted);
 		if (e.id === "e70412a4-7197-4726-8e74-f3e0deb92aa7")
 			throw new ApiError(meta.errors.youHaveBeenBlocked);
+
+		apiLogger.error("notes/reactions/create failed", {
+			ep: "notes/reactions/create",
+			ps: {
+				noteId: ps.noteId,
+				reaction: ps.reaction,
+			},
+			userId: user.id,
+			noteId: note.id,
+			e: {
+				id: e?.id,
+				name: e?.name,
+				message: e?.message,
+				stack: e?.stack,
+			},
+		});
+
 		throw new ApiError({
 			message: e?.message ? e.message : e,
 			code: "ERROR",
 			id: "7c2bfc07-480f-fd9c-93d1-16c739306280",
+		}, {
+			e: {
+				id: e?.id,
+				name: e?.name,
+				message: e?.message,
+				stack: e?.stack,
+			},
 		});
 	});
 	return;


### PR DESCRIPTION
### Motivation
- `notes/reactions/create` で再現性の低い例外が発生した際に調査が困難だったため、発生時のコンテキスト（入力・ユーザー・投稿・スタックトレース）を確実に記録する目的で変更しました。 
- `check-word-mute` 系処理で `mutedWords` が `null`/`undefined` の場合に例外や誤動作が起きうるため、呼び出し側の安全性を向上させる必要がありました。 

### Description
- `packages/backend/src/server/api/endpoints/notes/reactions/create.ts` に `apiLogger` を導入し、`createReaction` が既知エラー以外で失敗した場合に `ep`, `ps`（`noteId`/`reaction`）, `userId`, `noteId`（実体）, および `error` の `id/name/message/stack` をまとめてログ出力するようにしました。 
- 同ファイルでクライアントへ返却する `ApiError` の `info` にも同様の `e` 情報（`id/name/message/stack`）を含めるようにし、集約ログとの突合を容易にしました。 
- `packages/backend/src/misc/check-word-mute.ts` の関数署名を `mutedWords` が `Array<string | string[]> | null | undefined` を受け取るように変更し、各関数で `mutedWords` が配列でないか空の場合に早期リターンするガードを追加して null 安全性を確保しました。 

### Testing
- `pnpm --filter backend run lint` を実行しましたが、依存未インストール環境のため `rome` が見つからず実行失敗（`spawn rome ENOENT`）しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcfd63450832687d940a4cb19bc04)