### PR TITLE
fix: revert authenticate change and fetch local driveCapacity for reaction limit

### DIFF
--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -42,6 +42,9 @@ const INSTANCE_MAX_REACTIONS_CACHE_TTL_MS = 30 * 1000;
 const instanceMaxReactionsPerAccountCache = new Cache<number>(
 	INSTANCE_MAX_REACTIONS_CACHE_TTL_MS,
 );
+const localUserDriveCapacityCache = new Cache<number | null>(
+	INSTANCE_MAX_REACTIONS_CACHE_TTL_MS,
+);
 
 export function normalizeReactionMuteResult(
 	muteResult: boolean | { muted: boolean; reject?: boolean | undefined },
@@ -92,6 +95,23 @@ async function getMaxReactionsPerAccountByHost(host: string): Promise<number> {
 	);
 }
 
+async function getLocalUserMaxReactionsPerAccount(userId: string): Promise<number> {
+	const driveCapacityOverrideMb = await localUserDriveCapacityCache.fetch(
+		userId,
+		async () => {
+			const localUser = await Users.findOne({
+				where: { id: userId },
+				select: ["id", "driveCapacityOverrideMb"],
+			});
+			return localUser?.driveCapacityOverrideMb ?? null;
+		},
+	);
+
+	return (driveCapacityOverrideMb ?? 5120) > 5120
+		? MAX_REACTION_PER_ACCOUNT
+		: 1;
+}
+
 export default async (
 	user: {
 		id: User["id"];
@@ -100,7 +120,6 @@ export default async (
 		name: User["name"];
 		avatarUrl: User["avatarUrl"];
 		isSilenced: User["isSilenced"];
-		driveCapacityOverrideMb: User["driveCapacityOverrideMb"];
 		isExplorable: User["isExplorable"];
 		isRemoteExplorable: User["isRemoteExplorable"];
 		isBot: User["isBot"];
@@ -239,10 +258,7 @@ export default async (
 		let maxReactionsPerAccount = 1;
 		let maxReactionsNote = 1;
 		if (!user.host) {
-			maxReactionsPerAccount =
-				(user.driveCapacityOverrideMb ?? 5120) > 5120
-					? MAX_REACTION_PER_ACCOUNT
-					: 1;
+			maxReactionsPerAccount = await getLocalUserMaxReactionsPerAccount(user.id);
 		} else {
 			maxReactionsPerAccount = await getMaxReactionsPerAccountByHost(user.host);
 		}


### PR DESCRIPTION
### Motivation
- 認証キャッシュの取得内容に依存して `driveCapacityOverrideMb` を参照していたため、ある経路で値が存在せず複数リアクション判定に失敗する可能性があったため修正を行う。 
- `authenticate.ts` 側の拡張を元に戻し、判定ロジックを認証キャッシュに依存しない形に移すことで根本対処を狙う。

### Description
- `packages/backend/src/server/api/authenticate.ts` の元の挙動へ戻し、認証ユーザ取得は `AUTH_USER_SELECT` を用いる実装に復帰しました。 
- `packages/backend/src/services/note/reaction/create.ts` に `localUserDriveCapacityCache`（TTL 30秒）を追加し、`getLocalUserMaxReactionsPerAccount(userId)` を新設して `driveCapacityOverrideMb` を `Users.findOne(... select ...)` で再取得するようにしました。 
- `create.ts` の `user` 引数型から `driveCapacityOverrideMb` を削除し、ローカルユーザ時の多重リアクション上限判定を `user.driveCapacityOverrideMb` 参照から上記関数呼び出しへ置換しました。

### Testing
- 差分やファイル内容は `git diff` で確認済みです。 
- 単体テストを試行するために `pnpm -C packages/backend test -- reaction-create.ts` を実行しましたが、テスト環境で `cross-env: not found` および `node_modules` 未インストールのため実行失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd282b14483268c5bf971aba8cb12)