### PR TITLE
認証ユーザーキャッシュの不整合による絵文字処理クラッシュを根本修正

### DIFF
--- a/packages/backend/src/services/user-cache.ts
+++ b/packages/backend/src/services/user-cache.ts
@@ -26,6 +26,15 @@ function createTokenHash(token: string): string {
 	return createHash("sha256").update(token).digest("hex");
 }
 
+
+function isValidCacheableLocalUser(
+	value: CacheableLocalUser | null,
+): value is CacheableLocalUser | null {
+	if (value == null) return true;
+
+	return Array.isArray((value as Partial<CacheableLocalUser>).emojis);
+}
+
 function reviveCachedUserDates<T>(value: T): T {
 	if (value == null || typeof value !== "object") return value;
 
@@ -156,7 +165,11 @@ export async function fetchAuthUserByTokenCache(
 	const tokenHash = createTokenHash(token);
 	const localCached = authUserByTokenCache.get(tokenHash);
 	if (localCached !== undefined) {
-		return localCached;
+		if (isValidCacheableLocalUser(localCached)) {
+			return localCached;
+		}
+
+		authUserByTokenCache.delete(tokenHash);
 	}
 
 	const redisKey = createRedisKey(AUTH_USER_BY_TOKEN_REDIS_KEY_PREFIX, tokenHash);
@@ -165,8 +178,13 @@ export async function fetchAuthUserByTokenCache(
 		const parsed = reviveCachedUserDates(
 			JSON.parse(redisCached) as CacheableLocalUser | null,
 		);
-		authUserByTokenCache.set(tokenHash, parsed);
-		return parsed;
+
+		if (isValidCacheableLocalUser(parsed)) {
+			authUserByTokenCache.set(tokenHash, parsed);
+			return parsed;
+		}
+
+		await redisClient.del(redisKey);
 	}
 
 	const fetched = await fetcher();


### PR DESCRIPTION
### Motivation
- `populateEmojis` 側で `null/undefined` を受けるガードを置くのは対症療法であり、`User.emojis` が未定義になる根本原因は認証ユーザーキャッシュに不正なユーザー形状が残っている点にあるため、上流で修正する必要があった。

### Description
- `packages/backend/src/services/user-cache.ts` に `isValidCacheableLocalUser` を追加し、キャッシュから取り出した認証ユーザーが `emojis` を配列として持つか検証するようにした。 
- ローカル（in-memory）キャッシュの値が不正な場合は削除して再フェッチするようにし、Redis 側のキャッシュが不正な場合は該当 Redis キーを削除してから再フェッチにフォールバックするようにした。 
- `packages/backend/src/misc/populate-emojis.ts` の引数契約を元の `string[]` に戻し、以前入れた `null | undefined` の早期リターンを撤回して下流で問題を吸収しない設計に戻した。 

### Testing
- `pnpm -C packages/backend lint` を実行したが、開発環境で依存が未導入のため `rome` が見つからず実行できず（`spawn rome ENOENT`）検証は実行できなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd4745c208326a8bffc8d22dfc438)