### PR TITLE
notes作成処理にフェーズ計測ログを追加

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -239,6 +239,8 @@ export const paramDef = {
 } as const;
 
 export default define(meta, paramDef, async (ps, user) => {
+	const endpointStartedAt = Date.now();
+
 	if (user.movedToUri != null) throw new ApiError(meta.errors.accountLocked);
 	if (!ps.web && user.isMiniSilenced && ps.visibility === "public") {
 			throw new ApiError(meta.errors.appBlockPublic);
@@ -421,7 +423,8 @@ export default define(meta, paramDef, async (ps, user) => {
 	
 	const fileUrls = await Promise.all(fileUrlsPromises);
 	files.push(...(fileUrls.filter((x) => x != null)));
-	
+	const endpointPreprocessMs = Date.now() - endpointStartedAt;
+
 	// Create a post
 	try {
 			const note = await create(user, {
@@ -449,6 +452,7 @@ export default define(meta, paramDef, async (ps, user) => {
 					apMentions: ps.noExtractMentions ? [] : undefined,
 					apHashtags: ps.noExtractHashtags ? [] : undefined,
 					apEmojis: ps.noExtractEmojis ? [] : undefined,
+					endpointPreprocessMs,
 			});
 			return {
 					createdNote: await Notes.pack(note, user),

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -158,6 +158,7 @@ type MinimumUser = {
 
 type Option = {
 	createdAt?: Date | null;
+	endpointPreprocessMs?: number;
 	name?: string | null;
 	text?: string | null;
 	reply?: Note | null;
@@ -898,7 +899,9 @@ export default async (
 
 		data.isPublicLikeList = user.isPublicLikeList;
 
+		const insertNoteStartedAt = Date.now();
 		const note = await insertNote(user, data, tags, emojis, mentionedUsers);
+		const insertNoteMs = Date.now() - insertNoteStartedAt;
 
 		const usageTargetIds = (data.files ?? [])
 			.map((file) => file?.id)
@@ -912,7 +915,13 @@ export default async (
 		}
 
 		if (firstVisibility != note.visibility) console.log(`${note.id}:可視性変更 ${firstVisibility} -> ${note.visibility}`);
-		console.log(`[note-deliver-metric] api_response_ms=${Date.now() - apiStartedAt} note=${note.id}`);
+		const apiResponseMs = Date.now() - apiStartedAt;
+		if (apiResponseMs >= 1000) {
+			const endpointPreprocessMs = data.endpointPreprocessMs ?? 0;
+			console.log(
+				`[note-deliver-metric] api_response_ms=${apiResponseMs} endpoint_preprocess_ms=${endpointPreprocessMs} insert_note_ms=${insertNoteMs} note_id=${note.id} user_id=${user.id} user_host=${user.host ?? "local"} visibility=${note.visibility} is_reply=${Boolean(data.reply)} is_renote=${Boolean(data.renote)} file_count=${data.files?.length ?? 0}`,
+			);
+		}
 
 		res(note);
 


### PR DESCRIPTION
### Motivation
- notes 作成処理の各フェーズ（エンドポイント前処理／DB挿入／レスポンス直前まで）を `Date.now()` ベースで計測してパフォーマンス分析をしやすくするため。 

### Description
- エンドポイント先頭で開始時刻を取り、前処理（visibleUsers/files/reply/renote 取得～`fileUrls` 取り込み完了）までの時間を `endpointPreprocessMs` として算出し、`create` サービスに渡すようにした（`packages/backend/src/server/api/endpoints/notes/create.ts`）。
- サービス側の `Option` 型に `endpointPreprocessMs?: number` を追加して受け取りを可能にした（`packages/backend/src/services/note/create.ts`）。
- `insertNote` 実行前後で時刻を取り `insert_note_ms` を計測し、`res(note)` 直前までの合計を `api_response_ms` として算出するようにした（`packages/backend/src/services/note/create.ts`）。
- 既存のプレフィックスを維持しつつ、`api_response_ms >= 1000` の場合のみ詳細ログを出力するように変更し、ログは集計しやすい snake_case のキーで `api_response_ms`, `endpoint_preprocess_ms`, `insert_note_ms`, `note_id`, `user_id`, `user_host`, `visibility`, `is_reply`, `is_renote`, `file_count` を含めるようにした（`[note-deliver-metric]`）。

### Testing
- `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行したが、環境依存で `Cannot find type definition file for 'node'` エラーにより型チェックが失敗したためコンパイルは完了しませんでした（今回の変更が原因ではない想定）。
- 変更点はランタイムで既存の `create` フローに渡す追加数値と条件付きの `console.log` 出力のみのため、影響範囲は限定的です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de0e678a48326b7e0e68b60b59e60)