### PR TITLE
投稿作成時のWebhook取得を1回に集約し用途別Mapで再利用

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -156,6 +156,9 @@ type MinimumUser = {
 	isBot: User["isBot"];
 };
 
+type ActiveWebhook = Awaited<ReturnType<typeof getActiveWebhooks>>[number];
+type WebhooksByUserMap = Map<MinimumUser["id"], ActiveWebhook[]>;
+
 type Option = {
 	createdAt?: Date | null;
 	name?: string | null;
@@ -1031,6 +1034,21 @@ export default async (
 		}
 
 		if (!silent) {
+			const activeWebhooks = await getActiveWebhooks();
+			const noteWebhooksByUser = createWebhooksByUserMap(activeWebhooks, "note");
+			const replyWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"reply",
+			);
+			const renoteWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"renote",
+			);
+			const mentionWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"mention",
+			);
+
 			if (Users.isLocalUser(user)) activeUsersChart.write(user);
 
 			// 未読通知を作成
@@ -1068,9 +1086,7 @@ export default async (
 				});
 			}
 
-			const webhooks = await getActiveWebhooks().then((webhooks) =>
-				webhooks.filter((x) => x.userId === user.id && x.on.includes("note")),
-			);
+			const webhooks = noteWebhooksByUser.get(user.id) ?? [];
 
 			for (const webhook of webhooks) {
 				webhookDeliver(webhook, "note", {
@@ -1107,9 +1123,7 @@ export default async (
 						});
 						publishMainStream(data.reply.userId, "reply", packedReply);
 
-						const webhooks = (await getActiveWebhooks()).filter(
-							(x) => x.userId === data.reply!.userId && x.on.includes("reply"),
-						);
+						const webhooks = replyWebhooksByUser.get(data.reply.userId) ?? [];
 						for (const webhook of webhooks) {
 							if (webhook.userId === user.id) continue;
 							webhookDeliver(webhook, "reply", {
@@ -1150,9 +1164,7 @@ export default async (
 					});
 					publishMainStream(data.renote.userId, "renote", packedRenote);
 
-					const webhooks = (await getActiveWebhooks()).filter(
-						(x) => x.userId === data.renote!.userId && x.on.includes("renote"),
-					);
+					const webhooks = renoteWebhooksByUser.get(data.renote.userId) ?? [];
 					for (const webhook of webhooks) {
 						if (webhook.userId === user.id) continue;
 						webhookDeliver(webhook, "renote", {
@@ -1162,7 +1174,11 @@ export default async (
 				}
 			}
 
-			void createMentionedEventsInBackground(localMentionTargets, note);
+			void createMentionedEventsInBackground(
+				localMentionTargets,
+				note,
+				mentionWebhooksByUser,
+			);
 
 			Promise.all(nmRelatedPromises).then(() => {
 				nm.deliver();
@@ -1455,20 +1471,12 @@ async function enqueueMentionNotifications(
 function createMentionedEventsInBackground(
 	localMentionedUsers: MinimumUser[],
 	note: Note,
+	mentionWebhooksByUser: WebhooksByUserMap,
 ): void {
 	if (localMentionedUsers.length === 0) return;
 
 	void (async () => {
 		const errors: unknown[] = [];
-		const webhooks = await getActiveWebhooks();
-		const mentionWebhooksByUser = new Map<MinimumUser["id"], typeof webhooks>();
-
-		for (const webhook of webhooks) {
-			if (!webhook.on.includes("mention")) continue;
-			const list = mentionWebhooksByUser.get(webhook.userId) ?? [];
-			list.push(webhook);
-			mentionWebhooksByUser.set(webhook.userId, list);
-		}
 
 		for (const u of localMentionedUsers) {
 			try {
@@ -1505,6 +1513,23 @@ function createMentionedEventsInBackground(
 			err,
 		});
 	});
+}
+
+function createWebhooksByUserMap(
+	webhooks: ActiveWebhook[],
+	event: "note" | "reply" | "renote" | "mention",
+): WebhooksByUserMap {
+	const webhooksByUser = new Map<MinimumUser["id"], ActiveWebhook[]>();
+
+	for (const webhook of webhooks) {
+		if (!webhook.on.includes(event)) continue;
+
+		const userWebhooks = webhooksByUser.get(webhook.userId) ?? [];
+		userWebhooks.push(webhook);
+		webhooksByUser.set(webhook.userId, userWebhooks);
+	}
+
+	return webhooksByUser;
 }
 
 function isNotePackAccessDeniedError(err: unknown): boolean {


### PR DESCRIPTION
### Motivation
- 投稿処理内で複数回 `getActiveWebhooks()` を呼んでいたため、投稿単位での不要な再取得を削減するため。 
- 用途ごと（`note` / `reply` / `renote` / `mention`）にWebhookを振り分けて再利用し、配信処理を効率化するため。 
- `createMentionedEventsInBackground` 側で再取得しないようにし、呼び出し側で必要なWebhook情報を渡す構造にするため。 

### Description
- `ActiveWebhook` と `WebhooksByUserMap` 型を追加して型を明確化しました。 
- `createWebhooksByUserMap` ヘルパーを追加し、`getActiveWebhooks()` の結果からイベント種別（`"note" | "reply" | "renote" | "mention"`）ごとに `Map<userId, webhook[]>` を構築するようにしました。 
- `create` 関数内で最初に `const activeWebhooks = await getActiveWebhooks();` を1回だけ取得し、`noteWebhooksByUser` / `replyWebhooksByUser` / `renoteWebhooksByUser` / `mentionWebhooksByUser` を作成して使い回すように変更しました。 
- 各配信箇所の `getActiveWebhooks().filter(...)` を用途別Mapからの参照（`map.get(userId) ?? []`）へ置き換え、`createMentionedEventsInBackground` の呼び出しを `createMentionedEventsInBackground(localMentionTargets, note, mentionWebhooksByUser)` の形に変更して内部で再取得しないようにしました。 
- 既存の配信判定ロジック（`webhook.on.includes("note"|"reply"|"renote"|"mention")`）は `createWebhooksByUserMap` 側で維持しています。 

### Testing
- `pnpm --filter backend run lint` を実行しましたが、ローカル実行環境で `node_modules` が未インストールのため `rome` が見つからず `spawn rome ENOENT` で失敗しました。 
- 依存解決が行える環境での `lint` / `build` 実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de0eda3908326b22fe4c6a6a32af1)