### PR TITLE
Optimize NotificationManager.deliver mute filtering

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -113,39 +113,32 @@ class NotificationManager {
 		}
 	}
 
-        public async deliver() {
-                const targets = [...new Set(this.queue.map((x) => x.target))];
+	public async deliver() {
+		const targets = [...new Set(this.queue.map((x) => x.target))];
 
-                const mentioneeMutes =
-                        targets.length === 0
-                                ? []
-                                : await Mutings.findBy({
-                                          muterId: In(targets),
-                                  });
+		const mentioneeMutes =
+			targets.length === 0
+				? []
+				: await Mutings.findBy({
+					muterId: In(targets),
+					muteeId: this.notifier.id,
+				});
 
-                const mentioneeMutesMap = new Map<ILocalUser["id"], User["id"][]>();
+		const mentioneeMutedNotifierIds = new Set(
+			mentioneeMutes.map((mute) => mute.muterId),
+		);
 
-                for (const mute of mentioneeMutes) {
-                        if (!mentioneeMutesMap.has(mute.muterId)) {
-                                mentioneeMutesMap.set(mute.muterId, []);
-                        }
-
-                        mentioneeMutesMap.get(mute.muterId)!.push(mute.muteeId);
-                }
-
-                for (const x of this.queue) {
-                        const mentioneesMutedUserIds = mentioneeMutesMap.get(x.target) ?? [];
-
-                        // 通知される側のユーザーが通知する側のユーザーをミュートしていない限りは通知する
-                        if (!mentioneesMutedUserIds.includes(this.notifier.id)) {
-                                createNotification(x.target, x.reason, {
-                                        notifierId: this.notifier.id,
-                                        noteId: this.note.id,
-                                        note: this.note,
-                                });
-                        }
-                }
-        }
+		for (const x of this.queue) {
+			// 通知される側のユーザーが通知する側のユーザーをミュートしていない限りは通知する
+			if (!mentioneeMutedNotifierIds.has(x.target)) {
+				createNotification(x.target, x.reason, {
+					notifierId: this.notifier.id,
+					noteId: this.note.id,
+					note: this.note,
+				});
+			}
+		}
+	}
 }
 
 type MinimumUser = {


### PR DESCRIPTION
### Motivation
- `NotificationManager.deliver` が通知可否判定のために多くのミュート行を取得しており、クエリと判定コストを削減する必要があった。

### Description
- `packages/backend/src/services/note/create.ts` の `NotificationManager.deliver` を変更し、`Mutings.findBy` に `muteeId: this.notifier.id` 条件を追加して検索範囲を絞りました。
- 取得したミュート結果を `Set`（`mentioneeMutedNotifierIds`）に変換し、個々の通知判定を `includes` から `Set.has` に変更して O(1) 判定化しました。
- 既存の仕様である「自分自身には通知しない」と `push` による `reply/mention` 優先度ロジックは変更していません。
- 変更箇所は `NotificationManager.deliver` のロジック置換のみで、副作用のある別ロジックは触れていません（対象ファイル: `packages/backend/src/services/note/create.ts`）。

### Testing
- `node` スクリプトで旧実装と新実装の通知対象をランダムケース 5000 件で比較し、通知対象配列・件数がすべて一致することを確認しました（成功）。
- `rome` の静的チェックを実行しようとしましたが、実行環境で `rome` コマンドが見つからず (`ENOENT`) チェックは実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de0fb4d1083268441a04e1d941426)