### PR TITLE
リアクションWebhookのユーザー取得をID指定で修正（name欠落を防止）

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -156,6 +156,9 @@ type MinimumUser = {
 	isBot: User["isBot"];
 };
 
+type ActiveWebhook = Awaited<ReturnType<typeof getActiveWebhooks>>[number];
+type WebhooksByUserMap = Map<MinimumUser["id"], ActiveWebhook[]>;
+
 type Option = {
 	createdAt?: Date | null;
 	name?: string | null;
@@ -1031,6 +1034,21 @@ export default async (
 		}
 
 		if (!silent) {
+			const activeWebhooks = await getActiveWebhooks();
+			const noteWebhooksByUser = createWebhooksByUserMap(activeWebhooks, "note");
+			const replyWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"reply",
+			);
+			const renoteWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"renote",
+			);
+			const mentionWebhooksByUser = createWebhooksByUserMap(
+				activeWebhooks,
+				"mention",
+			);
+
 			if (Users.isLocalUser(user)) activeUsersChart.write(user);
 
 			// 未読通知を作成
@@ -1068,9 +1086,7 @@ export default async (
 				});
 			}
 
-			const webhooks = await getActiveWebhooks().then((webhooks) =>
-				webhooks.filter((x) => x.userId === user.id && x.on.includes("note")),
-			);
+			const webhooks = noteWebhooksByUser.get(user.id) ?? [];
 
 			for (const webhook of webhooks) {
 				webhookDeliver(webhook, "note", {
@@ -1107,9 +1123,7 @@ export default async (
 						});
 						publishMainStream(data.reply.userId, "reply", packedReply);
 
-						const webhooks = (await getActiveWebhooks()).filter(
-							(x) => x.userId === data.reply!.userId && x.on.includes("reply"),
-						);
+						const webhooks = replyWebhooksByUser.get(data.reply.userId) ?? [];
 						for (const webhook of webhooks) {
 							if (webhook.userId === user.id) continue;
 							webhookDeliver(webhook, "reply", {
@@ -1150,9 +1164,7 @@ export default async (
 					});
 					publishMainStream(data.renote.userId, "renote", packedRenote);
 
-					const webhooks = (await getActiveWebhooks()).filter(
-						(x) => x.userId === data.renote!.userId && x.on.includes("renote"),
-					);
+					const webhooks = renoteWebhooksByUser.get(data.renote.userId) ?? [];
 					for (const webhook of webhooks) {
 						if (webhook.userId === user.id) continue;
 						webhookDeliver(webhook, "renote", {
@@ -1162,7 +1174,11 @@ export default async (
 				}
 			}
 
-			void createMentionedEventsInBackground(localMentionTargets, note);
+			void createMentionedEventsInBackground(
+				localMentionTargets,
+				note,
+				mentionWebhooksByUser,
+			);
 
 			Promise.all(nmRelatedPromises).then(() => {
 				nm.deliver();
@@ -1455,20 +1471,12 @@ async function enqueueMentionNotifications(
 function createMentionedEventsInBackground(
 	localMentionedUsers: MinimumUser[],
 	note: Note,
+	mentionWebhooksByUser: WebhooksByUserMap,
 ): void {
 	if (localMentionedUsers.length === 0) return;
 
 	void (async () => {
 		const errors: unknown[] = [];
-		const webhooks = await getActiveWebhooks();
-		const mentionWebhooksByUser = new Map<MinimumUser["id"], typeof webhooks>();
-
-		for (const webhook of webhooks) {
-			if (!webhook.on.includes("mention")) continue;
-			const list = mentionWebhooksByUser.get(webhook.userId) ?? [];
-			list.push(webhook);
-			mentionWebhooksByUser.set(webhook.userId, list);
-		}
 
 		for (const u of localMentionedUsers) {
 			try {
@@ -1505,6 +1513,23 @@ function createMentionedEventsInBackground(
 			err,
 		});
 	});
+}
+
+function createWebhooksByUserMap(
+	webhooks: ActiveWebhook[],
+	event: "note" | "reply" | "renote" | "mention",
+): WebhooksByUserMap {
+	const webhooksByUser = new Map<MinimumUser["id"], ActiveWebhook[]>();
+
+	for (const webhook of webhooks) {
+		if (!webhook.on.includes(event)) continue;
+
+		const userWebhooks = webhooksByUser.get(webhook.userId) ?? [];
+		userWebhooks.push(webhook);
+		webhooksByUser.set(webhook.userId, userWebhooks);
+	}
+
+	return webhooksByUser;
 }
 
 function isNotePackAccessDeniedError(err: unknown): boolean {

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -397,7 +397,7 @@ export default async (
 			webhookDeliver(webhook, "reaction", {
 				note: await Notes.pack(note, { id: note.userId }),
 				reaction: {
-					user: await Users.pack(user, { id: note.userId }),
+					user: await Users.pack(user.id, { id: note.userId }),
 					emojiName: decodedReaction.name
 						? `:${decodedReaction.name}:`
 						: reaction + (existCount > 0 ? ` (+${existCount})` : ""),


### PR DESCRIPTION
### Motivation
- リアクションを配信するWebhookで `reaction.user` の `name` が `undefined` になる問題を回避するため、部分オブジェクト経由で `Users.pack` を呼ぶ経路を修正しました。
- 部分オブジェクトをそのまま使うとリポジトリが保持する完全なユーザー情報が参照されず項目欠落を招くため、ID指定で確実にDBから解決する必要がありました。
- また、複数イベントのWebhook取得処理が都度フィルタしていたため、事前にマップ化して効率化できる箇所を改善しました。

### Description
- `packages/backend/src/services/note/reaction/create.ts` で `Users.pack({ id: user.id }, { id: note.userId })` を `Users.pack(user.id, { id: note.userId })` に変更し、部分オブジェクト経由の優先利用を回避しました。
- `packages/backend/src/services/note/create.ts` に型別エイリアス `ActiveWebhook` と `WebhooksByUserMap` を追加し、`createWebhooksByUserMap` ヘルパーを実装して `note` / `reply` / `renote` / `mention` 用のWebhookをユーザー毎に事前集約するようにしました。
- `createMentionedEventsInBackground` のシグネチャを更新して事前に作成した `mentionWebhooksByUser` マップを受け取るように変更し、従来の `getActiveWebhooks()` を毎回呼ぶ処理を置き換えています。
- これらにより、Webhook配信時に常に完全なユーザー情報を使ってパックし、かつWebhook一覧の二重取得/多重フィルタを減らしています。

### Testing
- `pnpm --filter backend run lint` を実行しましたが、依存が未インストールの環境のため `rome` が見つからず `spawn rome ENOENT` で失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de0eda3908326b22fe4c6a6a32af1)