### PR TITLE
fix: revert blocking check added to note visibility

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -13,7 +13,6 @@ import {
 	NoteFavorites,
 	UserMemos,
 	UserProfiles,
-	Blockings,
 } from "../index.js";
 import type { Packed } from "@/misc/schema.js";
 import { nyaize } from "@/misc/nyaize.js";
@@ -450,17 +449,6 @@ export const NoteRepository = db.getRepository(Note).extend({
 		// localOnly が true かつ 自分がログインしてなければ非表示
 		if (note.localOnly && meId == null) {
 			return false;
-		}
-
-		if (meId != null && meId !== note.userId) {
-			const isBlocked = await Blockings.existsBy({
-				blockeeId: meId,
-				blockerId: note.userId,
-			});
-
-			if (isBlocked) {
-				return false;
-			}
 		}
 
 		return true;


### PR DESCRIPTION
### Motivation
- 2/13 に追加された `NoteRepository.isVisibleForMe` 内のブロック判定がタイムラインなどの可視性判定の共通経路で実行されるようになり、表示対象が過度に絞り込まれて特定ユーザの投稿しか流れなくなる可能性があったため、この変更を差し戻しました。\n
### Description
- `packages/backend/src/models/repositories/note.ts` から `Blockings` の import を削除し、`isVisibleForMe` 内で追加されていた `Blockings.existsBy` によるブロック判定を削除しました。\n
### Testing
- `pnpm --filter backend run lint` を実行しましたが、実行環境に `node_modules` と `rome` が無いため `ENOENT` で失敗しました（環境要因で自動テストは未完了）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ef2cf13f48326aaac5b6637c33583)