### PR TITLE
差し戻し: 2/13 の URI 判定とメディア安全性変更

### DIFF
--- a/packages/backend/src/misc/download-url.ts
+++ b/packages/backend/src/misc/download-url.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import * as net from "node:net";
 import * as stream from "node:stream";
 import * as util from "node:util";
 import got, * as Got from "got";
@@ -11,13 +10,8 @@ import IPCIDR from "ip-cidr";
 import PrivateIp from "private-ip";
 
 const pipeline = util.promisify(stream.pipeline);
-const blockedHostnames = new Set(["localhost", "localhost.localdomain"]);
 
 export async function downloadUrl(url: string, path: string): Promise<void> {
-	if (!isSafeUrl(url)) {
-		throw new StatusError("Invalid URL", 400);
-	}
-
 	const logger = new Logger("download");
 
 	logger.info(`Downloading ${chalk.cyan(url)} ...`);
@@ -25,13 +19,12 @@ export async function downloadUrl(url: string, path: string): Promise<void> {
 	const timeout = 30 * 1000;
 	const operationTimeout = 60 * 1000;
 	const maxSize = config.maxFileSize || 262144000;
-	const parsedUrl = new URL(url);
 
 	const req = got
 		.stream(url, {
 			headers: {
 				"User-Agent": config.userAgent,
-				Host: parsedUrl.hostname,
+				Host: new URL(url).hostname,
 			},
 			timeout: {
 				lookup: timeout,
@@ -51,12 +44,6 @@ export async function downloadUrl(url: string, path: string): Promise<void> {
 				limit: 0,
 			},
 		})
-		.on("redirect", (_res: Got.Response, opts: Got.NormalizedOptions) => {
-			if (!isSafeUrl(opts.url.toString())) {
-				logger.warn(`Blocked redirect URL: ${opts.url}`);
-				req.destroy(new StatusError("Invalid URL", 400));
-			}
-		})
 		.on("response", (res: Got.Response) => {
 			if (
 				(process.env.NODE_ENV === "production" ||
@@ -66,7 +53,7 @@ export async function downloadUrl(url: string, path: string): Promise<void> {
 			) {
 				if (isPrivateIp(res.ip)) {
 					logger.warn(`Blocked address: ${res.ip}`);
-					req.destroy(new StatusError("Invalid URL", 400));
+					req.destroy();
 				}
 			}
 
@@ -91,18 +78,12 @@ export async function downloadUrl(url: string, path: string): Promise<void> {
 	try {
 		await pipeline(req, fs.createWriteStream(path));
 	} catch (e) {
-		if (e instanceof StatusError) {
-			throw e;
-		}
-
 		if (e instanceof Got.HTTPError) {
 			throw new StatusError(
 				`${e.response.statusCode} ${e.response.statusMessage}`,
 				e.response.statusCode,
 				e.response.statusMessage,
 			);
-		} else if (e instanceof Got.RequestError && e.cause instanceof StatusError) {
-			throw e.cause;
 		} else {
 			throw e;
 		}
@@ -120,27 +101,4 @@ export function isPrivateIp(ip: string): boolean {
 	}
 
 	return PrivateIp(ip);
-}
-
-export function isSafeUrl(url: string | URL): boolean {
-	let parsedUrl: URL;
-	try {
-		parsedUrl = typeof url === "string" ? new URL(url) : url;
-	} catch {
-		return false;
-	}
-
-	if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-		return false;
-	}
-
-	const hostname = parsedUrl.hostname.replaceAll(/(\[)|(\])/g, "").toLowerCase();
-	if (hostname.length === 0 || blockedHostnames.has(hostname)) {
-		return false;
-	}
-	if (hostname.endsWith(".localhost")) {
-		return false;
-	}
-
-	return !(net.isIP(hostname) && isPrivateIp(hostname));
 }

--- a/packages/backend/src/remote/activitypub/db-resolver.ts
+++ b/packages/backend/src/remote/activitypub/db-resolver.ts
@@ -1,9 +1,11 @@
+import escapeRegexp from "escape-regexp";
 import config from "@/config/index.js";
 import type { Note } from "@/models/entities/note.js";
 import type {
 	CacheableRemoteUser,
 	CacheableUser,
 } from "@/models/entities/user.js";
+import { User, IRemoteUser } from "@/models/entities/user.js";
 import type { UserPublickey } from "@/models/entities/user-publickey.js";
 import type { MessagingMessage } from "@/models/entities/messaging-message.js";
 import {
@@ -18,7 +20,6 @@ import {
 	fetchUserByIdCache,
 	fetchUserByIdCacheMaybe,
 } from "@/services/user-cache.js";
-import { toPuny } from "@/misc/convert-host.js";
 import type { IObject } from "./type.js";
 import { getApId } from "./type.js";
 import { resolvePerson, updatePerson } from "./models/person.js";
@@ -46,19 +47,12 @@ export type UriParseResult =
 	  };
 
 export function parseUri(value: string | IObject): UriParseResult {
-	const uri = getApId(value);
-	const parsed = new URL(uri);
-
-	if (toPuny(parsed.host) !== toPuny(config.host)) {
-		return { local: false, uri };
-	}
-
 	const separator = "/";
-	const [, type, id, ...rest] = parsed.pathname.split(separator);
-	if (type == null || id == null) {
-		throw new Error(`Failed to parse local URI: ${uri}`);
-	}
 
+	const uri = new URL(getApId(value));
+	if (uri.origin !== config.url) return { local: false, uri: uri.href };
+
+	const [, type, id, ...rest] = uri.pathname.split(separator);
 	return {
 		local: true,
 		type,

--- a/packages/backend/src/server/proxy/proxy-media.ts
+++ b/packages/backend/src/server/proxy/proxy-media.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
-import { promises as dns } from "node:dns";
+import net from "node:net";
+import { promises } from "node:dns";
 import type Koa from "koa";
 import sharp from "sharp";
 import { sharpBmp } from "@misskey-dev/sharp-read-bmp";
@@ -10,7 +11,7 @@ import {
 	webpDefault,
 } from "@/services/drive/image-processor.js";
 import { createTemp } from "@/misc/create-temp.js";
-import { downloadUrl, isPrivateIp, isSafeUrl } from "@/misc/download-url.js";
+import { downloadUrl } from "@/misc/download-url.js";
 import { detectType } from "@/misc/get-file-info.js";
 import { StatusError } from "@/misc/fetch.js";
 import { FILE_TYPE_BROWSERSAFE } from "@/const.js";
@@ -34,29 +35,33 @@ export async function proxyMedia(ctx: Koa.Context) {
 		"media.misskeyusercontent.jp",
 	);
 
-	if (!isSafeUrl(url)) {
-		ctx.status = 400;
-		ctx.body = { message: "Invalid URL" };
-		return;
-	}
-
-	let resolvedAddresses;
+	let resolvedIps;
 	try {
 		const { hostname } = new URL(url);
-		resolvedAddresses = await dns.lookup(
-			hostname.replaceAll(/(\[)|(\])/g, ""),
-			{
-				all: true,
-				verbatim: true,
-			},
-		);
+		resolvedIps = await promises.resolve(hostname);
 	} catch (error) {
 		ctx.status = 400;
 		ctx.body = { message: "Invalid URL" };
 		return;
 	}
 
-	const isSSRF = resolvedAddresses.some(({ address }) => isPrivateIp(address));
+	const isSSRF = resolvedIps.some((ip) => {
+		if (net.isIPv4(ip)) {
+			const parts = ip.split(".").map(Number);
+			return (
+				parts[0] === 10 ||
+				(parts[0] === 172 && parts[1] >= 16 && parts[1] < 32) ||
+				(parts[0] === 192 && parts[1] === 168) ||
+				parts[0] === 127 ||
+				parts[0] === 0
+			);
+		} else if (net.isIPv6(ip)) {
+			return (
+				ip.startsWith("::") || ip.startsWith("fc00:") || ip.startsWith("fe80:")
+			);
+		}
+		return false;
+	});
 
 	if (isSSRF) {
 		ctx.status = 400;


### PR DESCRIPTION
### Motivation
- 2/13 に導入された URI 判定とメディアダウンロード周りの安全性強化が、連合配信時に画像付きノートが配送されない問題に関与している可能性があるため、まず最小差分で当該変更を元に戻して影響範囲を切り分ける目的で差し戻しました。

### Description
- `remote/activitypub/db-resolver.ts` の `parseUri` を以前の実装に戻し、`toPuny` ベース判定を削除して `new URL(...).origin !== config.url` によるローカル/リモート判定にしています。 
- `misc/download-url.ts` の `isSafeUrl` による事前検証やリダイレクト時の検証、関連の例外処理を差し戻して従来のダウンロードフローに戻しました。 
- `server/proxy/proxy-media.ts` は `isSafeUrl` の利用や `dns.lookup` + `isPrivateIp` 判定の変更を差し戻し、従来の `dns.resolve` を用いた名前解決と既存の SSRF 判定ロジックに戻しました。 

### Testing
- 実行した静的チェックは `pnpm -C packages/backend exec eslint src/remote/activitypub/db-resolver.ts src/misc/download-url.ts src/server/proxy/proxy-media.ts` で、ESLint v9 の設定要求（`eslint.config.*` 必須）により実行不能（失敗）でした。 
- `pnpm -C packages/backend lint` を実行しましたが、`rome` が見つからないか `node_modules` 未セットアップのため実行不能（失敗）でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f74fb2fd48326801c107af48cd4d3)