### PR TITLE
note テーブルのローカル未削除用部分インデックスを追加するマイグレーション

### DIFF
--- a/packages/backend/migration/1733000000000-add-local-not-deleted-note-index.js
+++ b/packages/backend/migration/1733000000000-add-local-not-deleted-note-index.js
@@ -1,0 +1,13 @@
+export class addLocalNotDeletedNoteIndex1733000000000 {
+	name = "addLocalNotDeletedNoteIndex1733000000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_note_local_not_deleted_id" ON "note" USING btree ("id") WHERE "userHost" IS NULL AND "deletedAt" IS NULL`,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_note_local_not_deleted_id"`);
+	}
+}


### PR DESCRIPTION
### Motivation
- `SELECT COUNT(1) FROM note WHERE "userHost" IS NULL AND "deletedAt" IS NULL` のようなクエリで `deletedAt` の事後フィルタを避け、実行計画と性能を改善するために部分的インデックスを追加します（対象ファイル: `packages/backend/migration/1733000000000-add-local-not-deleted-note-index.js`）。

### Description
- 新規マイグレーション `1733000000000-add-local-not-deleted-note-index.js` を追加し、`CREATE INDEX IF NOT EXISTS "idx_note_local_not_deleted_id" ON "note" ("id") WHERE "userHost" IS NULL AND "deletedAt" IS NULL` を作成し、`down` で `DROP INDEX IF EXISTS "idx_note_local_not_deleted_id"` を実行するロールバックを実装しました（非 CONCURRENTLY 実行を想定しています）。

### Testing
- `node --check packages/backend/migration/1733000000000-add-local-not-deleted-note-index.js` を実行して構文チェックは成功しました; 実データベース上の `EXPLAIN (ANALYZE, BUFFERS)` 等の性能比較はこの環境で実行できなかったため、導入後にお手元DBで比較を行ってください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f82ff6b6483268230eca84a27ee0f)