### PR TITLE
重複した note.tags インデックスを安全に削除するマイグレーション追加

### DIFF
--- a/packages/backend/migration/1733000000001-dropDuplicateIdxNoteTags.js
+++ b/packages/backend/migration/1733000000001-dropDuplicateIdxNoteTags.js
@@ -1,0 +1,34 @@
+export class dropDuplicateIdxNoteTags1733000000001 {
+	constructor() {
+		this.name = "dropDuplicateIdxNoteTags1733000000001";
+		this.transaction = false;
+	}
+
+	async up(queryRunner) {
+		const indexes = await queryRunner.query(
+			`SELECT indexname
+			 FROM pg_indexes
+			 WHERE schemaname = 'public'
+			   AND tablename = 'note'
+			   AND indexname IN ('IDX_NOTE_TAGS', 'idx_note_tags')`,
+			undefined,
+		);
+
+		const hasUpper = indexes.some((index) => index.indexname === 'IDX_NOTE_TAGS');
+		const hasLower = indexes.some((index) => index.indexname === 'idx_note_tags');
+
+		if (hasUpper && hasLower) {
+			await queryRunner.query(
+				`DROP INDEX CONCURRENTLY IF EXISTS public."IDX_NOTE_TAGS"`,
+				undefined,
+			);
+		}
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_NOTE_TAGS" ON public.note USING gin (tags)`,
+			undefined,
+		);
+	}
+}


### PR DESCRIPTION
### Motivation
- 大文字小文字の異なる `IDX_NOTE_TAGS` / `idx_note_tags` が重複して存在する可能性に対して、誤って唯一のインデックスを削除しないよう安全に対処するためのマイグレーションを追加します。

### Description
- `packages/backend/migration/1733000000001-dropDuplicateIdxNoteTags.js` を追加し、マイグレーションクラス内で `this.transaction = false` を設定して `CONCURRENTLY` を用いる操作を許可しています。 
- `up` では `pg_indexes` を照会して `IDX_NOTE_TAGS` と `idx_note_tags` の両方が存在する場合のみ `DROP INDEX CONCURRENTLY IF EXISTS public."IDX_NOTE_TAGS"` を実行するガードを追加しています。 
- `down` は `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_NOTE_TAGS" ON public.note USING gin (tags)` で巻き戻し可能にしています。 
- 副作用として、重複インデックスを削除した環境では書き込み時のインデックス更新コストとディスク使用量が改善される一方で、実行計画がわずかに変わる可能性があるため、重要なクエリは `EXPLAIN (ANALYZE, BUFFERS)` 等で再確認することを推奨します。

### Testing
- `node --check packages/backend/migration/1733000000001-dropDuplicateIdxNoteTags.js` を実行し構文チェックは成功しました。 
- `git status --short` で新規ファイルが検出されることを確認しました。 
- `git commit -m "Drop duplicate note tags index safely"` を実行して変更をコミットしました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f82b3bc648326a257277d8e8b2d69)