### PR TITLE
既読通知のRedisキャッシュ活用とフォールバック追加

### DIFF
--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -1,10 +1,15 @@
 import { In, LessThanOrEqual } from "typeorm";
 import { publishMainStream } from "@/services/stream.js";
 import { pushNotification } from "@/services/push-notification.js";
+import { Logger } from "@/services/logger.js";
 import type { User } from "@/models/entities/user.js";
 import type { Notification } from "@/models/entities/notification.js";
 import { Notifications, Users } from "@/models/index.js";
 import { redisClient } from "@/db/redis.js";
+import config from "@/config/index.js";
+
+const LATEST_READ_NOTIFICATION_TTL_SECONDS = 86400;
+const readNotificationLogger = new Logger("read-notification");
 
 export async function readNotification(
 	userId: User["id"],
@@ -26,16 +31,49 @@ export async function readNotification(
 
 	if (result.affected === 0) return;
 
-	if (!(await Users.getHasUnreadNotification(userId)))
+	if (!(await Users.getHasUnreadNotification(userId))) {
+		await updateLatestReadNotificationByIds(userId, notificationIds);
 		return postReadAllNotifications(userId);
-	else return postReadNotifications(userId, notificationIds);
+	} else {
+		return postReadNotifications(userId, notificationIds);
+	}
 }
 
 export async function readAllNotifications(
 	userId: User["id"],
 	latestNotificationId: Notification["id"],
 ) {
-	await redisClient.set(`latestReadNotification:${userId}`, latestNotificationId, "EX", 86400);
+	const cacheKey = getLatestReadNotificationCacheKey(userId);
+	const cachedLatestReadNotification = await redisClient.get(cacheKey);
+	if (cachedLatestReadNotification != null) {
+		const compared = compareNotificationIds(
+			latestNotificationId,
+			cachedLatestReadNotification,
+		);
+
+		if (compared != null && compared <= 0) {
+			readNotificationLogger.info(
+				"readAllNotifications skipped by cache",
+				{
+					userId,
+					latestNotificationId,
+					cachedLatestReadNotification,
+				},
+			);
+			return;
+		}
+
+		if (compared == null) {
+			readNotificationLogger.warn(
+				"readAllNotifications cache fallback due to invalid cache value",
+				{
+					userId,
+					latestNotificationId,
+					cachedLatestReadNotification,
+				},
+			);
+		}
+	}
 
 	const result = await Notifications.update(
 		{
@@ -49,6 +87,8 @@ export async function readAllNotifications(
 	);
 
 	if (result.affected === 0) return;
+
+	await updateLatestReadNotificationCache(userId, latestNotificationId);
 
 	return postReadAllNotifications(userId);
 }
@@ -79,4 +119,86 @@ function postReadNotifications(
 ) {
 	publishMainStream(userId, "readNotifications", notificationIds);
 	return pushNotification(userId, "readNotifications", { notificationIds });
+}
+
+function getLatestReadNotificationCacheKey(userId: User["id"]) {
+	return `latestReadNotification:${userId}`;
+}
+
+async function updateLatestReadNotificationByIds(
+	userId: User["id"],
+	notificationIds: Notification["id"][],
+) {
+	let latestReadNotificationId: Notification["id"] | null = null;
+
+	for (const notificationId of notificationIds) {
+		if (latestReadNotificationId == null) {
+			latestReadNotificationId = notificationId;
+			continue;
+		}
+
+		const compared = compareNotificationIds(notificationId, latestReadNotificationId);
+		if (compared == null) {
+			readNotificationLogger.warn(
+				"skip latestReadNotification cache update because notification id is not comparable",
+				{
+					userId,
+					notificationId,
+					latestReadNotificationId,
+				},
+			);
+			return;
+		}
+
+		if (compared > 0) {
+			latestReadNotificationId = notificationId;
+		}
+	}
+
+	if (latestReadNotificationId == null) return;
+
+	await updateLatestReadNotificationCache(userId, latestReadNotificationId);
+}
+
+async function updateLatestReadNotificationCache(
+	userId: User["id"],
+	latestNotificationId: Notification["id"],
+) {
+	await redisClient.set(
+		getLatestReadNotificationCacheKey(userId),
+		latestNotificationId,
+		"EX",
+		LATEST_READ_NOTIFICATION_TTL_SECONDS,
+	);
+}
+
+function compareNotificationIds(
+	a: Notification["id"],
+	b: Notification["id"],
+): -1 | 0 | 1 | null {
+	const idMethod = config.id.toLowerCase();
+
+	if (!isComparableNotificationId(a, idMethod) || !isComparableNotificationId(b, idMethod)) {
+		return null;
+	}
+
+	if (a === b) return 0;
+	return a < b ? -1 : 1;
+}
+
+function isComparableNotificationId(notificationId: string, idMethod: string) {
+	switch (idMethod) {
+		case "aid":
+			return /^[0-9a-z]{10}$/.test(notificationId);
+		case "meid":
+			return /^[0-9a-f]{24}$/.test(notificationId);
+		case "meidg":
+			return /^g[0-9a-f]{23}$/.test(notificationId);
+		case "ulid":
+			return /^[0-9A-HJKMNP-TV-Z]{26}$/.test(notificationId);
+		case "objectid":
+			return /^[0-9a-f]{24}$/.test(notificationId);
+		default:
+			return false;
+	}
 }


### PR DESCRIPTION
### Motivation
- `readAllNotifications` 呼び出しで既に最新既読IDがキャッシュされている場合は不要な DB 更新と通知発火を避けて性能を改善するため、キャッシュ値参照による早期 return を導入しました。 
- Redis の欠損や不整合で誤スキップが発生するリスクを避けるため、キャッシュが不正・比較不能な場合は必ず DB 更新へフォールバックする設計としました。 
- 複数端末や同時操作時の競合に備え、ID 比較は既存の ID フォーマットに合わせたバリデーション付き比較を行い、変化が確実にない時のみ早期 return するようにしています。 

### Description
- `readAllNotifications` でまず Redis の `latestReadNotification:${userId}` を読み、受け取った `latestNotificationId` がキャッシュ値以下（比較可能かつ `<=`）なら `Notifications.update(...)` をスキップして早期 return するロジックを追加しました。 
- キャッシュ値が不正・欠損・比較不能な場合は `warn` ログを出して必ず DB 更新にフォールバックするように変更しました。 
- DB 更新が成功した場合のみ Redis の `latestReadNotification:${userId}` を `EX 86400`（`LATEST_READ_NOTIFICATION_TTL_SECONDS` 定数）で更新するように変更し、`readNotification`（および `readNotificationByQuery` 経由での「全件既読到達」ケース）でも同キー更新処理を追加しました。 
- ID 比較は `config.id` に合わせて `aid`/`meid`/`meidg`/`ulid`/`objectid` のフォーマット検証を行い、比較不能な場合は `null` を返す実装にして誤判定を避け、観測性のため `read-notification` ロガーで `info`/`warn` を追加しました。 
- `publishMainStream` / `pushNotification` の呼び出し箇所や発火条件は既存のまま維持しており、既読状態に変化がない場合にはイベント発火を行わない挙動は変えていません。 

### Testing
- 自動チェックとして `pnpm --filter backend run lint` を実行しましたが、`rome` がローカルに無く（`node_modules` 未展開）コマンド実行できず失敗しました。 
- その他の自動テスト（ユニット/統合）は今回実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f86fa3c108326bbe4d47eb54e1f9e)