### PR TITLE
Redisのクールダウン判定を`SET ... NX EX`へ置換

### DIFF
--- a/packages/backend/src/server/activitypub.ts
+++ b/packages/backend/src/server/activitypub.ts
@@ -73,7 +73,14 @@ async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
         serverLogger.debug(`resendDeleteAccount: requester host ${host}`);
 
         const key = `deleteResend:${toPuny(host)}:${deleted.id}`;
-        if ((await redisClient.exists(key)) > 0) {
+        const acquired = await redisClient.set(
+                key,
+                "1",
+                "EX",
+                DELETE_RESEND_COOLDOWN_SEC,
+                "NX",
+        );
+        if (acquired === null) {
                 serverLogger.debug(
                         `resendDeleteAccount: cooldown active for ${host}`,
                 );
@@ -101,7 +108,6 @@ async function resendDeleteAccount(ctx: Router.RouterContext, userId: string) {
         );
 
         await deliverToUser(deleted as ILocalUser, activity, remote);
-        await redisClient.set(key, 1, "EX", DELETE_RESEND_COOLDOWN_SEC);
 }
 
 //#region Routing

--- a/packages/backend/src/server/api/endpoints/ap/show.ts
+++ b/packages/backend/src/server/api/endpoints/ap/show.ts
@@ -114,12 +114,11 @@ async function fetchAny(
 		if (local.type === "Note" && note?.uri && note.hasPoll) {
 			// Update questions if the stored (remote) note contains the poll
 			const key = `pollFetched:${note.uri}`;
-			if ((await redisClient.exists(key)) === 0) {
+			const acquired = await redisClient.set(key, "1", "EX", 60, "NX");
+			if (acquired !== null) {
 				if (await updateQuestion(note.uri)) {
 					local.object.poll = await populatePoll(note, me?.id ?? null);
 				}
-				// Allow fetching the poll again after 1 minute
-				await redisClient.set(key, 1, "EX", 60);
 			}
 		}
 		return local;


### PR DESCRIPTION
### Motivation
- Redisへの往復を削減するため、`EXISTS` 判定と別途の `SET` を組み合わせた実装を単一の `SET key "1" EX <sec> NX` に置き換えることを目的としています。
- 既存の「クールダウン中は処理を行わない」挙動を維持しつつ、ラウンドトリップ削減を図ります。

### Description
- `packages/backend/src/server/api/endpoints/ap/show.ts` の `pollFetched` 判定を `redisClient.exists(key)` から `const acquired = await redisClient.set(key, "1", "EX", 60, "NX"); if (acquired !== null) { ... }` に置換しました。
- `packages/backend/src/server/activitypub.ts` の `deleteResend` 判定を `redisClient.exists(key)` と後続の `set` の組合せから `SET key "1" EX DELETE_RESEND_COOLDOWN_SEC NX` に置換し、`acquired === null` の場合にクールダウン扱いで早期returnするようにしました。
- これにより既存の `exists` 呼び出しを削除し、1リクエストあたりのRedisラウンドトリップ数を削減しています。
- 実装変更に伴い、`deleteResend` は送信前にクールダウンキーを取得するようになり、送信処理が失敗した場合でもクールダウンが張られる可能性があります（再試行が遅延する副作用）。

### Testing
- 型チェックとして `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが、環境側で `@types/node` が見つからず `TS2688` により型チェックは失敗しました。
- 変更箇所は検索(`rg`)で確認し、該当ファイルの差分をコミットしています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f8726348883269d7e6ee53fe5ea9d)