### PR TITLE
fix(backend): run migrations with per-migration transaction mode

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"start": "pnpm node ./built/index.js",
 		"start:test": "NODE_ENV=test pnpm node ./built/index.js",
-		"migrate": "typeorm migration:run -d ormconfig.js",
-		"revertmigration": "typeorm migration:revert -d ormconfig.js",
+		"migrate": "typeorm migration:run -d ormconfig.js --transaction each",
+		"revertmigration": "typeorm migration:revert -d ormconfig.js --transaction each",
 		"check:connect": "node ./check_connect.js",
 		"build": "napi build --platform --release --cargo-cwd native-utils ./native-utils/built/ && pnpm swc src -d built -D",
 		"watch": "pnpm swc src -d built -D -w",


### PR DESCRIPTION
### Motivation
- TypeORM のグローバル transaction mode が `all` の場合に、マイグレーション側で `this.transaction = false` を指定した（例: `1733000000001-dropDuplicateIdxNoteTags` の `DROP INDEX CONCURRENTLY`）ときに発生する `ForbiddenTransactionModeOverrideError` を回避するため。 

### Description
- `packages/backend/package.json` の `migrate` と `revertmigration` スクリプトに `--transaction each` を追加してマイグレーションをマイグレーション単位でトランザクション実行するよう変更したため、`this.transaction = false` を使うマイグレーションが正しく実行されるようになる一方で、全体を一つのトランザクションで包む動作からマイグレーションごとのトランザクションに変わるため、途中で失敗しても既に適用されたマイグレーションはロールバックされない点に注意が必要である。 

### Testing
- `git diff` で `packages/backend/package.json` の変更（`--transaction each` 追加）を確認してコミットを作成済みであるが、環境内で `pnpm run migrate` や `typeorm --help` の実行を試みたところ `typeorm: not found`（`node_modules` 未インストール）で実行できなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f8866acb0832696125398847ff629)