### PR TITLE
rankResult の notesCount クエリに CACHE_TIME を追加

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/stats.ts
+++ b/packages/backend/src/server/api/endpoints/users/stats.ts
@@ -399,6 +399,7 @@ export default define(meta, paramDef, async (ps, me) => {
 				.andWhere("note.createdAt >= :borderDate", {
 					borderDate: borderDate.toISOString(),
 				})
+				.cache(CACHE_TIME)
 				.getCount(),
 			repliesCount: Notes.createQueryBuilder("note")
 				.where("note.userId = :userId", { userId: user.id })


### PR DESCRIPTION
### Motivation
- `packages/backend/src/server/api/endpoints/users/stats.ts` の `rankResult` 側 `awaitAll` ブロックで `notesCount` のみ他クエリと異なりキャッシュが無かったため、可読性と一貫性を保つために `CACHE_TIME` を使ってキャッシュを追加し、ただしこれにより `rankResult.notesCount` が最大で `CACHE_TIME`（約10分）分だけ遅延して見える可能性があります。

### Description
- `Notes.createQueryBuilder(...).andWhere("note.createdAt >= :borderDate", { borderDate: borderDate.toISOString() })` の直後に `.cache(CACHE_TIME)` を挿入して `.getCount()` の直前に配置しました（ファイル: `packages/backend/src/server/api/endpoints/users/stats.ts`）。

### Testing
- 自動チェックとして `git diff --check` を実行し問題はありませんでした（変更はコミット済み: `backend: add cache to rank notes count query`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f91114f148326972f7bea98315dbc)