### PR TITLE
fix(backend): web/index に getLocalNotesCount の import を追加

### DIFF
--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -18,6 +18,7 @@ import { KoaAdapter } from "@bull-board/koa";
 import { In, IsNull, Not, MoreThan } from "typeorm";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import config from "@/config/index.js";
+import { getLocalNotesCount } from "@/services/note/local-notes-count-cache.js";
 import {
 	Users,
 	Notes,


### PR DESCRIPTION
### Motivation
- ルートで `getLocalNotesCount` を呼び出している箇所で `ReferenceError: getLocalNotesCount is not defined` が発生しているため、最小変更でこの実行時エラーを解消する目的で修正しました。

### Description
- `packages/backend/src/server/web/index.ts` に `import { getLocalNotesCount } from "@/services/note/local-notes-count-cache.js";` を追加しました（ロジックやクエリは変更していません）。
- 副作用は極めて低いですが、依存解決で循環参照がある場合は起動時に別のエラーが発生する可能性があります。

### Testing
- `pnpm --filter backend run lint` を実行しましたが、この環境では `node_modules` 未導入のため `rome` が見つからず実行できませんでした（失敗）。
- 変更は1行の import 追加のみでコミット済みです（該当ファイル: `packages/backend/src/server/web/index.ts`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f92fef3e4832692319aa6b6bcf7de)