### PR TITLE
同一端末の自動バックアップを上書き保存へ修正

### DIFF
--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -67,7 +67,7 @@ import {
 	initializeDetectNetworkChange,
 } from "@/scripts/datasaver";
 import { acct } from "./filters/user";
-import { applyProfile, autoSave } from "./scripts/backup";
+import { applyProfile, autoSave, getCurrentUaClass, getProfileUaClass, isAutoProfile } from "./scripts/backup";
 import { v4 as uuid } from "uuid";
 
 let waitMessages: string[] = [];
@@ -1082,33 +1082,39 @@ const autoSaveConfig = async () => {
 					(await api("i/registry/get-all", {
 						scope: ["clientPreferencesProfiles"],
 					})) || {};
-				if (
-					Object.values(profiles).some(
-						(x) =>
-							x.name ===
-							`AutoSave: ${/mobile|iphone|android/.test(navigator.userAgent.toLowerCase()) ? "mobile" : "desktop"}`,
-					)
-				) {
-					const entry = Object.entries(profiles).find(
-						([key, value]) =>
-							value.name ===
-							`AutoSave: ${/mobile|iphone|android/.test(navigator.userAgent.toLowerCase()) ? "mobile" : "desktop"}`,
-					);
-					if (entry) {
-						const [key, value] = entry;
-						const { canceled } = await yesno({
-							type: "question",
-							text: "サーバ上に設定の自動保存が存在する様です。\n設定を復元しますか？",
-						});
-						if (!canceled) {
-							applyProfile(key);
-							await set("lastBackup", {
-								...lastBackupData,
-								[$i.id]: Date.now(),
-							});
-						} else {
-							defaultStore.set("autoSaveBackup", false);
+				const uaClass = getCurrentUaClass();
+				const latestAutoBackup = Object.entries(profiles)
+					.filter(([, value]) => isAutoProfile(value))
+					.filter(([, value]) => getProfileUaClass(value) === uaClass)
+					.sort((a, b) => {
+						const aTime = Date.parse(a[1].updatedAt ?? a[1].createdAt);
+						const bTime = Date.parse(b[1].updatedAt ?? b[1].createdAt);
+						const normalizedATime = Number.isNaN(aTime)
+							? Number.NEGATIVE_INFINITY
+							: aTime;
+						const normalizedBTime = Number.isNaN(bTime)
+							? Number.NEGATIVE_INFINITY
+							: bTime;
+						if (normalizedATime === normalizedBTime) {
+							return a[0].localeCompare(b[0]);
 						}
+						return normalizedBTime - normalizedATime;
+					})[0];
+
+				if (latestAutoBackup) {
+					const [key] = latestAutoBackup;
+					const { canceled } = await yesno({
+						type: "question",
+						text: "サーバ上に設定の自動保存が存在する様です。\n設定を復元しますか？",
+					});
+					if (!canceled) {
+						applyProfile(key);
+						await set("lastBackup", {
+							...lastBackupData,
+							[$i.id]: Date.now(),
+						});
+					} else {
+						defaultStore.set("autoSaveBackup", false);
 					}
 				} else {
 					if (

--- a/packages/client/src/scripts/backup.ts
+++ b/packages/client/src/scripts/backup.ts
@@ -13,6 +13,9 @@ type Profile = {
 	updatedAt: string | null;
 	misskeyVersion: string;
 	host: string;
+	kind?: "auto" | "manual";
+	uaClass?: "mobile" | "desktop";
+	clientId?: string;
 	settings: {
 		hot: Record<keyof typeof defaultStore.def, unknown>;
 		cold: Record<keyof typeof ColdDeviceStorage.default, unknown>;
@@ -24,35 +27,118 @@ type Profile = {
 	};
 };
 
-const scope = ["clientPreferencesProfiles"]
+const scope = ["clientPreferencesProfiles"];
+const autoSaveClientIdStorageKey = "autoSaveClientId";
+const autoSaveMaxPerUaClass = 5;
+
+function getDateValue(value: string | null | undefined): number {
+	if (!value) return Number.NEGATIVE_INFINITY;
+	const parsed = Date.parse(value);
+	if (Number.isNaN(parsed)) return Number.NEGATIVE_INFINITY;
+	return parsed;
+}
+
+export function getCurrentUaClass(): "mobile" | "desktop" {
+	return /mobile|iphone|android/.test(navigator.userAgent.toLowerCase())
+		? "mobile"
+		: "desktop";
+}
+
+function getAutoSaveClientId(): string {
+	const saved = localStorage.getItem(autoSaveClientIdStorageKey);
+	if (saved) return saved;
+
+	const created = uuid();
+	localStorage.setItem(autoSaveClientIdStorageKey, created);
+	return created;
+}
+
+export function getProfileUaClass(profile: Profile): "mobile" | "desktop" | null {
+	if (profile.uaClass === "mobile" || profile.uaClass === "desktop") {
+		return profile.uaClass;
+	}
+
+	if (profile.name === "AutoSave: mobile") {
+		return "mobile";
+	}
+
+	if (profile.name === "AutoSave: desktop") {
+		return "desktop";
+	}
+
+	return null;
+}
+
+export function isAutoProfile(profile: Profile): boolean {
+	if (profile.kind === "auto") return true;
+	return profile.name === "AutoSave: mobile" || profile.name === "AutoSave: desktop";
+}
+
+function sortByUpdatedAtDesc(
+	a: [string, Profile],
+	b: [string, Profile],
+): number {
+	const aTime = getDateValue(a[1].updatedAt ?? a[1].createdAt);
+	const bTime = getDateValue(b[1].updatedAt ?? b[1].createdAt);
+
+	if (aTime === bTime) {
+		return a[0].localeCompare(b[0]);
+	}
+
+	return bTime - aTime;
+}
+
+async function cleanupOldAutoSaves(
+	profiles: Record<string, Profile>,
+	uaClass: "mobile" | "desktop",
+): Promise<void> {
+	const autoProfiles = Object.entries(profiles)
+		.filter(([, value]) => isAutoProfile(value))
+		.filter(([, value]) => getProfileUaClass(value) === uaClass)
+		.sort(sortByUpdatedAtDesc);
+
+	const removeTargets = autoProfiles.slice(autoSaveMaxPerUaClass);
+	for (const [key] of removeTargets) {
+		await os.api("i/registry/remove", {
+			scope,
+			key,
+		});
+	}
+}
 
 export async function autoSave(blockUpdate = false): Promise<void> {
-	const profiles = (await os.api("i/registry/get-all", { scope })) || {}
+	const profiles = (await os.api("i/registry/get-all", { scope })) || {};
 
 	if (!profiles) return;
 
-	let id = uuid();
-	let name: Profile["name"] = `AutoSave: ${/mobile|iphone|android/.test(navigator.userAgent.toLowerCase()) ? "mobile" : "desktop"}`
-	let createdAt: Profile["createdAt"] = new Date().toISOString();
-	let updatedAt: Profile["updatedAt"] = null;
+	const uaClass = getCurrentUaClass();
+	const name: Profile["name"] = `AutoSave: ${uaClass}`;
+	const clientId = getAutoSaveClientId();
+	const now = new Date().toISOString();
+	const existingSameClientEntry = Object.entries(profiles)
+		.filter(([, value]) =>
+			isAutoProfile(value) &&
+			getProfileUaClass(value) === uaClass &&
+			value.clientId === clientId,
+		)
+		.sort(sortByUpdatedAtDesc)[0];
 
-	if (Object.values(profiles).some((x) => x.name === name)) {
-		if (blockUpdate) return;
-		const entry = Object.entries(profiles).find(([key, value]) => value.name === name);
-		if (entry) {
-			const [key, value] = entry;
-			id = key;
-			name = value.name;
-			createdAt = value.createdAt;
-			updatedAt = new Date().toISOString()
-		}
-	}
+	if (blockUpdate && !existingSameClientEntry) return;
+
+	const id = existingSameClientEntry?.[0] ?? uuid();
+	const createdAt: Profile["createdAt"] =
+		existingSameClientEntry?.[1].createdAt ?? now;
+	const updatedAt: Profile["updatedAt"] = existingSameClientEntry ? now : null;
+
 	const profile: Profile = {
 		name,
 		createdAt,
 		updatedAt,
 		misskeyVersion: version,
 		host,
+		kind: "auto",
+		uaClass,
+		clientId,
 		settings: getSettings(true),
 	};
 	await os.api("i/registry/set", {
@@ -60,8 +146,9 @@ export async function autoSave(blockUpdate = false): Promise<void> {
 		key: id,
 		value: profile,
 	});
-}
 
+	await cleanupOldAutoSaves({ ...profiles, [id]: profile }, uaClass);
+}
 
 export function getSettings(deviceOnly): Profile["settings"] {
 	const hot = {} as Record<keyof typeof defaultStore.def, unknown>;


### PR DESCRIPTION
### Motivation
- 同一端末（同一 `clientId`）で自動バックアップが増殖してしまう挙動を防ぎ、同一端末では常に1件を上書きして保持するための改善を行いました。 
- UA（mobile/desktop）ごとの最新復元と自動削除上限のロジックを維持・整備して、端末間の衝突や肥大化を抑制します。 
- 副作用として同一端末内で世代を残すことはできなくなるため、世代管理が必要な場合は手動バックアップを併用する必要があります。 

### Description
- `packages/client/src/scripts/backup.ts` にて、同一 `uaClass` + `clientId` に一致する既存の自動バックアップを検索し、存在する場合はその `key` を再利用して上書き保存するように `autoSave` を変更しました。 
- 上書き時は `createdAt` を維持して `updatedAt` のみ現在時刻に設定し、既存エントリが無ければ新規作成します。 
- `blockUpdate` の挙動を調整し、同一端末エントリがない場合のみ作成抑止となるようにしました。 
- 自動削除や選択ロジックのために `getCurrentUaClass` / `getProfileUaClass` / `isAutoProfile` / `sortByUpdatedAtDesc` / `cleanupOldAutoSaves` 等のユーティリティを追加し、`packages/client/src/init.ts` の初回復元判定を最新1件選択に合わせて更新しました。 

### Testing
- `pnpm -C packages/client lint` を実行しましたが、ローカル環境で依存が未インストールのため `rome` が見つからず `spawn rome ENOENT` により lint は実行できませんでした（失敗）。 
- その他の自動テストは実行しておらず、変更は静的差分確認と手動レビューで検証しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990172b12d08326b9160456e4eb7aa7)