### PR TITLE
fix(backend): DM配送対象の判定をIn条件へ修正

### DIFF
--- a/packages/backend/src/services/note/ap-deliver.ts
+++ b/packages/backend/src/services/note/ap-deliver.ts
@@ -10,7 +10,7 @@ import { deliverToRelays } from "../relay.js";
 import { decodeReaction, resolveApReaction } from "@/misc/reaction-lib.js";
 import { buildReactionDeliverManager } from "@/services/note/reaction/deliver.js";
 import { Emojis, NoteReactions, Notes, Users } from "@/models/index.js";
-import { IsNull } from "typeorm";
+import { In, IsNull } from "typeorm";
 import type { ILocalUser, User } from "@/models/entities/user.js";
 import type { NoteReaction } from "@/models/entities/note-reaction.js";
 import type { Note } from "@/models/entities/note.js";
@@ -95,14 +95,20 @@ async function renderNoteOrRenoteActivityFromNote(note: Note) {
 
 async function addNoteActivityDeliveryRecipes(dm: DeliverManager, note: Note) {
 	if (note.visibility === "specified") {
-		for (const u of await Users.findBy({ id: note.visibleUserIds as User["id"][] })) {
-			if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+		if (note.visibleUserIds.length > 0) {
+			for (const u of await Users.findBy({ id: In(note.visibleUserIds as User["id"][]) })) {
+				if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+			}
 		}
 	}
 
-	const mentionedUsers = await Users.findBy({ id: note.mentions as User["id"][] });
-	for (const u of mentionedUsers) {
-		if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+	if (note.mentions.length > 0) {
+		const mentionedUsers = await Users.findBy({
+			id: In(note.mentions as User["id"][]),
+		});
+		for (const u of mentionedUsers) {
+			if (Users.isRemoteUser(u)) dm.addDirectRecipe(u);
+		}
 	}
 
 	if (note.reply && note.reply.userHost !== null) {


### PR DESCRIPTION
### Motivation
- 投稿のAP配送をジョブ化した変更で、`visibleUserIds` / `mentions` の複数ID検索に誤った条件が入り、リモート宛のDM配送先が取得できず `deliver: 0` になる問題を修正するため。

### Description
- `packages/backend/src/services/note/ap-deliver.ts` に `In` を import し、`Users.findBy({ id: 配列 })` を `Users.findBy({ id: In(配列) })` に置換しました。 
- `visibleUserIds` と `mentions` の取得は空配列時にクエリを打たないようガードを追加しました。 
- 上記により、`specified` 可視性やメンション先のリモートユーザーを正しく配送レシピに追加するようにしています。

### Testing
- 実行したコード調査コマンド（`git log`, `git show`, `git diff`, ソース表示等）は成功し、変更箇所と履歴を確認しました。 (成功)
- `git add`/`git commit` による差分適用は正常に行われ、修正はコミット済みです。 (成功)
- `pnpm --filter backend run lint` を実行しましたが、`rome ENOENT` により失敗しました（`node_modules` 未構築のため）。 (失敗)
- 変更は型とクエリの修正のみで、本番挙動に影響するのは配送先が漏れていたケースの復元であり、同一inboxへの重複配送は既存の `DeliverManager` の重複排除で保護されています。 (注意)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914ae0cf108326b2f9927c9f61cfde)