### PR TITLE
notes/create に Redis ベースの冪等性ガードを追加

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -20,6 +20,15 @@ import { HOUR } from "@/const.js";
 import { getNote } from "../../common/getters.js";
 import { uploadFromUrl } from "@/services/drive/upload-from-url.js";
 import { publishMainStream } from "@/services/stream.js";
+import { redisClient } from "@/db/redis.js";
+
+const NOTES_CREATE_IDEMPOTENCY_TTL_SEC = 60;
+
+function normalizeIdempotencyKey(key: unknown): string | null {
+	if (typeof key !== "string") return null;
+	const normalized = key.trim();
+	return normalized.length > 0 ? normalized : null;
+}
 
 export const meta = {
 	tags: ["notes"],
@@ -48,6 +57,20 @@ export const meta = {
 	},
 
 	errors: {
+		duplicateRequest: {
+			message: "同じリクエストが短時間に送信されました。",
+			code: "DUPLICATE_REQUEST",
+			id: "8f1cbf7f-e932-47d5-a2bb-bddc877130af",
+			httpStatusCode: 409,
+		},
+
+		idempotencyKeyConflict: {
+			message: "Idempotency key がリクエスト本文とヘッダーで一致しません。",
+			code: "IDEMPOTENCY_KEY_CONFLICT",
+			id: "76090195-f1a3-44c0-95bc-e1db4f0a4d5f",
+			httpStatusCode: 400,
+		},
+
 		noSuchRenoteTarget: {
 			message: "その投稿は存在しません。",
 			code: "NO_SUCH_RENOTE_TARGET",
@@ -198,6 +221,7 @@ export const paramDef = {
 				],
 			},
 		},
+		idempotencyKey: { type: "string", maxLength: 128, nullable: true },
 	},
 	anyOf: [
 		{
@@ -238,8 +262,34 @@ export const paramDef = {
 	],
 } as const;
 
-export default define(meta, paramDef, async (ps, user) => {
+export default define(meta, paramDef, async (ps, user, _token, _file, _cleanup, _ip, headers) => {
 	const endpointStartedAt = Date.now();
+	const bodyIdempotencyKey = normalizeIdempotencyKey(ps.idempotencyKey);
+	const headerIdempotencyKey = normalizeIdempotencyKey(headers?.["idempotency-key"]);
+
+	if (
+		bodyIdempotencyKey != null &&
+		headerIdempotencyKey != null &&
+		bodyIdempotencyKey !== headerIdempotencyKey
+	) {
+		throw new ApiError(meta.errors.idempotencyKeyConflict);
+	}
+
+	const idempotencyKey = headerIdempotencyKey ?? bodyIdempotencyKey;
+	if (idempotencyKey != null) {
+		const redisKey = `notes:create:idempotency:${user.id}:${idempotencyKey}`;
+		const setResult = await redisClient.set(
+			redisKey,
+			"1",
+			"EX",
+			NOTES_CREATE_IDEMPOTENCY_TTL_SEC,
+			"NX",
+		);
+
+		if (setResult !== "OK") {
+			throw new ApiError(meta.errors.duplicateRequest);
+		}
+	}
 
 	if (user.movedToUri != null) throw new ApiError(meta.errors.accountLocked);
 	if (!ps.web && user.isMiniSilenced && ps.visibility === "public") {

--- a/packages/backend/test/note.ts
+++ b/packages/backend/test/note.ts
@@ -276,6 +276,37 @@ describe("Note", () => {
 	}));
 
 	describe("notes/create", () => {
+		it("同じ idempotencyKey で短時間に再投稿すると重複として拒否される", async(async () => {
+			const postData = {
+				text: "idempotency test",
+				idempotencyKey: "note-idempotency-test-key",
+			};
+
+			const firstRes = await request("/notes/create", postData, alice);
+			assert.strictEqual(firstRes.status, 200);
+
+			const secondRes = await request("/notes/create", postData, alice);
+			assert.strictEqual(secondRes.status, 409);
+			assert.strictEqual(secondRes.body.error.code, "DUPLICATE_REQUEST");
+		}));
+
+		it("idempotencyKey の本文とヘッダーが不一致なら拒否される", async(async () => {
+			const res = await request(
+				"/notes/create",
+				{
+					text: "idempotency header mismatch",
+					idempotencyKey: "body-key",
+				},
+				alice,
+				{
+					"Idempotency-Key": "header-key",
+				},
+			);
+
+			assert.strictEqual(res.status, 400);
+			assert.strictEqual(res.body.error.code, "IDEMPOTENCY_KEY_CONFLICT");
+		}));
+
 		it("投票を添付できる", async(async () => {
 			const res = await request(
 				"/notes/create",

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -73,6 +73,7 @@ export const request = async (
 	endpoint: string,
 	params: any,
 	me?: any,
+	extraHeaders?: Record<string, string>,
 ): Promise<{ body: any; status: number }> => {
 	const auth = me
 		? {
@@ -84,6 +85,7 @@ export const request = async (
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
+			...extraHeaders,
 		},
 		body: JSON.stringify(Object.assign(auth, params)),
 	});

--- a/packages/calckey-js/src/api.types.ts
+++ b/packages/calckey-js/src/api.types.ts
@@ -809,6 +809,7 @@ export type Endpoints = {
 	"notes/conversation": { req: TODO; res: TODO };
 	"notes/create": {
 		req: {
+			idempotencyKey?: string | null;
 			visibility?: "public" | "home" | "followers" | "specified";
 			visibleUserIds?: User["id"][];
 			text?: null | string;

--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -2195,6 +2195,31 @@ interface PostPayload {
         ccUserIds?: string[];
         inheritCc?: boolean;
         referenceIds?: string[];
+		idempotencyKey?: string;
+}
+
+const IDEMPOTENCY_KEY_REUSE_MS = 60 * 1000;
+let lastIdempotencyPayloadSignature: string | null = null;
+let lastIdempotencyKey: string | null = null;
+let lastIdempotencyGeneratedAt = 0;
+
+function resolveIdempotencyKey(postData: PostPayload): string {
+	const payloadSignature = JSON.stringify(postData);
+	const now = Date.now();
+	if (
+		lastIdempotencyKey != null &&
+		lastIdempotencyPayloadSignature === payloadSignature &&
+		now - lastIdempotencyGeneratedAt <= IDEMPOTENCY_KEY_REUSE_MS
+	) {
+		lastIdempotencyGeneratedAt = now;
+		return lastIdempotencyKey;
+	}
+
+	const newKey = uuid();
+	lastIdempotencyPayloadSignature = payloadSignature;
+	lastIdempotencyKey = newKey;
+	lastIdempotencyGeneratedAt = now;
+	return newKey;
 }
 
 function buildPostPayload(options: BuildPostPayloadOptions): PostPayload {
@@ -2305,6 +2330,7 @@ async function submitPostRequest({
 }: SubmitPostRequestOptions): Promise<void> {
 	posting = true;
 	try {
+		postData.idempotencyKey = resolveIdempotencyKey(postData);
 		await waitForFileSelectingToBeFalse(backupDraftData);
 		postData.fileIds =
 			((postData?.fileIds?.length ?? 0) + files.length > 0)

--- a/packages/client/src/os.ts
+++ b/packages/client/src/os.ts
@@ -42,6 +42,17 @@ export const api = ((
 	const authorization = authorizationToken
 		? `Bearer ${authorizationToken}`
 		: undefined;
+	const idempotencyKey =
+		endpoint === "notes/create" && typeof data.idempotencyKey === "string"
+			? data.idempotencyKey
+			: undefined;
+	const headers: Record<string, string> = {};
+	if (authorization) {
+		headers.authorization = authorization;
+	}
+	if (idempotencyKey) {
+		headers["Idempotency-Key"] = idempotencyKey;
+	}
 
 	const promise = new Promise((resolve, reject) => {
 		fetch(endpoint.indexOf("://") > -1 ? endpoint : `${apiUrl}/${endpoint}`, {
@@ -49,7 +60,7 @@ export const api = ((
 			body: JSON.stringify(data),
 			credentials: "omit",
 			cache: "no-cache",
-			headers: authorization ? { authorization } : {},
+			headers,
 		})
 			.then(async (res) => {
 				const body = res.status === 204 ? null : await res.json();


### PR DESCRIPTION
### Motivation
- 同一投稿の短時間重複送信を防ぎ、クライアント側のリトライによる二重投稿を抑止するために `notes/create` に冪等性制御を導入する。\

### Description
- サーバ側で `idempotencyKey`（リクエスト本文）と `Idempotency-Key`（HTTPヘッダー）を受け付け、本文とヘッダーが両方存在して不一致なら `IDEMPOTENCY_KEY_CONFLICT`（400）を返すようにした。\
- Redis の `SET ... NX EX`（TTL 60秒）を使って同一ユーザー＋同一キーの短時間再送を検出し、既に存在する場合は `DUPLICATE_REQUEST`（409）で拒否するガードを `notes/create` に追加した（サーバ実装：`packages/backend/src/server/api/endpoints/notes/create.ts`）。\
- クライアント側で `idempotencyKey` を生成して `notes/create` リクエスト本文に含め、同一ペイロードの短時間リトライでは同じキーを再利用するロジックを追加した（クライアント実装：`packages/client/src/components/MkPostForm.vue`）、および API 呼び出しで `Idempotency-Key` ヘッダーを付与するように変更した（`packages/client/src/os.ts`）。\
- 型定義に `notes/create.req.idempotencyKey` を追加（`packages/calckey-js/src/api.types.ts`）し、テストユーティリティとテストケースを追加して振る舞いを確認するためのケースを作成した（`packages/backend/test/utils.ts` と `packages/backend/test/note.ts` にテストを追加）。\
- 変更点の影響範囲として、Redis 可用性に依存する挙動になる点と、TTL（60秒）経過後は同一キーでも再投稿が可能になる点を注意事項として残す。\

### Testing
- 新たに追加した自動テストケース（`packages/backend/test/note.ts` の idempotency 関連テスト）はリポジトリに追加したが、ローカルでの実行を試みた `pnpm --filter backend run mocha -- test/note.ts` はテスト実行環境（`cross-env` が見つからない、`node_modules` 未インストール）により失敗したため実行できなかった。\
- テスト実行環境が整えば（依存インストール後）、追加したテストは以下のケースを検証する想定である：同一 `idempotencyKey` の短時間再投稿が `409 DUPLICATE_REQUEST` になること、本文とヘッダーのキー不一致で `400 IDEMPOTENCY_KEY_CONFLICT` になること。\
- コードは該当箇所へ変更を加えた状態で作成済みで、ユニットテストは追加済みだが、実行は環境整備後に要再確認である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992675e286083268d511047e572fde7)