### PR TITLE
fix(client): correct global selector syntax in queue overview

### DIFF
--- a/packages/client/src/pages/admin/overview.queue.vue
+++ b/packages/client/src/pages/admin/overview.queue.vue
@@ -135,30 +135,28 @@ onUnmounted(() => {
 
 <style lang="scss" module>
 .root {
-	&:global {
-		> .status {
-			padding: 0 0 1rem 0;
-		}
+	> :global(.status) {
+		padding: 0 0 1rem 0;
+	}
 
-		.reason {
-			font-size: 0.8em;
-			opacity: 0.8;
-		}
+	:global(.reason) {
+		font-size: 0.8em;
+		opacity: 0.8;
+	}
 
-		> .charts {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			gap: 0.75rem;
+	> :global(.charts) {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.75rem;
 
-			> .chart {
-				min-width: 0;
-				padding: 1rem;
-				background: var(--panel);
-				border-radius: var(--radius);
+		> :global(.chart) {
+			min-width: 0;
+			padding: 1rem;
+			background: var(--panel);
+			border-radius: var(--radius);
 
-				> .title {
-					font-size: 0.85em;
-				}
+			> :global(.title) {
+				font-size: 0.85em;
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation
- Vite/PostCSS のビルドで発生する `Missing whitespace before :global` エラーを回避するため、Vue SFC のモジュールスコープ内での `&:global` パターンを見直しました。

### Description
- `packages/client/src/pages/admin/overview.queue.vue` のスタイルを修正し、`&:global { ... }` 形式を `:global(...)` を使った明示的なセレクタ（`.status` / `.reason` / `.charts` / `.chart` / `.title`）に置き換えています。
- レイアウトやプロパティ（余白・フォントサイズ・グリッド等）は変更せず、表示上の意図は維持しています。
- 注意点として、`CSS Modules` 内での `:global(...)` の解釈により同名クラスが他で増えた場合の影響範囲が変わる可能性がある点を付記します。

### Testing
- `rg "&:global" packages/client/src/pages/admin/overview.queue.vue` による確認で対象ファイルに `&:global` が残っていないことを確認しました（成功）。
- `pnpm --filter client build` を試行しましたが、この環境は `node_modules` が無く `vite` が見つからなかったためビルド検証は実行できませんでした（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699282872a848326a65487ec02ce2ba5)