### PR TITLE
queue: use typed non-retryable flags instead of message matching

### DIFF
--- a/packages/backend/src/misc/fetch.ts
+++ b/packages/backend/src/misc/fetch.ts
@@ -244,7 +244,12 @@ export class StatusError extends Error {
 	public isClientError: boolean;
 	public isRetryable: boolean;
 
-	constructor(message: string, statusCode: number, statusMessage?: string) {
+	constructor(
+		message: string,
+		statusCode: number,
+		statusMessage?: string,
+		isRetryable?: boolean,
+	) {
 		super(message);
 		this.name = "StatusError";
 		this.statusCode = statusCode;
@@ -253,7 +258,10 @@ export class StatusError extends Error {
 			typeof this.statusCode === "number" &&
 			this.statusCode >= 400 &&
 			this.statusCode < 500;
-		this.isRetryable = !this.isClientError || this.statusCode === 429;
+		this.isRetryable =
+			typeof isRetryable === "boolean"
+				? isRetryable
+				: !this.isClientError || this.statusCode === 429;
 	}
 }
 

--- a/packages/backend/src/misc/identifiable-error.ts
+++ b/packages/backend/src/misc/identifiable-error.ts
@@ -4,10 +4,12 @@
 export class IdentifiableError extends Error {
 	public message: string;
 	public id: string;
+	public isRetryable: boolean;
 
-	constructor(id: string, message?: string) {
+	constructor(id: string, message?: string, isRetryable = true) {
 		super(message);
 		this.message = message || "";
 		this.id = id;
+		this.isRetryable = isRetryable;
 	}
 }

--- a/packages/backend/src/queue/delayed-retry-reason.ts
+++ b/packages/backend/src/queue/delayed-retry-reason.ts
@@ -50,6 +50,21 @@ const remoteErrorCodes = new Set([
 	"ESOCKETTIMEDOUT",
 ]);
 
+const remoteErrorNames = new Set(["TimeoutError"]);
+
+const remoteErrorMessagePatterns = [
+	"Promise timed out",
+	"maximum redirect reached",
+	"Bad Gateway",
+	"Hostname/IP does not match certificate's altnames",
+	"alert handshake failure",
+	"EPROTO",
+];
+
+const localErrorMessagePatterns = [
+	"job stalled more than allowable limit",
+];
+
 function classifyDelayedRetryReason(error: unknown): DelayedRetryReason {
 	if (error instanceof StatusError) {
 		return error.isRetryable ? "remote" : "local";
@@ -60,6 +75,13 @@ function classifyDelayedRetryReason(error: unknown): DelayedRetryReason {
 		if (
 			typeof anyError.code === "string" &&
 			remoteErrorCodes.has(anyError.code)
+		) {
+			return "remote";
+		}
+
+		if (
+			typeof anyError.name === "string" &&
+			remoteErrorNames.has(anyError.name)
 		) {
 			return "remote";
 		}
@@ -86,12 +108,20 @@ function classifyDelayedRetryReasonByMessage(
 		if (message.includes(code)) return "remote";
 	}
 
+	for (const pattern of remoteErrorMessagePatterns) {
+		if (message.includes(pattern)) return "remote";
+	}
+
 	if (
 		["TypeError", "SyntaxError", "ReferenceError", "RangeError"].some((name) =>
 			message.includes(name),
 		)
 	) {
 		return "local";
+	}
+
+	for (const pattern of localErrorMessagePatterns) {
+		if (message.includes(pattern)) return "local";
 	}
 
 	if (message.length > 0) {

--- a/packages/backend/src/queue/processors/inbox.ts
+++ b/packages/backend/src/queue/processors/inbox.ts
@@ -23,8 +23,26 @@ import type { CacheableRemoteUser } from "@/models/entities/user.js";
 import type { UserPublickey } from "@/models/entities/user-publickey.js";
 import { shouldBlockInstance } from "@/misc/should-block-instance.js";
 import { verifySignature } from "@/remote/activitypub/check-fetch.js";
+import { IdentifiableError } from "@/misc/identifiable-error.js";
 
 const logger = new Logger("inbox");
+
+const nonRetryableIdentifiableErrorIds = new Set([
+	"639cc3a5-fe68-b071-0c20-413c887054cd", // deleted note reaction
+	"119b8757-2ba5-385e-82cf-7fa4bc73c4d1", // muted reaction rejected
+]);
+
+
+function isNonRetryableInboxError(error: unknown): boolean {
+	if (error instanceof StatusError) return !error.isRetryable;
+
+	if (error instanceof IdentifiableError) {
+		if (nonRetryableIdentifiableErrorIds.has(error.id)) return true;
+		return !error.isRetryable;
+	}
+
+	return false;
+}
 
 // Processing when an activity arrives in the user's inbox
 export default async (job: Bull.Job<InboxJobData>): Promise<string> => {
@@ -201,7 +219,18 @@ export default async (job: Bull.Job<InboxJobData>): Promise<string> => {
 	job.progress(50);
 
 	// アクティビティを処理
-	await perform(authUser.user, activity, job.data.user?.id);
+	try {
+		await perform(authUser.user, activity, job.data.user?.id);
+	} catch (error) {
+		if (isNonRetryableInboxError(error)) {
+			if (error instanceof Error) {
+				return `skip: non retryable inbox error ${error.message}`;
+			}
+			return "skip: non retryable inbox error";
+		}
+		throw error;
+	}
+
 	job.progress(100);
 	return "ok";
 };

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -171,6 +171,7 @@ export default async (
 			throw new IdentifiableError(
 				"639cc3a5-fe68-b071-0c20-413c887054cd",
 				"削除された投稿に対してはリアクション出来ません。",
+				false,
 			);
 		}
 	})();
@@ -229,6 +230,7 @@ export default async (
 			throw new IdentifiableError(
 				"119b8757-2ba5-385e-82cf-7fa4bc73c4d1",
 				"投稿者のリアクションミュート設定の為、リアクションが拒否されました。",
+				false,
 			);
 		}
 


### PR DESCRIPTION
### Motivation
- エラー文言に依存した `includes(...)` 判定は文言変更で誤検出しやすいため、再試行可否はエラーオブジェクト側で明示したい。 
- `inbox` の処理で「再試行しても意味のない失敗」を安定して `skip` 扱いにできるようにするため。 
- `notes/create` や `reaction/create` といったエラー発生箇所で、発生時に再試行可否を設定できるようにして運用負荷を下げるため。 

### Description
- `packages/backend/src/misc/identifiable-error.ts` に `isRetryable` フラグを追加し、デフォルト `true` としてエラー生成側で再試行可否を指定可能にしました。 
- `packages/backend/src/misc/fetch.ts` の `StatusError` に `isRetryable?: boolean` を追加し、未指定時は従来の 4xx は非再試行（ただし 429 は再試行可）という既存挙動を維持するようにしました。 
- `packages/backend/src/queue/processors/inbox.ts` の判定ロジックをメッセージ照合から撤廃し、`StatusError.isRetryable` / `IdentifiableError.isRetryable`（および既知の特定IDセット）に基づくコード判定へ切り替え、`perform(...)` 実行を `try/catch` でラップして非再試行は `skip` として扱うようにしました。 
- `packages/backend/src/services/note/reaction/create.ts` で、削除済み投稿へのリアクションや投稿者ミュートによる拒否など明らかに再試行不要なケースを `IdentifiableError(..., false)` で送出するようにしました。 
- `packages/backend/src/queue/delayed-retry-reason.ts` において、リモート系／ローカル系のパターン判定を補強（`remoteErrorNames` / `remoteErrorMessagePatterns` / `localErrorMessagePatterns` を追加）し、メッセージベース分類の精度を改善しました。 
- 副作用として `IdentifiableError` にプロパティが増えたため、将来このクラスをシリアライズして出力する箇所がある場合は差分が発生する可能性がある点と、`StatusError` の第4引数を誤設定すると再試行挙動に影響する点に注意が必要です。 

### Testing
- `pnpm -C packages/backend lint` を実行しましたが、ローカル環境で `node_modules` が未導入なため `rome` が見つからず実行失敗しました（`spawn rome ENOENT`）。 
- 自動化テスト／lint は依存解決された環境で再実行が必要です（今回の変更は型／API 追加のため `rome` 等の静的チェックで警告が出る可能性があります）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929b0f82248326a3ad3cb95d9869d0)