### PR TITLE
backend: Accept重複受信時のfollow request未存在エラーを非再試行化

### DIFF
--- a/packages/backend/src/queue/processors/inbox.ts
+++ b/packages/backend/src/queue/processors/inbox.ts
@@ -30,6 +30,7 @@ const logger = new Logger("inbox");
 const nonRetryableIdentifiableErrorIds = new Set([
 	"639cc3a5-fe68-b071-0c20-413c887054cd", // deleted note reaction
 	"119b8757-2ba5-385e-82cf-7fa4bc73c4d1", // muted reaction rejected
+	"8884c2dd-5795-4ac9-b27e-6a01d38190f9", // duplicated Accept without follow request
 ]);
 
 

--- a/packages/backend/src/services/following/requests/accept.ts
+++ b/packages/backend/src/services/following/requests/accept.ts
@@ -28,6 +28,7 @@ export default async function (
 		throw new IdentifiableError(
 			"8884c2dd-5795-4ac9-b27e-6a01d38190f9",
 			"No follow request.",
+			false,
 		);
 	}
 


### PR DESCRIPTION
### Motivation
- 重複した `Accept`` を受け取った際に、`follow request` が見つからないエラーでジョブが再試行され続けて Failed/Delayed が増えるのを防止するため。これによりノイズとリトライ負荷を低減する。 

### Description
- `packages/backend/src/services/following/requests/accept.ts` の `request == null` 分岐で投げる `IdentifiableError` を `new IdentifiableError("8884c2dd-5795-4ac9-b27e-6a01d38190f9", "No follow request.", false)` として `isRetryable = false` に変更しました。 
- `packages/backend/src/queue/processors/inbox.ts` の `nonRetryableIdentifiableErrorIds` に同ID `8884c2dd-5795-4ac9-b27e-6a01d38190f9` を追加して、inbox 側でも明示的に非再試行扱いとしています。 
- 副作用として、一時的な順序ずれ等で本来再試行したいケースもこのIDでは `skip` になり再試行されなくなる可能性があるため、その場合は別IDで retryable に分ける設計を検討してください。 

### Testing
- `pnpm --filter backend run lint` を実行しようとしましたが、依存が未インストールで `rome` が見つからず `spawn rome ENOENT` により実行できませんでした（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992d890418083269ef27bb606df4dea)