### PR TITLE
backend: refine delayed retry reason classification

### DIFF
--- a/packages/backend/src/queue/delayed-retry-reason.ts
+++ b/packages/backend/src/queue/delayed-retry-reason.ts
@@ -56,14 +56,20 @@ const remoteErrorMessagePatterns = [
 	"Promise timed out",
 	"maximum redirect reached",
 	"Bad Gateway",
+	"Gateway Time-out",
+	"Gateway Timeout",
 	"Hostname/IP does not match certificate's altnames",
 	"alert handshake failure",
 	"EPROTO",
+	"socket hang up",
 ];
 
 const localErrorMessagePatterns = [
 	"job stalled more than allowable limit",
+	"Acquire mutex",
 ];
+
+const remoteHttpStatusPattern = /\b5\d\d\b/;
 
 function classifyDelayedRetryReason(error: unknown): DelayedRetryReason {
 	if (error instanceof StatusError) {
@@ -110,6 +116,10 @@ function classifyDelayedRetryReasonByMessage(
 
 	for (const pattern of remoteErrorMessagePatterns) {
 		if (message.includes(pattern)) return "remote";
+	}
+
+	if (remoteHttpStatusPattern.test(message)) {
+		return "remote";
 	}
 
 	if (


### PR DESCRIPTION
## 概要
- delayed ジョブの原因分類に、運用ログで頻出していたパターンを追加しました。
- `U` (unknown) に偏っていた `5xx` / `socket hang up` / `Acquire mutex` をより実態に沿って分類します。

## 変更内容
- `packages/backend/src/queue/delayed-retry-reason.ts`
  - remote 判定メッセージに以下を追加
    - `Gateway Time-out`
    - `Gateway Timeout`
    - `socket hang up`
  - local 判定メッセージに以下を追加
    - `Acquire mutex`
  - メッセージ中の HTTP 5xx を remote として扱う正規表現判定を追加
    - `\b5\d\d\b`

## 期待される効果
- queue widget / queue stats 上の `U` が減り、`remote`/`local` の内訳が運用実態に近づく。
- 対向サーバー不調と自サーバー内要因（mutex timeout）の切り分けがしやすくなる。

## 副作用・注意点
- 5xx を包括的に remote 扱いするため、理論上は自サーバー起因で 5xx 文字列が現れるケースも remote に寄る可能性があります。
- 既存ダッシュボードの時系列比較では、分類ルール変更時点を境に `unknown` と `remote/local` の比率が変化します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ff1eeb288326acedb8eeea9e97e0)