### PR TITLE
fix(backend): include username in auth user cache select

### DIFF
--- a/packages/backend/src/server/api/authenticate.ts
+++ b/packages/backend/src/server/api/authenticate.ts
@@ -17,6 +17,7 @@ export class AuthenticationError extends Error {
 
 const AUTH_USER_SELECT = {
 	id: true,
+	username: true,
 	host: true,
 	isSuspended: true,
 	isAdmin: true,


### PR DESCRIPTION
### Motivation
- 2/12 の認証キャッシュ最適化以降、認証で取得されるローカルユーザーに `username` が含まれず、`src = users` 指定のアンテナ判定で投稿者の acct 比較が `undefined@<host>` になりローカルユーザー指定アンテナの受信漏れが発生していたため、`username` を認証取得の選択列に追加しました。

### Description
- `packages/backend/src/server/api/authenticate.ts` の `AUTH_USER_SELECT` に `username: true` を追加して、認証経由で取得されるユーザーオブジェクトに `username` が含まれるようにしました（副作用は認証時の SELECT に列が1つ増えるだけで限定的です）。

### Testing
- 自動型チェックとして `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが、実行環境に `@types/node` がないためコンパイルは失敗しました（環境依存の型定義不足によるエラー）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69946fc59384832694533053e3d4d509)