### PR TITLE
パスキー認証をMisskey/WebAuthn仕様に合わせて修正

### DIFF
--- a/packages/backend/migration/1735000000000-passkey-enhancements.js
+++ b/packages/backend/migration/1735000000000-passkey-enhancements.js
@@ -1,0 +1,32 @@
+export class passkeyEnhancements1735000000000 {
+	name = "passkeyEnhancements1735000000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "user_security_key" ADD "signCount" integer NOT NULL DEFAULT 0`,
+		);
+		await queryRunner.query(
+			`COMMENT ON COLUMN "user_security_key"."signCount" IS 'Signature counter from authenticatorData for replay detection.'`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "passkey_login_challenge" ("id" character varying(32) NOT NULL, "challenge" character varying(64) NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_passkey_login_challenge_id" PRIMARY KEY ("id"))`,
+		);
+		await queryRunner.query(
+			`COMMENT ON COLUMN "passkey_login_challenge"."challenge" IS 'Hex-encoded sha256 hash of the challenge.'`,
+		);
+		await queryRunner.query(
+			`COMMENT ON COLUMN "passkey_login_challenge"."createdAt" IS 'The date challenge was created for expiry purposes.'`,
+		);
+		await queryRunner.query(
+			`CREATE INDEX "IDX_passkey_login_challenge_challenge" ON "passkey_login_challenge" ("challenge") `,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(
+			`DROP INDEX "public"."IDX_passkey_login_challenge_challenge"`,
+		);
+		await queryRunner.query(`DROP TABLE "passkey_login_challenge"`);
+		await queryRunner.query(`ALTER TABLE "user_security_key" DROP COLUMN "signCount"`);
+	}
+}

--- a/packages/backend/src/daemons/janitor.ts
+++ b/packages/backend/src/daemons/janitor.ts
@@ -1,7 +1,7 @@
 // TODO: 消したい
 
 const interval = 30 * 60 * 1000;
-import { AttestationChallenges } from "@/models/index.js";
+import { AttestationChallenges, PasskeyLoginChallenges } from "@/models/index.js";
 import { LessThan } from "typeorm";
 
 /**
@@ -10,6 +10,10 @@ import { LessThan } from "typeorm";
 export default function () {
 	async function tick() {
 		await AttestationChallenges.delete({
+			createdAt: LessThan(new Date(new Date().getTime() - 5 * 60 * 1000)),
+		});
+
+		await PasskeyLoginChallenges.delete({
 			createdAt: LessThan(new Date(new Date().getTime() - 5 * 60 * 1000)),
 		});
 	}

--- a/packages/backend/src/db/postgre.ts
+++ b/packages/backend/src/db/postgre.ts
@@ -76,6 +76,7 @@ import { Webhook } from "@/models/entities/webhook.js";
 import { UserIp } from "@/models/entities/user-ip.js";
 import { NoteEdit } from "@/models/entities/note-edit.js";
 import { UserMemo } from "@/models/entities/user-memo.js";
+import { PasskeyLoginChallenge } from "@/models/entities/passkey-login-challenge.js";
 
 import { entities as charts } from "@/services/chart/entities.js";
 import { envOption } from "../env.js";
@@ -139,6 +140,7 @@ export const entities = [
 	UserMemo,
 	UsedUsername,
 	AttestationChallenge,
+	PasskeyLoginChallenge,
 	Following,
 	FollowRequest,
 	Muting,

--- a/packages/backend/src/models/entities/passkey-login-challenge.ts
+++ b/packages/backend/src/models/entities/passkey-login-challenge.ts
@@ -1,0 +1,33 @@
+import {
+	Entity,
+	PrimaryColumn,
+	Column,
+	Index,
+} from "typeorm";
+import { id } from "../id.js";
+
+@Entity()
+export class PasskeyLoginChallenge {
+	@PrimaryColumn(id())
+	public id: string;
+
+	@Index()
+	@Column("varchar", {
+		length: 64,
+		comment: "Hex-encoded sha256 hash of the challenge.",
+	})
+	public challenge: string;
+
+	@Column("timestamp with time zone", {
+		comment: "The date challenge was created for expiry purposes.",
+	})
+	public createdAt: Date;
+
+	constructor(data: Partial<PasskeyLoginChallenge>) {
+		if (data == null) return;
+
+		for (const [k, v] of Object.entries(data)) {
+			(this as any)[k] = v;
+		}
+	}
+}

--- a/packages/backend/src/models/entities/user-security-key.ts
+++ b/packages/backend/src/models/entities/user-security-key.ts
@@ -45,6 +45,12 @@ export class UserSecurityKey {
 	})
 	public name: string;
 
+	@Column("integer", {
+		default: 0,
+		comment: "Signature counter from authenticatorData for replay detection.",
+	})
+	public signCount: number;
+
 	constructor(data: Partial<UserSecurityKey>) {
 		if (data == null) return;
 

--- a/packages/backend/src/models/index.ts
+++ b/packages/backend/src/models/index.ts
@@ -71,6 +71,7 @@ import { Webhook } from "./entities/webhook.js";
 import { UserIp } from "./entities/user-ip.js";
 import { NoteEdit } from "./entities/note-edit.js";
 import { UserMemo } from "./entities/user-memo.js";
+import { PasskeyLoginChallenge } from "./entities/passkey-login-challenge.js";
 
 export const Announcements = db.getRepository(Announcement);
 export const AnnouncementReads = db.getRepository(AnnouncementRead);
@@ -89,6 +90,7 @@ export const UserProfiles = db.getRepository(UserProfile);
 export const UserKeypairs = db.getRepository(UserKeypair);
 export const UserPendings = db.getRepository(UserPending);
 export const AttestationChallenges = db.getRepository(AttestationChallenge);
+export const PasskeyLoginChallenges = db.getRepository(PasskeyLoginChallenge);
 export const UserSecurityKeys = db.getRepository(UserSecurityKey);
 export const UserPublickeys = db.getRepository(UserPublickey);
 export const UserLists = UserListRepository;

--- a/packages/backend/src/server/api/2fa.ts
+++ b/packages/backend/src/server/api/2fa.ts
@@ -108,6 +108,7 @@ export function verifyLogin({
 	clientData,
 	signature,
 	challenge,
+	requireUserVerification = false,
 }: {
 	publicKey: Buffer;
 	authenticatorData: Buffer;
@@ -115,6 +116,7 @@ export function verifyLogin({
 	clientData: any;
 	signature: Buffer;
 	challenge: string;
+	requireUserVerification?: boolean;
 }) {
 	if (clientData.type !== "webauthn.get") {
 		throw new Error("type is not webauthn.get");
@@ -127,15 +129,44 @@ export function verifyLogin({
 		throw new Error("origin mismatch");
 	}
 
+	if (authenticatorData.length < 37) {
+		throw new Error("authenticatorData too short");
+	}
+
+	const rpIdHash = authenticatorData.slice(0, 32);
+	const rpIdHashReal = hash(Buffer.from(config.hostname, "utf-8"));
+
+	if (!rpIdHash.equals(rpIdHashReal)) {
+		throw new Error("rpIdHash mismatch");
+	}
+
+	const flags = authenticatorData[32];
+	const userPresent = !!(flags & 0x01);
+	const userVerified = !!(flags & 0x04);
+
+	if (!userPresent) {
+		throw new Error("user not present");
+	}
+
+	if (requireUserVerification && !userVerified) {
+		throw new Error("user not verified");
+	}
+
+	const signCount = authenticatorData.readUInt32BE(33);
 	const verificationData = Buffer.concat(
 		[authenticatorData, hash(clientDataJSON)],
 		32 + authenticatorData.length,
 	);
 
-	return crypto
+	const isValid = crypto
 		.createVerify("SHA256")
 		.update(verificationData)
 		.verify(PEMString(publicKey), signature);
+
+	return {
+		isValid,
+		signCount,
+	};
 }
 
 export const procedures = {

--- a/packages/backend/src/server/api/endpoints/i/2fa/key-done.ts
+++ b/packages/backend/src/server/api/endpoints/i/2fa/key-done.ts
@@ -78,6 +78,7 @@ export default define(meta, paramDef, async (ps, user) => {
 	}
 
 	const authData = Buffer.from(attestation.authData);
+	const signCount = authData.readUInt32BE(33);
 	const credentialIdLength = authData.readUInt16BE(53);
 	const credentialId = authData.slice(55, 55 + credentialIdLength);
 	const publicKeyData = authData.slice(55 + credentialIdLength);
@@ -132,6 +133,7 @@ export default define(meta, paramDef, async (ps, user) => {
 		lastUsed: new Date(),
 		name: ps.name,
 		publicKey: verificationData.publicKey.toString("hex"),
+		signCount,
 	});
 
 	// Publish meUpdated event

--- a/packages/backend/src/server/api/endpoints/i/2fa/register-key.ts
+++ b/packages/backend/src/server/api/endpoints/i/2fa/register-key.ts
@@ -1,5 +1,5 @@
 import define from "../../../define.js";
-import { UserProfiles, AttestationChallenges } from "@/models/index.js";
+import { UserProfiles, AttestationChallenges, UserSecurityKeys } from "@/models/index.js";
 import { promisify } from "node:util";
 import * as crypto from "node:crypto";
 import { genId } from "@/misc/gen-id.js";
@@ -32,9 +32,9 @@ export default define(meta, paramDef, async (ps, user) => {
 		throw new Error("incorrect password");
 	}
 
-	// if (!profile.twoFactorEnabled) {
-	// 	throw new Error("2fa not enabled");
-	// }
+	if (!profile.twoFactorEnabled) {
+		throw new Error("2fa not enabled");
+	}
 
 	// 32 byte challenge
 	const entropy = await randomBytes(32);
@@ -54,8 +54,15 @@ export default define(meta, paramDef, async (ps, user) => {
 		registrationChallenge: true,
 	});
 
+	const securityKeys = await UserSecurityKeys.findBy({
+		userId: user.id,
+	});
+
 	return {
 		challengeId,
 		challenge,
+		excludeCredentials: securityKeys.map((key) => ({
+			id: key.id,
+		})),
 	};
 });

--- a/packages/backend/src/server/api/index.ts
+++ b/packages/backend/src/server/api/index.ts
@@ -19,6 +19,7 @@ import compatibility from "./compatibility.js";
 import handler from "./api-handler.js";
 import signup from "./private/signup.js";
 import signin from "./private/signin.js";
+import signinPasskeyChallenge from "./private/signin-passkey-challenge.js";
 import signupPending from "./private/signup-pending.js";
 import verifyEmail from "./private/verify-email.js";
 import discord from "./service/discord.js";
@@ -207,6 +208,7 @@ for (const endpoint of [...endpoints, ...compatibility]) {
 
 router.post("/signup", signup);
 router.post("/signin", signin);
+router.post("/signin/passkey-challenge", signinPasskeyChallenge);
 router.post("/signup-pending", signupPending);
 router.post("/verify-email", verifyEmail);
 

--- a/packages/backend/src/server/api/private/signin-passkey-challenge.ts
+++ b/packages/backend/src/server/api/private/signin-passkey-challenge.ts
@@ -1,0 +1,30 @@
+import type Koa from "koa";
+import config from "@/config/index.js";
+import { PasskeyLoginChallenges } from "@/models/index.js";
+import { genId } from "@/misc/gen-id.js";
+import { randomBytes } from "node:crypto";
+import { hash } from "../2fa.js";
+
+export default async (ctx: Koa.Context) => {
+	ctx.set("Access-Control-Allow-Origin", config.url);
+	ctx.set("Access-Control-Allow-Credentials", "true");
+
+	const challenge = randomBytes(32)
+		.toString("base64")
+		.replace(/=/g, "")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_");
+	const challengeId = genId();
+
+	await PasskeyLoginChallenges.insert({
+		id: challengeId,
+		challenge: hash(Buffer.from(challenge, "utf-8")).toString("hex"),
+		createdAt: new Date(),
+	});
+
+	ctx.body = {
+		challenge,
+		challengeId,
+	};
+	ctx.status = 200;
+};

--- a/packages/backend/src/server/api/private/signin.ts
+++ b/packages/backend/src/server/api/private/signin.ts
@@ -8,6 +8,7 @@ import {
 	UserProfiles,
 	UserSecurityKeys,
 	AttestationChallenges,
+	PasskeyLoginChallenges,
 } from "@/models/index.js";
 import type { ILocalUser } from "@/models/entities/user.js";
 import { genId } from "@/misc/gen-id.js";
@@ -37,7 +38,6 @@ export default async (ctx: Koa.Context) => {
 	}
 
 	try {
-		// not more than 1 attempt per second and not more than 10 attempts per hour
 		await limiter(
 			{ key: "signin", duration: 60 * 60 * 1000, max: 10, minInterval: 1000 },
 			getIpHash(ctx.ip),
@@ -51,6 +51,145 @@ export default async (ctx: Koa.Context) => {
 				id: "22d05606-fbcf-421a-a2db-b32610dcfd1b",
 			},
 		};
+		return;
+	}
+
+	async function fail(
+		userId?: string,
+		status?: number,
+		failure?: { id: string },
+	) {
+		if (userId) {
+			await Signins.insert({
+				id: genId(),
+				createdAt: new Date(),
+				userId,
+				ip: ctx.ip,
+				headers: ctx.headers,
+				success: false,
+			});
+		}
+
+		error(
+			status || 500,
+			failure || { id: "4e30e80c-e338-45a0-8c8f-44455efa3b76" },
+		);
+	}
+
+	const passkeyAuth =
+		typeof body.credentialId === "string" &&
+		typeof body.authenticatorData === "string" &&
+		typeof body.clientDataJSON === "string" &&
+		typeof body.signature === "string";
+
+	if (passkeyAuth && typeof body.challengeId === "string") {
+		const clientDataJSON = Buffer.from(body.clientDataJSON, "hex");
+		const clientData = JSON.parse(clientDataJSON.toString("utf-8"));
+		const keyId = Buffer.from(
+			body.credentialId.replace(/-/g, "+").replace(/_/g, "/"),
+			"base64",
+		).toString("hex");
+
+		const securityKey = await UserSecurityKeys.findOneBy({ id: keyId });
+
+		if (!securityKey) {
+			await fail(undefined, 403, {
+				id: "66269679-aeaf-4474-862b-eb761197e046",
+			});
+			return;
+		}
+
+		const user = (await Users.findOneBy({
+			id: securityKey.userId,
+			host: IsNull(),
+		})) as ILocalUser;
+
+		if (!user || user.isSuspended) {
+			await fail(securityKey.userId, 403, {
+				id: "e03a5f46-d309-4865-9b69-56282d94e1eb",
+			});
+			return;
+		}
+
+		if (body.userHandle != null) {
+			if (typeof body.userHandle !== "string") {
+				await fail(user.id, 400, {
+					id: "93b86c4b-72f9-40eb-9815-798928603d1e",
+				});
+				return;
+			}
+
+			const userHandle = Buffer.from(body.userHandle, "hex").toString("utf-8");
+
+			if (userHandle !== user.id) {
+				await fail(user.id, 403, {
+					id: "93b86c4b-72f9-40eb-9815-798928603d1e",
+				});
+				return;
+			}
+		}
+
+		const challengeHash = hash(Buffer.from(clientData.challenge, "utf-8")).toString("hex");
+
+		const userChallenge = await AttestationChallenges.findOneBy({
+			userId: user.id,
+			id: body.challengeId,
+			registrationChallenge: false,
+			challenge: challengeHash,
+		});
+
+		const globalChallenge = await PasskeyLoginChallenges.findOneBy({
+			id: body.challengeId,
+			challenge: challengeHash,
+		});
+
+		if (!userChallenge && !globalChallenge) {
+			await fail(user.id, 403, {
+				id: "2715a88a-2125-4013-932f-aa6fe72792da",
+			});
+			return;
+		}
+
+		await AttestationChallenges.delete({ userId: user.id, id: body.challengeId });
+		await PasskeyLoginChallenges.delete({ id: body.challengeId });
+
+		const createdAt = userChallenge?.createdAt ?? globalChallenge?.createdAt;
+		if (!createdAt || new Date().getTime() - createdAt.getTime() >= 5 * 60 * 1000) {
+			await fail(user.id, 403, {
+				id: "2715a88a-2125-4013-932f-aa6fe72792da",
+			});
+			return;
+		}
+
+		const verificationResult = verifyLogin({
+			publicKey: Buffer.from(securityKey.publicKey, "hex"),
+			authenticatorData: Buffer.from(body.authenticatorData, "hex"),
+			clientDataJSON,
+			clientData,
+			signature: Buffer.from(body.signature, "hex"),
+			challenge: (userChallenge?.challenge ?? globalChallenge!.challenge),
+			requireUserVerification: false,
+		});
+
+		if (!verificationResult.isValid) {
+			await fail(user.id, 403, {
+				id: "93b86c4b-72f9-40eb-9815-798928603d1e",
+			});
+			return;
+		}
+
+		if (securityKey.signCount > 0 && verificationResult.signCount <= securityKey.signCount) {
+			await fail(user.id, 403, {
+				id: "93b86c4b-72f9-40eb-9815-798928603d1e",
+			});
+			return;
+		}
+
+		securityKey.lastUsed = new Date();
+		securityKey.signCount = verificationResult.signCount;
+		await UserSecurityKeys.save(securityKey);
+
+		signin(ctx, user);
 		return;
 	}
 
@@ -69,7 +208,6 @@ export default async (ctx: Koa.Context) => {
 		return;
 	}
 
-	// Fetch user
 	const user = (await Users.findOneBy({
 		usernameLower: username.toLowerCase(),
 		host: IsNull(),
@@ -90,8 +228,6 @@ export default async (ctx: Koa.Context) => {
 	}
 
 	const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
-
-	// Compare password
 	const same = await comparePassword(password, profile.password!);
 
 	if (same && isOldAlgorithm(profile.password!)) {
@@ -99,38 +235,21 @@ export default async (ctx: Koa.Context) => {
 		await UserProfiles.save(profile);
 	}
 
-	async function fail(status?: number, failure?: { id: string }) {
-		// Append signin history
-		await Signins.insert({
-			id: genId(),
-			createdAt: new Date(),
-			userId: user.id,
-			ip: ctx.ip,
-			headers: ctx.headers,
-			success: false,
-		});
-
-		error(
-			status || 500,
-			failure || { id: "4e30e80c-e338-45a0-8c8f-44455efa3b76" },
-		);
-	}
-
 	if (!profile.twoFactorEnabled) {
 		if (same) {
 			signin(ctx, user);
 			return;
-		} else {
-			await fail(403, {
-				id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			});
-			return;
 		}
+
+		await fail(user.id, 403, {
+			id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
+		});
+		return;
 	}
 
 	if (token) {
 		if (!same) {
-			await fail(403, {
+			await fail(user.id, 403, {
 				id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
 			});
 			return;
@@ -139,132 +258,59 @@ export default async (ctx: Koa.Context) => {
 		const verified = (speakeasy as any).totp.verify({
 			secret: profile.twoFactorSecret,
 			encoding: "base32",
-			token: token,
+			token,
 			window: 2,
 		});
 
 		if (verified) {
 			signin(ctx, user);
 			return;
-		} else {
-			await fail(403, {
-				id: "cdf1235b-ac71-46d4-a3a6-84ccce48df6f",
-			});
-			return;
-		}
-	} else if (body.credentialId) {
-		if (!(same || profile.usePasswordLessLogin)) {
-			await fail(403, {
-				id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			});
-			return;
 		}
 
-		const clientDataJSON = Buffer.from(body.clientDataJSON, "hex");
-		const clientData = JSON.parse(clientDataJSON.toString("utf-8"));
-		const challenge = await AttestationChallenges.findOneBy({
-			userId: user.id,
-			id: body.challengeId,
-			registrationChallenge: false,
-			challenge: hash(clientData.challenge).toString("hex"),
+		await fail(user.id, 403, {
+			id: "cdf1235b-ac71-46d4-a3a6-84ccce48df6f",
 		});
-
-		if (!challenge) {
-			await fail(403, {
-				id: "2715a88a-2125-4013-932f-aa6fe72792da",
-			});
-			return;
-		}
-
-		await AttestationChallenges.delete({
-			userId: user.id,
-			id: body.challengeId,
-		});
-
-		if (new Date().getTime() - challenge.createdAt.getTime() >= 5 * 60 * 1000) {
-			await fail(403, {
-				id: "2715a88a-2125-4013-932f-aa6fe72792da",
-			});
-			return;
-		}
-
-		const securityKey = await UserSecurityKeys.findOneBy({
-			id: Buffer.from(
-				body.credentialId.replace(/-/g, "+").replace(/_/g, "/"),
-				"base64",
-			).toString("hex"),
-		});
-
-		if (!securityKey) {
-			await fail(403, {
-				id: "66269679-aeaf-4474-862b-eb761197e046",
-			});
-			return;
-		}
-
-		const isValid = verifyLogin({
-			publicKey: Buffer.from(securityKey.publicKey, "hex"),
-			authenticatorData: Buffer.from(body.authenticatorData, "hex"),
-			clientDataJSON,
-			clientData,
-			signature: Buffer.from(body.signature, "hex"),
-			challenge: challenge.challenge,
-		});
-
-		if (isValid) {
-			signin(ctx, user);
-			return;
-		} else {
-			await fail(403, {
-				id: "93b86c4b-72f9-40eb-9815-798928603d1e",
-			});
-			return;
-		}
-	} else {
-		if (!(same || profile.usePasswordLessLogin)) {
-			await fail(403, {
-				id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-			});
-			return;
-		}
-
-		const keys = await UserSecurityKeys.findBy({
-			userId: user.id,
-		});
-
-		if (keys.length === 0) {
-			await fail(403, {
-				id: "f27fd449-9af4-4841-9249-1f989b9fa4a4",
-			});
-			return;
-		}
-
-		// 32 byte challenge
-		const challenge = randomBytes(32)
-			.toString("base64")
-			.replace(/=/g, "")
-			.replace(/\+/g, "-")
-			.replace(/\//g, "_");
-
-		const challengeId = genId();
-
-		await AttestationChallenges.insert({
-			userId: user.id,
-			id: challengeId,
-			challenge: hash(Buffer.from(challenge, "utf-8")).toString("hex"),
-			createdAt: new Date(),
-			registrationChallenge: false,
-		});
-
-		ctx.body = {
-			challenge,
-			challengeId,
-			securityKeys: keys.map((key) => ({
-				id: key.id,
-			})),
-		};
-		ctx.status = 200;
 		return;
 	}
-	// never get here
+
+	if (!(same || profile.usePasswordLessLogin)) {
+		await fail(user.id, 403, {
+			id: "932c904e-9460-45b7-9ce6-7ed33be7eb2c",
+		});
+		return;
+	}
+
+	const keys = await UserSecurityKeys.findBy({ userId: user.id });
+
+	if (keys.length === 0) {
+		await fail(user.id, 403, {
+			id: "f27fd449-9af4-4841-9249-1f989b9fa4a4",
+		});
+		return;
+	}
+
+	const challenge = randomBytes(32)
+		.toString("base64")
+		.replace(/=/g, "")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_");
+
+	const challengeId = genId();
+
+	await AttestationChallenges.insert({
+		userId: user.id,
+		id: challengeId,
+		challenge: hash(Buffer.from(challenge, "utf-8")).toString("hex"),
+		createdAt: new Date(),
+		registrationChallenge: false,
+	});
+
+	ctx.body = {
+		challenge,
+		challengeId,
+		securityKeys: keys.map((key) => ({
+			id: key.id,
+		})),
+	};
+	ctx.status = 200;
 };

--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -61,8 +61,15 @@
 					primary
 					:disabled="signing"
 					style="margin: 1rem auto"
-					>{{ signing ? i18n.ts.loggingIn : i18n.ts.login }}</MkButton
-				>
+					>{{ signing ? i18n.ts.loggingIn : i18n.ts.login }}</MkButton>
+				<MkButton
+					v-if="window.PublicKeyCredential"
+					class="_formBlock"
+					type="button"
+					:disabled="signing || queryingKey"
+					@click="signinWithPasskey"
+					style="margin: 0 auto"
+				>{{ i18n.ts.securityKey }}</MkButton>
 			</div>
 			<div
 				v-if="totpLogin"
@@ -178,7 +185,6 @@ let password = $ref("");
 let token = $ref("");
 let host = $ref(toUnicode(configHost));
 let totpLogin = $ref(false);
-let credential = $ref(null);
 let challengeData = $ref(null);
 let queryingKey = $ref(false);
 let hCaptchaResponse = $ref(null);
@@ -263,6 +269,7 @@ function queryKey() {
 					transports: ["usb", "nfc", "ble", "internal"],
 				})),
 				timeout: 60 * 1000,
+				userVerification: "preferred",
 			},
 		})
 		.catch(() => {
@@ -296,6 +303,48 @@ function queryKey() {
 				type: "error",
 				text: i18n.ts.signinFailed,
 			});
+			signing = false;
+		});
+}
+
+
+async function signinWithPasskey() {
+	if (!window.PublicKeyCredential || !navigator.credentials) return;
+	signing = true;
+	queryingKey = true;
+
+	os.api("signin/passkey-challenge", {}, undefined, true)
+		.then((res) => {
+			challengeData = res;
+			return navigator.credentials.get({
+				publicKey: {
+					challenge: byteify(res.challenge, "base64"),
+					timeout: 60 * 1000,
+					userVerification: "preferred",
+				},
+			});
+		})
+		.then((passkeyCredential) => {
+			const credential = passkeyCredential as PublicKeyCredential;
+			const response = credential.response as AuthenticatorAssertionResponse;
+			return os.api("signin", {
+				signature: hexify(response.signature),
+				authenticatorData: hexify(response.authenticatorData),
+				clientDataJSON: hexify(response.clientDataJSON),
+				credentialId: credential.id,
+				userHandle: response.userHandle ? hexify(response.userHandle) : null,
+				challengeId: challengeData.challengeId,
+				"hcaptcha-response": hCaptchaResponse,
+				"g-recaptcha-response": reCaptchaResponse,
+			});
+		})
+		.then((res) => {
+			emit("login", res);
+			return onLogin(res);
+		})
+		.catch(loginFailed)
+		.finally(() => {
+			queryingKey = false;
 			signing = false;
 		});
 }

--- a/packages/client/src/pages/settings/2fa.vue
+++ b/packages/client/src/pages/settings/2fa.vue
@@ -269,9 +269,20 @@ function addSecurityKey() {
 							name: $i!.username,
 							displayName: $i!.name,
 						},
-						pubKeyCredParams: [{ alg: -7, type: "public-key" }],
+						pubKeyCredParams: [
+							{ alg: -7, type: "public-key" },
+							{ alg: -257, type: "public-key" },
+						],
+						authenticatorSelection: {
+							residentKey: "preferred",
+							userVerification: "preferred",
+						},
 						timeout: 60000,
-						attestation: "direct",
+						attestation: "none",
+						excludeCredentials: (reg!.excludeCredentials ?? []).map((key) => ({
+							id: byteify(key.id, "hex"),
+							type: "public-key",
+						})),
 					},
 					saving: true,
 				};


### PR DESCRIPTION
### Motivation
- パスキー（WebAuthn）優先ログインの実装が一部仕様と異なり、`userHandle` の扱いやチャレンジ比較が不安定だったため、Misskey 実装と仕様に近づけることを目的としています。 
- 鍵登録時のポリシーが緩くなっていたため、Misskey 側の方針に合わせて `twoFactorEnabled` 前提を復帰します。 

### Description
- サーバー側でパスキー（アサーション）処理において、クライアントから `userHandle` が送られた場合は復号して解決したユーザーIDと一致することを必須検証するようにしました（`packages/backend/src/server/api/private/signin.ts`）。
- パスキー用チャレンジのハッシュ化入力を `Buffer.from(..., "utf-8")` に統一して比較の決定性を向上させました（`signin` と `signin-passkey-challenge`、登録チャレンジ生成箇所）。
- 検証関数 `verifyLogin` を強化して `authenticatorData` 長さ、`rpIdHash` の検査、UP/UV フラグのチェックと署名カウンタ（`signCount`）の取得を行うようにし、検証結果として `isValid` と `signCount` を返すようにしました（`packages/backend/src/server/api/2fa.ts`）。
- 鍵登録エンドポイント `i/2fa/register-key` で `twoFactorEnabled` のチェックを再度有効化し、またクライアント側で送信される `excludeCredentials`・`authenticatorSelection`・複数 `pubKeyCredParams`・`attestation` を Misskey 互換に調整しました（`packages/backend/src/server/api/endpoints/i/2fa/register-key.ts`、`packages/client/src/components/MkSignin.vue`、`packages/client/src/pages/settings/2fa.vue`）。
- パスキー優先ログイン用にグローバルチャレンジ保存用のエンティティ `PasskeyLoginChallenge` とマイグレーション、ジャニタでの削除処理、`/signin/passkey-challenge` エンドポイントを追加しました（`packages/backend/src/models/entities/passkey-login-challenge.ts`、`packages/backend/migration/1735000000000-passkey-enhancements.js`、`packages/backend/src/daemons/janitor.ts`、`packages/backend/src/server/api/private/signin-passkey-challenge.ts`）。

### Testing
- `curl` によるリモートコード参照で、参照した `i/2fa/register-key` と `MkSignin.vue` の内容を確認しました（取得成功）。
- `pnpm -C packages/backend run lint` を実行しましたが、依存関係（`node_modules`／`rome` 等）が未導入の環境のため失敗しました（環境起因の失敗）。
- Playwright を使ったローカル UI 確認を試みましたが、ローカルサーバーが起動しておらず `Page.goto` が `ERR_EMPTY_RESPONSE` で失敗しました（環境起因）。
- 変更点は静的に差分で確認済みで、サーバー側の検証強化とクライアントのリクエスト調整は意図通り反映されていますが、統合テストは依存解決とサーバー起動後に実行が必要です。

想定される副作用: `userHandle` 検証を追加したため、一部の authenticator やブラウザ組み合わせでこれまで通っていた認証が失敗する可能性があり、`twoFactorEnabled` を必須化したことで 2FA 未設定ユーザーは鍵登録ができなくなります。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f2fd99ac83268570d878e6715a03)