### PR TITLE
設定: セキュリティ画面のレイアウトと文言を整備

### DIFF
--- a/packages/client/src/pages/settings/security.vue
+++ b/packages/client/src/pages/settings/security.vue
@@ -1,36 +1,40 @@
 <template>
 	<div class="_formRoot">
-		<FormSection>
+		<FormSection class="_formBlock">
 			<template #label>{{ i18n.ts.password }}</template>
-			<FormButton primary @click="change()">{{
-				i18n.ts.changePassword
-			}}</FormButton>
+			<FormSlot>
+				<FormButton primary @click="change()">{{
+					i18n.ts.changePassword
+				}}</FormButton>
+			</FormSlot>
 		</FormSection>
 
-		<FormSection>
+		<FormSection class="_formBlock">
 			<template #label>{{ i18n.ts.twoStepAuthentication }}</template>
 			<X2fa />
 		</FormSection>
 
-		<FormSection>
+		<FormSection class="_formBlock">
 			<template #label>{{ i18n.ts.signinHistory }}</template>
 			<MkPagination :pagination="pagination" disable-auto-load>
+				<template #empty>
+					<FormInfo>{{ i18n.ts.noHistory }}</FormInfo>
+				</template>
 				<template #default="{ items }">
-					<div>
+					<div v-panel class="signin-history">
 						<div
 							v-for="item in items"
 							:key="item.id"
-							v-panel
-							class="timnmucd"
+							class="signin-history-item"
 						>
 							<header>
 								<i
 									v-if="item.success"
-									class="ph-check ph-bold ph-lg icon succ"
+									class="ph-check-circle ph-bold ph-lg icon succ"
 								></i>
 								<i
 									v-else
-									class="ph-circle-wavy-warning ph-bold ph-lg icon fail"
+									class="ph-x-circle ph-bold ph-lg icon fail"
 								></i>
 								<code class="ip _monospace">{{ item.ip }}</code>
 								<MkTime :time="item.createdAt" class="time" />
@@ -41,7 +45,7 @@
 			</MkPagination>
 		</FormSection>
 
-		<FormSection>
+		<FormSection class="_formBlock">
 			<FormSlot>
 				<FormButton danger @click="regenerateToken"
 					><i class="ph-arrows-clockwise ph-bold ph-lg"></i>
@@ -60,6 +64,7 @@ import X2fa from "./2fa.vue";
 import FormSection from "@/components/form/section.vue";
 import FormSlot from "@/components/form/slot.vue";
 import FormButton from "@/components/MkButton.vue";
+import FormInfo from "@/components/MkInfo.vue";
 import MkPagination from "@/components/MkPagination.vue";
 import * as os from "@/os";
 import { i18n } from "@/i18n";
@@ -111,7 +116,7 @@ function regenerateToken(): void {
 		type: "password",
 	}).then(({ canceled, result: password }) => {
 		if (canceled) return;
-		os.api("i/regenerate_token", {
+		os.api("i/regenerate-token", {
 			password: password,
 		});
 	});
@@ -128,7 +133,12 @@ definePageMetadata({
 </script>
 
 <style lang="scss" scoped>
-.timnmucd {
+.signin-history {
+	border-radius: 0.5rem;
+	overflow: hidden;
+}
+
+.signin-history-item {
 	padding: 1rem;
 
 	&:first-child {


### PR DESCRIPTION
### Motivation
- セキュリティ設定画面が他の設定画面と比べてレイアウトやブロックの見た目が揃っておらず、表示を他画面に合わせて統一するための変更です。  
- またログイン履歴の空状態表示がなく見た目がわかりにくかったため、空状態の文言追加や履歴リストの表示改善、API呼び出し名の誤りを直しました。  
- 副作用としてはアイコン（成功/失敗）やリストの見た目が変わるため、既存のデザインに慣れているユーザーには見え方が変わる点と、APIエンドポイント名を`i/regenerate-token`へ変更したためサーバーが旧エンドポイントのみ対応している環境では影響が出る可能性があります。  

### Description
- `packages/client/src/pages/settings/security.vue`の各`FormSection`へ`class="_formBlock"`を付与し、パスワード変更ボタンを`FormSlot`内に移動して他画面と同等のブロックレイアウトにしました。  
- ログイン履歴表示を単一パネル風のコンテナにまとめるためにDOMを`signin-history`/`signin-history-item`に整理し、空状態用に`<template #empty>`で`FormInfo`（`i18n.ts.noHistory`）を追加しました。  
- 成功/失敗アイコンをより判別しやすい`ph-check-circle`/`ph-x-circle`へ変更し、対応するSCSSを追加・調整しました（旧`timnmucd`を置換）。  
- 誤っていたAPI呼び出し`i/regenerate_token`を`i/regenerate-token`へ修正し、`FormInfo`をインポートしました。  

### Testing
- `pnpm --filter client run lint`を実行しましたが、`rome`が見つからず`node_modules`未導入のため実行不可（失敗）。  
- Playwrightでの画面キャプチャを試みましたが、ローカルの開発サーバーが起動しておらず`ERR_EMPTY_RESPONSE`で取得できませんでした（失敗）。  
- 上記環境依存のため自動テストは未実行で、変更は主にビルド済み環境での表示確認が必要です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995214389708326abc4e2e36a8401bd)