### PR TITLE
ログイン画面でセキュリティキーボタンをDiscordログインの上に配置

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -62,14 +62,6 @@
 					:disabled="signing"
 					style="margin: 1rem auto"
 					>{{ signing ? i18n.ts.loggingIn : i18n.ts.login }}</MkButton>
-				<MkButton
-					v-if="isPasskeySupported"
-					class="_formBlock"
-					type="button"
-					:disabled="signing || queryingKey"
-					@click="signinWithPasskey"
-					style="margin: 0 auto"
-				>{{ i18n.ts.securityKey }}</MkButton>
 			</div>
 			<div
 				v-if="totpLogin"
@@ -150,6 +142,16 @@
 				></i
 				>{{ i18n.t("signinWith", { x: "GitHub" }) }}</a
 			>
+			<button
+				v-if="isPasskeySupported"
+				class="_borderButton _gap"
+				type="button"
+				:disabled="signing || queryingKey"
+				@click="signinWithPasskey"
+			>
+				<i class="ph-key ph-bold ph-lg" style="margin-right: 0.25rem"></i>
+				{{ i18n.ts.securityKey }}
+			</button>
 			<a
 				v-if="meta && meta.enableDiscordIntegration"
 				class="_borderButton _gap"


### PR DESCRIPTION
### Motivation
- セキュリティキーでのログインボタンをソーシャルログイン群に並べ、Discordの上に縦並びで表示して見た目と配置を統一するため。 

### Description
- `packages/client/src/components/MkSignin.vue` で通常ログインフォーム直下にあった `MkButton` のセキュリティキーボタンを削除し、ソーシャルログイン領域に移動して `button._borderButton._gap` と `ph-key` アイコンで追加しました。 
- 条件 `isPasskeySupported` と無効化条件 `:disabled="signing || queryingKey"` は維持しているため、機能的な呼び出しロジックは変更していません。 
- 見た目の統一のためボタン要素を `MkButton` から通常の `button` に変更しています。 

### Testing
- `git diff --check` を実行して差分に問題がないことを確認しました（成功）。
- `pnpm --filter client exec rome check packages/client/src/components/MkSignin.vue` は環境に `rome` が無く `spawn rome ENOENT` となり実行できませんでした（未実行）。
- Playwright を使ったスクリーンショット取得はローカルサーバー未起動により `ERR_EMPTY_RESPONSE` となり取得できませんでした（未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952748d3c08326bc0574bc5e29653f)