### PR TITLE
セキュリティ設定のパスキー一覧をカードUIに統一

### DIFF
--- a/packages/client/src/pages/settings/2fa.vue
+++ b/packages/client/src/pages/settings/2fa.vue
@@ -15,15 +15,23 @@
 
 			<h2 class="heading">{{ i18n.ts.securityKey }}</h2>
 			<p>{{ i18n.ts._2fa.securityKeyInfo }}</p>
-			<div class="key-list">
-				<div v-for="key in $i.securityKeysList" class="key">
-					<h3>{{ key.name }}</h3>
-					<div class="last-used">
-						{{ i18n.ts.lastUsed }}<MkTime :time="key.lastUsed" />
+			<div v-if="$i.securityKeysList.length > 0" class="key-list">
+				<div
+					v-for="key in $i.securityKeysList"
+					:key="key.id"
+					v-panel
+					class="key"
+				>
+					<div class="key-header">
+						<h3>{{ key.name }}</h3>
+						<MkButton danger @click="unregisterKey(key)">{{
+							i18n.ts.unregister
+						}}</MkButton>
 					</div>
-					<MkButton @click="unregisterKey(key)">{{
-						i18n.ts.unregister
-					}}</MkButton>
+					<div class="_keyValue">
+						<div>{{ i18n.ts.lastUsed }}:</div>
+						<div><MkTime :time="key.lastUsed" /></div>
+					</div>
 				</div>
 			</div>
 
@@ -312,3 +320,30 @@ async function updatePasswordLessLogin() {
 	});
 }
 </script>
+
+<style lang="scss" scoped>
+.key-list {
+	display: grid;
+	gap: 0.75rem;
+	margin: 1rem 0;
+}
+
+.key {
+	padding: 1rem;
+
+	> .key-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-bottom: 0.75rem;
+
+		> h3 {
+			margin: 0;
+			font-size: 1rem;
+			line-height: 1.4;
+			word-break: break-word;
+		}
+	}
+}
+</style>


### PR DESCRIPTION
### Motivation
- セキュリティ設定画面で表示される登録済みパスキーの見た目が他の画面と異なっていたため、UIを他画面のカード／パネル風レイアウトに揃えて視認性を向上させる目的で変更しました。
- 各パスキー項目の操作（削除）と情報（最終利用日時）を明確に分離して操作性を改善します。

### Description
- `packages/client/src/pages/settings/2fa.vue` のパスキー一覧表示を再構成し、`v-for` に `:key="key.id"` を追加して一覧レンダリングの安定性を確保しました。  
- 各アイテムに `v-panel` を適用し、項目内を `key-header`（名前 + 削除ボタン）と `_keyValue`（最終利用日時）に分割する構造に変更しました。  
- 削除ボタンを `danger` スタイルに変更し、見た目を他画面のトークン／アプリ一覧に合わせました。  
- 一覧表示の間隔・ヘッダー整列・長い名称の折り返しを調整する scoped SCSS を追加しました（見た目のみの変更、ビジネスロジックは変更していません）。

### Testing
- `git diff --check` は問題なしで通りました（差分の構文エラー等はなし）。  
- `pnpm -C packages/client lint`（`rome` 実行） は `node_modules` 未作成のため実行不能で失敗しました（`rome` 実行ファイルが見つからない）。  
- `pnpm -C packages/client dev` / `vue-tsc` による型チェックやローカルサーバ確認は環境に依存して起動できず実行できませんでした（`vue-tsc` 実行ファイルが見つからない、サーバも未起動のため Playwright スクリーンショット取得は `ERR_EMPTY_RESPONSE` で失敗）。  

影響範囲・副作用: 表示のみの変更のため機能的な影響は想定していませんが、ヘッダーを左右に配置したことで非常に長い鍵名は従来と折り返し位置が変わる可能性があります（`word-break` で崩れは抑えています）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699530a6d85883269d8ff32233858cdc)