### PR TITLE
fix(client): replace invalid .2fa-signin CSS selector

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -65,7 +65,7 @@
 			</div>
 			<div
 				v-if="totpLogin"
-				class="2fa-signin"
+				class="totp-signin"
 				:class="{ securityKeys: user && user.securityKeys }"
 			>
 				<div
@@ -476,7 +476,7 @@ function resetPassword() {
 			border-radius: 100%;
 		}
 
-		.2fa-signin {
+		.totp-signin {
 			.totp-group > button[type="submit"] {
 				margin: 1rem auto 0;
 			}


### PR DESCRIPTION
### Motivation
- Sass/CSS のセレクタが数字で始まると無効になるため、`MkSignin.vue` 内の `.2fa-signin` セレクタが Vite/Sass ビルドで `Expected identifier` エラーを引き起こしていたため修正しました。 

### Description
- テンプレートのクラス属性とスコープ付きスタイルを `packages/client/src/components/MkSignin.vue` で `2fa-signin` から `totp-signin` に置換して整合させました（テンプレート側: `class="totp-signin"`, スタイル側: `.totp-signin { ... }`）。
- 副作用として、リポジトリ外部や E2E テスト・カスタム CSS などで直接 `.2fa-signin` を参照している箇所があると見た目やテストが崩れる可能性があるため、それらを更新する必要があります。 

### Testing
- `pnpm -C packages/client build` を実行してビルド検証を試みましたが、環境に `node_modules` が無く `vite ENOENT` によりビルドは実行できませんでした（完全なビルド検証は未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995340cdc70832686ac240cc468bbf1)