### PR TITLE
fix(signin): show fallback step for passwordless login with passkey

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -82,7 +82,11 @@
 				</div>
 				<div class="twofa-group totp-group">
 					<p style="margin-bottom: 0">
-						{{ i18n.ts.twoStepAuthentication }}
+						{{
+							user && user.twoFactorEnabled
+								? i18n.ts.twoStepAuthentication
+								: i18n.ts.password
+						}}
 					</p>
 					<MkInput
 						v-if="user && user.usePasswordLessLogin"
@@ -98,6 +102,7 @@
 						></template>
 					</MkInput>
 					<MkInput
+						v-if="user && user.twoFactorEnabled"
 						v-model="token"
 						class="_formBlock"
 						type="text"
@@ -282,6 +287,7 @@ function queryKey() {
 		})
 		.catch(() => {
 			queryingKey = false;
+			signing = false;
 			return Promise.reject(null);
 		})
 		.then((credential) => {
@@ -362,7 +368,7 @@ async function onSubmit() {
 	if (!user && username) {
 		await fetchUser();
 	}
-	if (!totpLogin && user && user.twoFactorEnabled) {
+	if (!totpLogin && user && (user.twoFactorEnabled || user.usePasswordLessLogin)) {
 		if (window.PublicKeyCredential && user.securityKeys) {
 			os.api("signin", {
 				username,


### PR DESCRIPTION
### Motivation
- パスキー登録済みで二段階認証がオフ、かつパスワードレスが有効なアカウントでログインしても画面が変わらずパスワードへフォールバックできない問題を解消するため。

### Description
- `packages/client/src/components/MkSignin.vue` を変更し、ログイン後に既存の二段階認証用の中間画面をパスワードレス時にも再利用して「パスキー または パスワード」で続行できるようにした。 
- 見出しを動的にして、`twoFactorEnabled` が true のときは従来通り `twoStepAuthentication` を表示し、false のときは `password` を表示するようにした。 
- トークン入力欄は `twoFactorEnabled` が true の場合のみ表示し、`usePasswordLessLogin` が true の場合はパスワード入力欄を表示するようにした。 
- セキュリティキー問い合わせがキャンセル／失敗した際にローディング状態が残らないように `queryKey` の catch で `signing = false` を設定するようにして、パスワードフォールバックが即座に使えるようにした。
- 影響範囲: パスワードレスONかつセキュリティキーを持つユーザーは、二段階認証がオフでも中間ステップ（従来の2FA画面）に遷移するため若干のフロー変化を感じる可能性がある点に注意。

### Testing
- `pnpm --filter client run lint` を実行したが、この環境では `rome` が存在せず依存が未インストールのためエラーとなり実行失敗となった。 
- Playwright を使ってページのスクリーンショット取得を試みたが、ローカルのアプリケーションが起動しておらず `ERR_EMPTY_RESPONSE` で取得できなかった。 
- 以上のとおり自動化テストはこの実行環境では失敗しており、依存インストール＋アプリ起動後に再検証する必要がある。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953acf67a48326933b620f67b39a96)