### PR TITLE
fix: remove module export from external-app-redirect

### DIFF
--- a/packages/client/src/pages/external-app-redirect.vue
+++ b/packages/client/src/pages/external-app-redirect.vue
@@ -32,7 +32,7 @@ import MkButton from "@/components/MkButton.vue";
 import { useRouter } from "@/router";
 
 /** 誘導先ごとの表示名・説明。path は先頭の / なしで指定。 */
-export const EXTERNAL_APP_CONFIG: Record<
+const EXTERNAL_APP_CONFIG: Record<
 	string,
 	{ title: string; description: string; moveLabel?: string; icon: string }
 > = {


### PR DESCRIPTION
### Motivation
- `<script setup>` 内で ES module の `export` を含めると `[@vue/compiler-sfc] <script setup> cannot contain ES module export` エラーとなるため、ビルドエラーを解消する目的で修正しました。

### Description
- `packages/client/src/pages/external-app-redirect.vue` 内の `EXTERNAL_APP_CONFIG` を `export const` から `const` に変更しました。 
- 変更は同ファイル内でのみ参照されている定数の可視性を下げるものに限定しています。 
- 外部からこの定数を import している箇所は無かったため実行時の挙動には影響しない想定です。 
- 将来的に外部再利用したい場合は別モジュールに切り出すか `<script lang="ts">` に分離する必要があります。

### Testing
- `pnpm --filter client run build` を実行しましたが、`node_modules` 未配置により `vite` が見つからずビルドは実行できませんでした（失敗）。
- ファイル編集後に `git commit` を行い変更を記録しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a711d55483268d31fcecd05155dd)