### PR TITLE
GoogleログインとGoogle連携設定を追加

### DIFF
--- a/packages/backend/migration/1736000000000-add-google-integration.js
+++ b/packages/backend/migration/1736000000000-add-google-integration.js
@@ -1,0 +1,21 @@
+export class addGoogleIntegration1736000000000 {
+	name = "addGoogleIntegration1736000000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "enableGoogleIntegration" boolean NOT NULL DEFAULT false`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "googleClientId" character varying(128)`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "googleClientSecret" character varying(128)`,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "googleClientSecret"`);
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "googleClientId"`);
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "enableGoogleIntegration"`);
+	}
+}

--- a/packages/backend/src/models/entities/meta.ts
+++ b/packages/backend/src/models/entities/meta.ts
@@ -380,6 +380,23 @@ export class Meta {
 	})
 	public discordClientSecret: string | null;
 
+	@Column('boolean', {
+		default: false,
+	})
+	public enableGoogleIntegration: boolean;
+
+	@Column('varchar', {
+		length: 128,
+		nullable: true,
+	})
+	public googleClientId: string | null;
+
+	@Column('varchar', {
+		length: 128,
+		nullable: true,
+	})
+	public googleClientSecret: string | null;
+
 	@Column('varchar', {
 		length: 128,
 		nullable: true,

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -184,6 +184,11 @@ export const meta = {
 				optional: false,
 				nullable: false,
 			},
+			enableGoogleIntegration: {
+				type: "boolean",
+				optional: false,
+				nullable: false,
+			},
 			enableServiceWorker: {
 				type: "boolean",
 				optional: false,
@@ -355,6 +360,16 @@ export const meta = {
 				optional: true,
 				nullable: true,
 			},
+			googleClientId: {
+				type: "string",
+				optional: true,
+				nullable: true,
+			},
+			googleClientSecret: {
+				type: "string",
+				optional: true,
+				nullable: true,
+			},
 			summaryProxy: {
 				type: "string",
 				optional: true,
@@ -521,6 +536,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		enableTwitterIntegration: instance.enableTwitterIntegration,
 		enableGithubIntegration: instance.enableGithubIntegration,
 		enableDiscordIntegration: instance.enableDiscordIntegration,
+		enableGoogleIntegration: instance.enableGoogleIntegration,
 		enableServiceWorker: instance.enableServiceWorker,
 		translatorAvailable:
 			instance.deeplAuthKey != null || instance.libreTranslateApiUrl != null,
@@ -553,6 +569,8 @@ export default define(meta, paramDef, async (ps, me) => {
 		githubClientSecret: instance.githubClientSecret,
 		discordClientId: instance.discordClientId,
 		discordClientSecret: instance.discordClientSecret,
+		googleClientId: instance.googleClientId,
+		googleClientSecret: instance.googleClientSecret,
 		summalyProxy: instance.summalyProxy,
 		email: instance.email,
 		smtpSecure: instance.smtpSecure,

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -143,6 +143,9 @@ export const paramDef = {
 		enableDiscordIntegration: { type: "boolean" },
 		discordClientId: { type: "string", nullable: true },
 		discordClientSecret: { type: "string", nullable: true },
+		enableGoogleIntegration: { type: "boolean" },
+		googleClientId: { type: "string", nullable: true },
+		googleClientSecret: { type: "string", nullable: true },
 		enableEmail: { type: "boolean" },
 		email: { type: "string", nullable: true },
 		smtpSecure: { type: "boolean" },
@@ -414,6 +417,18 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	if (ps.discordClientSecret !== undefined) {
 		set.discordClientSecret = ps.discordClientSecret;
+	}
+
+	if (ps.enableGoogleIntegration !== undefined) {
+		set.enableGoogleIntegration = ps.enableGoogleIntegration;
+	}
+
+	if (ps.googleClientId !== undefined) {
+		set.googleClientId = ps.googleClientId;
+	}
+
+	if (ps.googleClientSecret !== undefined) {
+		set.googleClientSecret = ps.googleClientSecret;
 	}
 
 	if (ps.enableEmail !== undefined) {

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -282,6 +282,11 @@ export const meta = {
 				optional: false,
 				nullable: false,
 			},
+			enableGoogleIntegration: {
+				type: "boolean",
+				optional: false,
+				nullable: false,
+			},
 			enableServiceWorker: {
 				type: "boolean",
 				optional: false,
@@ -512,6 +517,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		enableTwitterIntegration: instance.enableTwitterIntegration,
 		enableGithubIntegration: instance.enableGithubIntegration,
 		enableDiscordIntegration: instance.enableDiscordIntegration,
+		enableGoogleIntegration: instance.enableGoogleIntegration,
 
 		enableServiceWorker: instance.enableServiceWorker,
 
@@ -557,6 +563,7 @@ export default define(meta, paramDef, async (ps, me) => {
 			twitter: instance.enableTwitterIntegration,
 			github: instance.enableGithubIntegration,
 			discord: instance.enableDiscordIntegration,
+			google: instance.enableGoogleIntegration,
 			serviceWorker: instance.enableServiceWorker,
 			miauth: true,
 		};

--- a/packages/backend/src/server/api/index.ts
+++ b/packages/backend/src/server/api/index.ts
@@ -24,6 +24,7 @@ import signupPending from "./private/signup-pending.js";
 import verifyEmail from "./private/verify-email.js";
 import discord from "./service/discord.js";
 import github from "./service/github.js";
+import google from "./service/google.js";
 import twitter from "./service/twitter.js";
 import { koaBody } from "koa-body";
 import {
@@ -214,6 +215,7 @@ router.post("/verify-email", verifyEmail);
 
 router.use(discord.routes());
 router.use(github.routes());
+router.use(google.routes());
 router.use(twitter.routes());
 
 router.get("/v1/instance/peers", async (ctx) => {

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -1,0 +1,349 @@
+import type Koa from "koa";
+import Router from "@koa/router";
+import { OAuth2 } from "oauth";
+import { v4 as uuid } from "uuid";
+import { IsNull } from "typeorm";
+import { getJson } from "@/misc/fetch.js";
+import config from "@/config/index.js";
+import { publishMainStream } from "@/services/stream.js";
+import { fetchMeta } from "@/misc/fetch-meta.js";
+import { Users, UserProfiles } from "@/models/index.js";
+import type { ILocalUser } from "@/models/entities/user.js";
+import { redisClient } from "../../../db/redis.js";
+import signin from "../common/signin.js";
+
+function getUserToken(ctx: Koa.BaseContext): string | null {
+	return ((ctx.headers["cookie"] || "").match(/igi=(\w+)/) || [null, null])[1];
+}
+
+function compareOrigin(ctx: Koa.BaseContext): boolean {
+	function normalizeUrl(url?: string): string {
+		return url ? (url.endsWith("/") ? url.slice(0, -1) : url) : "";
+	}
+
+	const referer = ctx.headers["referer"];
+
+	return normalizeUrl(referer) === normalizeUrl(config.url);
+}
+
+function getRedisValue(key: string): Promise<string | null> {
+	return new Promise((resolve, reject) => {
+		redisClient.get(key, (err, value) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve(value);
+		});
+	});
+}
+
+function deleteRedisKey(key: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		redisClient.del(key, (err) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve();
+		});
+	});
+}
+
+function parseJsonSafely<T>(value: string): T | null {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return null;
+	}
+}
+
+const router = new Router();
+
+router.get("/disconnect/google", async (ctx) => {
+	if (!compareOrigin(ctx)) {
+		ctx.throw(400, "invalid origin");
+		return;
+	}
+
+	const userToken = getUserToken(ctx);
+	if (!userToken) {
+		ctx.throw(400, "signin required");
+		return;
+	}
+
+	const user = await Users.findOneByOrFail({
+		host: IsNull(),
+		token: userToken,
+	});
+
+	const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
+	profile.integrations.google = undefined;
+
+	await UserProfiles.update(user.id, {
+		integrations: profile.integrations,
+	});
+
+	ctx.body = "Googleの連携を解除しました :v:";
+
+	publishMainStream(
+		user.id,
+		"meUpdated",
+		await Users.pack(user, user, {
+			detail: true,
+			includeSecrets: true,
+		}),
+	);
+});
+
+async function getOAuth2() {
+	const meta = await fetchMeta(true);
+
+	if (
+		meta.enableGoogleIntegration &&
+		meta.googleClientId &&
+		meta.googleClientSecret
+	) {
+		return new OAuth2(
+			meta.googleClientId,
+			meta.googleClientSecret,
+			"https://accounts.google.com/",
+			"o/oauth2/v2/auth",
+			"token",
+		);
+	}
+
+	return null;
+}
+
+router.get("/connect/google", async (ctx) => {
+	if (!compareOrigin(ctx)) {
+		ctx.throw(400, "invalid origin");
+		return;
+	}
+
+	const userToken = getUserToken(ctx);
+	if (!userToken) {
+		ctx.throw(400, "signin required");
+		return;
+	}
+
+	const params = {
+		redirect_uri: `${config.url}/api/go/cb`,
+		scope: ["openid", "profile", "email"],
+		state: uuid(),
+		response_type: "code",
+	};
+
+	redisClient.set(userToken, JSON.stringify(params), "EX", 600);
+
+	const oauth2 = await getOAuth2();
+	ctx.redirect(oauth2!.getAuthorizeUrl(params));
+});
+
+router.get("/signin/google", async (ctx) => {
+	const sessid = uuid();
+
+	const params = {
+		redirect_uri: `${config.url}/api/go/cb`,
+		scope: ["openid", "profile", "email"],
+		state: uuid(),
+		response_type: "code",
+	};
+
+	ctx.cookies.set("signin_with_google_sid", sessid, {
+		path: "/",
+		secure: config.url.startsWith("https"),
+		httpOnly: true,
+	});
+
+	redisClient.set(sessid, JSON.stringify(params), "EX", 600);
+
+	const oauth2 = await getOAuth2();
+	ctx.redirect(oauth2!.getAuthorizeUrl(params));
+});
+
+router.get("/go/cb", async (ctx) => {
+	const userToken = getUserToken(ctx);
+	const oauth2 = await getOAuth2();
+
+	if (!oauth2) {
+		ctx.throw(503, "google integration unavailable");
+		return;
+	}
+
+	const code = ctx.query.code;
+	if (!code || typeof code !== "string") {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	if (!userToken) {
+		const sessid = ctx.cookies.get("signin_with_google_sid");
+		if (!sessid) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const savedState = await getRedisValue(sessid);
+		if (!savedState) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
+		if (!savedStateObject) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const { redirect_uri, state } = savedStateObject;
+		if (ctx.query.state !== state) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		await deleteRedisKey(sessid);
+
+		const { accessToken } = await new Promise<any>((res, rej) =>
+			oauth2.getOAuthAccessToken(
+				code,
+				{ redirect_uri },
+				(err, accessToken, refresh, result) => {
+					if (err) {
+						rej(err);
+					} else if (result.error) {
+						rej(result.error);
+					} else {
+						res({ accessToken });
+					}
+				},
+			),
+		);
+
+		const { sub, name, email } = (await getJson(
+			"https://www.googleapis.com/oauth2/v3/userinfo",
+			"application/json",
+			10 * 1000,
+			{ Authorization: `Bearer ${accessToken}` },
+		)) as Record<string, unknown>;
+
+		if (typeof sub !== "string") {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const profile = await UserProfiles.createQueryBuilder()
+			.where("\"integrations\"->'google'->>'id' = :id", { id: sub })
+			.andWhere('"userHost" IS NULL')
+			.getOne();
+
+		if (!profile) {
+			ctx.throw(
+				404,
+				`${typeof email === "string" ? email : sub}と連携しているMisskeyアカウントはありませんでした...`,
+			);
+			return;
+		}
+
+		await UserProfiles.update(profile.userId, {
+			integrations: {
+				...profile.integrations,
+				google: {
+					id: sub,
+					accessToken,
+					name: typeof name === "string" ? name : null,
+					email: typeof email === "string" ? email : null,
+				},
+			},
+		});
+
+		signin(
+			ctx,
+			(await Users.findOneBy({ id: profile.userId })) as ILocalUser,
+			true,
+		);
+		return;
+	}
+
+	const savedState = await getRedisValue(userToken);
+	if (!savedState) {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
+	if (!savedStateObject) {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	const { redirect_uri, state } = savedStateObject;
+	if (ctx.query.state !== state) {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	await deleteRedisKey(userToken);
+
+	const { accessToken } = await new Promise<any>((res, rej) =>
+		oauth2.getOAuthAccessToken(
+			code,
+			{ redirect_uri },
+			(err, accessToken, refresh, result) => {
+				if (err) {
+					rej(err);
+				} else if (result.error) {
+					rej(result.error);
+				} else {
+					res({ accessToken });
+				}
+			},
+		),
+	);
+
+	const { sub, name, email } = (await getJson(
+		"https://www.googleapis.com/oauth2/v3/userinfo",
+		"application/json",
+		10 * 1000,
+		{ Authorization: `Bearer ${accessToken}` },
+	)) as Record<string, unknown>;
+
+	if (typeof sub !== "string") {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	const user = await Users.findOneByOrFail({
+		host: IsNull(),
+		token: userToken,
+	});
+	const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
+
+	await UserProfiles.update(user.id, {
+		integrations: {
+			...profile.integrations,
+			google: {
+				id: sub,
+				accessToken,
+				name: typeof name === "string" ? name : null,
+				email: typeof email === "string" ? email : null,
+			},
+		},
+	});
+
+	ctx.body = `Google: ${typeof email === "string" ? email : sub} を、Misskey: @${user.username} に接続しました！`;
+
+	publishMainStream(
+		user.id,
+		"meUpdated",
+		await Users.pack(user, user, {
+			detail: true,
+			includeSecrets: true,
+		}),
+	);
+});
+
+export default router;

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -314,13 +314,14 @@ export type LiteInstanceMetadata = {
 	maxNoteTextLength: number;
 	enableEmail: boolean;
 	enableTwitterIntegration: boolean;
-        enableGithubIntegration: boolean;
-        enableDiscordIntegration: boolean;
-        enableServiceWorker: boolean;
-        emojiUpdatedAt: DateString | null;
-        emojis: CustomEmoji[];
-        ads: {
-                id: ID;
+	enableGithubIntegration: boolean;
+	enableDiscordIntegration: boolean;
+	enableGoogleIntegration: boolean;
+	enableServiceWorker: boolean;
+	emojiUpdatedAt: DateString | null;
+	emojis: CustomEmoji[];
+	ads: {
+		id: ID;
 		ratio: number;
 		place: string;
 		url: string;

--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -161,6 +161,13 @@
 				{{ i18n.t("signinWith", { x: i18n.ts.securityKey }) }}
 			</button>
 			<a
+				v-if="meta && meta.enableGoogleIntegration"
+				class="_borderButton _gap"
+				:href="`${apiUrl}/signin/google`"
+				><i class="social-icon ph-google-logo ph-bold ph-lg"></i
+				>{{ i18n.t("signinWith", { x: "Google" }) }}</a
+			>
+			<a
 				v-if="meta && meta.enableDiscordIntegration"
 				class="_borderButton _gap"
 				:href="`${apiUrl}/signin/discord`"

--- a/packages/client/src/pages/admin/integrations.google.vue
+++ b/packages/client/src/pages/admin/integrations.google.vue
@@ -1,0 +1,69 @@
+<template>
+	<FormSuspense :p="init">
+		<div class="_formRoot">
+			<FormSwitch v-model="enableGoogleIntegration" class="_formBlock">
+				<template #label>{{ i18n.ts.enable }}</template>
+			</FormSwitch>
+
+			<template v-if="enableGoogleIntegration">
+				<FormInfo class="_formBlock"
+					>Callback URL: {{ `${uri}/api/go/cb` }}</FormInfo
+				>
+
+				<FormInput v-model="googleClientId" class="_formBlock">
+					<template #prefix
+						><i class="ph-key ph-bold ph-lg"></i
+					></template>
+					<template #label>Client ID</template>
+				</FormInput>
+
+				<FormInput v-model="googleClientSecret" class="_formBlock">
+					<template #prefix
+						><i class="ph-key ph-bold ph-lg"></i
+					></template>
+					<template #label>Client Secret</template>
+				</FormInput>
+			</template>
+
+			<FormButton primary class="_formBlock" @click="save"
+				><i class="ph-floppy-disk-back ph-bold ph-lg"></i>
+				{{ i18n.ts.save }}</FormButton
+			>
+		</div>
+	</FormSuspense>
+</template>
+
+<script lang="ts" setup>
+import {} from "vue";
+import FormSwitch from "@/components/form/switch.vue";
+import FormInput from "@/components/form/input.vue";
+import FormButton from "@/components/MkButton.vue";
+import FormInfo from "@/components/MkInfo.vue";
+import FormSuspense from "@/components/form/suspense.vue";
+import * as os from "@/os";
+import { fetchInstance } from "@/instance";
+import { i18n } from "@/i18n";
+
+let uri: string = $ref("");
+let enableGoogleIntegration: boolean = $ref(false);
+let googleClientId: string | null = $ref(null);
+let googleClientSecret: string | null = $ref(null);
+
+async function init() {
+	const meta = await os.api("admin/meta");
+	uri = meta.uri;
+	enableGoogleIntegration = meta.enableGoogleIntegration;
+	googleClientId = meta.googleClientId;
+	googleClientSecret = meta.googleClientSecret;
+}
+
+function save() {
+	os.apiWithDialog("admin/update-meta", {
+		enableGoogleIntegration,
+		googleClientId,
+		googleClientSecret,
+	}).then(() => {
+		fetchInstance();
+	});
+}
+</script>

--- a/packages/client/src/pages/admin/integrations.vue
+++ b/packages/client/src/pages/admin/integrations.vue
@@ -22,6 +22,16 @@
 				</FormFolder>
 				<FormFolder class="_formBlock">
 					<template #icon
+						><i class="ph-google-logo ph-bold ph-lg"></i
+					></template>
+					<template #label>Google</template>
+					<template #suffix>{{
+						enableGoogleIntegration ? i18n.ts.enabled : i18n.ts.disabled
+					}}</template>
+					<XGoogle />
+				</FormFolder>
+				<FormFolder class="_formBlock">
+					<template #icon
 						><i class="ph-discord-logo ph-bold ph-lg"></i
 					></template>
 					<template #label>Discord</template>
@@ -41,6 +51,7 @@
 import {} from "vue";
 import XGithub from "./integrations.github.vue";
 import XDiscord from "./integrations.discord.vue";
+import XGoogle from "./integrations.google.vue";
 import FormSuspense from "@/components/form/suspense.vue";
 import FormFolder from "@/components/form/folder.vue";
 import * as os from "@/os";
@@ -50,12 +61,14 @@ import { definePageMetadata } from "@/scripts/page-metadata";
 let enableTwitterIntegration: boolean = $ref(false);
 let enableGithubIntegration: boolean = $ref(false);
 let enableDiscordIntegration: boolean = $ref(false);
+let enableGoogleIntegration: boolean = $ref(false);
 
 async function init() {
 	const meta = await os.api("admin/meta");
 	enableTwitterIntegration = meta.enableTwitterIntegration;
 	enableGithubIntegration = meta.enableGithubIntegration;
 	enableDiscordIntegration = meta.enableDiscordIntegration;
+	enableGoogleIntegration = meta.enableGoogleIntegration;
 }
 
 const headerActions = $computed(() => []);

--- a/packages/client/src/pages/settings/integration.vue
+++ b/packages/client/src/pages/settings/integration.vue
@@ -24,6 +24,25 @@
 			}}</MkButton>
 		</FormSection>
 
+		<FormSection v-if="instance.enableGoogleIntegration">
+			<template #label
+				><i class="ph-google-logo ph-bold ph-lg"></i> Google</template
+			>
+			<p v-if="integrations.google">
+				{{ i18n.ts.connectedTo }}:
+				<span>{{ integrations.google.email ?? integrations.google.name ?? integrations.google.id }}</span>
+			</p>
+			<MkButton
+				v-if="integrations.google"
+				danger
+				@click="disconnectGoogle"
+				>{{ i18n.ts.disconnectService }}</MkButton
+			>
+			<MkButton v-else primary @click="connectGoogle">{{
+				i18n.ts.connectService
+			}}</MkButton>
+		</FormSection>
+
 		<FormSection v-if="instance.enableGithubIntegration">
 			<template #label
 				><i class="ph-github-logo ph-bold ph-lg"></i> GitHub</template
@@ -63,6 +82,7 @@ import { definePageMetadata } from "@/scripts/page-metadata";
 const twitterForm = ref<Window | null>(null);
 const discordForm = ref<Window | null>(null);
 const githubForm = ref<Window | null>(null);
+const googleForm = ref<Window | null>(null);
 
 const integrations = computed(() => $i!.integrations);
 const discordHandle = computed(() => {
@@ -117,6 +137,14 @@ function disconnectGithub() {
 	openWindow("github", "disconnect");
 }
 
+function connectGoogle() {
+	googleForm.value = openWindow("google", "connect");
+}
+
+function disconnectGoogle() {
+	openWindow("google", "disconnect");
+}
+
 onMounted(() => {
 	document.cookie = `igi=${$i!.token}; ${getCookieAttributes(31536000)}`;
 
@@ -129,6 +157,9 @@ onMounted(() => {
 		}
 		if (integrations.value.github) {
 			if (githubForm.value) githubForm.value.close();
+		}
+		if (integrations.value.google) {
+			if (googleForm.value) googleForm.value.close();
 		}
 	});
 });


### PR DESCRIPTION
## 概要
- サインイン画面に「Googleでログイン」を追加（Discordの上に表示）
- 設定 > 連携 に Google 連携の接続/解除UIを追加
- 管理画面 > Integrations に Google 設定（有効化、Client ID/Secret、Callback URL）を追加
- バックエンドに Google OAuth2 フロー（signin/connect/disconnect/callback）を追加
- `meta` の Google 連携フラグとクライアント情報を追加し、APIレスポンス/更新APIへ反映
- DBマイグレーションで `meta` テーブルに Google 連携用カラムを追加
- `calckey-js` のインスタンスメタ型に `enableGoogleIntegration` を追加

## 変更ファイル
- `packages/client/src/components/MkSignin.vue`
- `packages/client/src/pages/settings/integration.vue`
- `packages/client/src/pages/admin/integrations.vue`
- `packages/client/src/pages/admin/integrations.google.vue` (new)
- `packages/backend/src/server/api/service/google.ts` (new)
- `packages/backend/src/server/api/index.ts`
- `packages/backend/src/server/api/endpoints/meta.ts`
- `packages/backend/src/server/api/endpoints/admin/meta.ts`
- `packages/backend/src/server/api/endpoints/admin/update-meta.ts`
- `packages/backend/src/models/entities/meta.ts`
- `packages/backend/migration/1736000000000-add-google-integration.js` (new)
- `packages/calckey-js/src/entities.ts`

## 確認状況
- 実行テストは未実施です（静的な実装反映のみ）。

## 想定される副作用
- Google連携を有効化しても Client ID/Secret が未設定の場合、Google OAuth開始時に失敗する可能性があります。
- 既存の `integrations` JSON に `google` キーが追加されるため、外部連携情報を参照する独自スクリプトがある場合はキー追加を考慮してください。
- OAuthコールバックURLが `.../api/go/cb` に固定のため、Google Cloud Console 側のリダイレクトURI設定不一致でログイン/連携に失敗します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699603788aa0832697ddf16984ffcea2)