### PR TITLE
ログイン画面のユーザー名自動フォーカス条件を調整

### DIFF
--- a/packages/client/src/components/MkSignin.vue
+++ b/packages/client/src/components/MkSignin.vue
@@ -24,7 +24,7 @@
 					type="text"
 					pattern="^[a-zA-Z0-9_]+$"
 					:spellcheck="false"
-					autofocus
+					:autofocus="!hasAlternativeSignInMethod"
 					required
 					data-cy-signin-username
 					@update:modelValue="onUsernameChange"
@@ -215,6 +215,19 @@ const isPasskeySupported = $computed(
 		typeof navigator !== "undefined" &&
 		!!window.PublicKeyCredential &&
 		!!navigator.credentials,
+);
+const hasExternalServiceSignIn = $computed(
+	() =>
+		!!meta &&
+		(
+			meta.enableTwitterIntegration ||
+			meta.enableGithubIntegration ||
+			meta.enableGoogleIntegration ||
+			meta.enableDiscordIntegration
+		),
+);
+const hasAlternativeSignInMethod = $computed(
+	() => isPasskeySupported || hasExternalServiceSignIn,
 );
 
 const emit = defineEmits<{


### PR DESCRIPTION
### Motivation
- パスキー対応端末や外部サービス認証が有効な環境では、ログイン画面表示時に自動でユーザー名入力へフォーカスが当たると代替認証の操作性が下がるため、フォーカス挙動を環境に応じて抑制する目的です。 
- 既存のパスキー判定は残しつつ、外部サービス認証（Twitter/GitHub/Google/Discord）の存在も考慮して判断する必要がありました。 
- 副作用として、代替認証手段がある環境ではユーザー名入力へ自動フォーカスされなくなるため、従来よりキーボード入力開始までに1操作増える可能性がありますが、代替手段の誤操作や意図しない入力の阻害は減ります。 

### Description
- `packages/client/src/components/MkSignin.vue` を変更しました。
- ユーザー名入力の属性を固定の `autofocus` から条件付きの `:autofocus="!hasAlternativeSignInMethod"` に変更しました。
- 外部サービス判定のために `hasExternalServiceSignIn` を追加し、`meta.enableTwitterIntegration` / `meta.enableGithubIntegration` / `meta.enableGoogleIntegration` / `meta.enableDiscordIntegration` のいずれかが有効かを判定するようにしました。
- パスキー対応の既存判定 `isPasskeySupported` と外部サービス判定を統合する `hasAlternativeSignInMethod` を追加して、総合的にフォーカス動作を決定するようにしました。

### Testing
- `pnpm --filter client lint` を実行しようとしましたが、`rome` 実行ファイルが見つからないかつ `node_modules` が存在しないため実行できませんでした（環境依存のため実行不能）。
- 変更はフロントエンドのテンプレートと computed 値の追加のみで、既存のログイン処理や API 呼び出しロジックは変更していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996060715e08326af18cd91a43eca7f)