### PR TITLE
fix(light): もっと見る時にTLを末尾追記で描画する

### DIFF
--- a/packages/backend/src/server/web/light.js
+++ b/packages/backend/src/server/web/light.js
@@ -638,11 +638,13 @@
 			if (currentTl === "channel") params.channelId = getSetting("channelId", "");
 			const data = await api(ep, params);
 			if (untilId) {
-				notes = [...notes, ...(data || [])];
+				const additionalNotes = data || [];
+				notes = [...notes, ...additionalNotes];
+				renderNotes(additionalNotes);
 			} else {
 				notes = data || [];
+				renderNotes();
 			}
-			renderNotes();
 			const loadMore = document.getElementById("load-more");
 			if (loadMore) {
 				loadMore.style.display = (data || []).length >= 20 ? "block" : "none";
@@ -1087,18 +1089,31 @@
 		return html;
 	}
 
-	function renderNotes() {
+	function renderNotes(additionalNotes) {
 		const container = document.getElementById("notes");
 		if (!container) return;
 		const showIcons = getSetting("showIcons", true);
-		const keywords = getWordMuteKeywords();
-		container.innerHTML = notes
+		const sourceNotes = Array.isArray(additionalNotes) ? additionalNotes : notes;
+		const renderedHtml = sourceNotes
 			.filter((n) => {
 				const text = (n.renote || n).text || (n.renote || n).cw || "";
 				return !isWordMuted(text);
 			})
 			.map((note) => renderNote(note, showIcons))
 			.join("");
+
+		if (Array.isArray(additionalNotes)) {
+			if (!renderedHtml) return;
+			const fragment = document.createElement("div");
+			fragment.innerHTML = renderedHtml;
+			[...fragment.children].forEach((node) => {
+				container.appendChild(node);
+				bindNoteEvents(node);
+			});
+			return;
+		}
+
+		container.innerHTML = renderedHtml;
 		bindNoteEvents(container);
 	}
 


### PR DESCRIPTION
### Motivation
- 軽量版クライアントで「もっと見る」（`untilId` 指定）を実行すると既存の投稿DOMが再生成され、展開済みの画像/CW/絵文字表示が閉じてしまう問題を解消するため。 
- 初回読み込みやTL切替時は従来どおり全件描画を維持しつつ、追加取得時のみ末尾へ追記する挙動に変更することでUXを改善する。 
- 副作用として既存要素に対する再バインドを行わないため、将来的に全件再初期化前提の処理を導入する場合はこの分岐を考慮する必要がある。 

### Description
- `loadTimeline` において `untilId` 指定時は取得データを `additionalNotes` として結合し、`renderNotes(additionalNotes)` を呼ぶよう変更した（`packages/backend/src/server/web/light.js`）。
- `renderNotes` のシグネチャを `renderNotes(additionalNotes)` に拡張し、引数がある場合は追加分のみHTMLを生成して一時的な `div` に挿入し、子要素を末尾へ `appendChild` して個別に `bindNoteEvents` を行う分岐を追加した。 
- 引数なしの従来パスはそのまま全体を `container.innerHTML` に書き換え、既存のワードミュートや絵文字処理のロジックは踏襲している。 

### Testing
- `node --check packages/backend/src/server/web/light.js` を実行して構文チェックは成功。 
- Playwright を用いたブラウザスクリーンショット取得を試行したが、ローカルサーバーが起動しておらず `net::ERR_EMPTY_RESPONSE` で失敗した（サーバー起動下での動作確認を推奨）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965bfca62c83268fa6a9a4b2d03522)