### PR TITLE
OAuth認証エラー時に白画面へ遷移しないよう修正

### DIFF
--- a/packages/backend/src/server/index.ts
+++ b/packages/backend/src/server/index.ts
@@ -164,14 +164,31 @@ router.get("/missing", async (ctx) => {
 
 mastoRouter.get("/oauth/authorize", async (ctx) => {
 	const { client_id, state, redirect_uri } = ctx.request.query;
-	console.log(ctx.request.req);
+	const redirectToClientWithError = (error: string) => {
+		ctx.redirect(`/?oauth_error=${encodeURIComponent(error)}`);
+	};
+
+	if (!client_id) {
+		redirectToClientWithError("invalid_client_id");
+		return;
+	}
+
+	let decodedClientId: string;
+	try {
+		decodedClientId = Buffer.from(client_id.toString(), "base64").toString();
+		const clientUrl = new URL(decodedClientId);
+		if (!["http:", "https:"].includes(clientUrl.protocol)) {
+			throw new Error("invalid protocol");
+		}
+	} catch (error) {
+		redirectToClientWithError("invalid_client_id");
+		return;
+	}
+
 	let param = "mastodon=true";
 	if (state) param += `&state=${state}`;
 	if (redirect_uri) param += `&redirect_uri=${redirect_uri}`;
-	const client = client_id ? client_id : "";
-	ctx.redirect(
-		`${Buffer.from(client.toString(), "base64").toString()}?${param}`,
-	);
+	ctx.redirect(`${decodedClientId}?${param}`);
 });
 
 mastoRouter.post("/oauth/token", async (ctx) => {

--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -238,19 +238,31 @@ const initializeViewport = () => {
 const initializeLoginId = async () => {
 	const params = new URLSearchParams(location.search);
 	const loginId = params.get("loginId");
+	const oauthError = params.get("oauth_error");
+	const hasOauthError = !!oauthError;
 
-	if (loginId) {
-		const waitMsg = "ログインIDを初期化中...";
-		waitMessages.push(waitMsg);
-		const target = getUrlWithoutLoginId(location.href);
-		if (!$i || $i.id !== loginId) {
-			const account = await getAccountFromId(loginId);
-			if (account) {
-				await login(account.token, target);
-			}
+	if (!loginId && !hasOauthError) return;
+
+	const waitMsg = "ログインIDを初期化中...";
+	waitMessages.push(waitMsg);
+	const target = getUrlWithoutLoginId(location.href);
+	if (loginId && (!$i || $i.id !== loginId)) {
+		const account = await getAccountFromId(loginId);
+		if (account) {
+			await login(account.token, target);
 		}
-		history.replaceState({ misskey: "loginId" }, "", target);
-		waitMessages = waitMessages.filter((x) => x !== waitMsg);
+	}
+	history.replaceState({ misskey: "loginId" }, "", target);
+	waitMessages = waitMessages.filter((x) => x !== waitMsg);
+
+	if (hasOauthError) {
+		alert({
+			type: "error",
+			text:
+				oauthError === "invalid_client_id"
+					? i18n.ts.somethingHappened
+					: `${i18n.ts.somethingHappened} (${oauthError})`,
+		});
 	}
 };
 


### PR DESCRIPTION
## 概要
- `/oauth/authorize` で `client_id` が欠損・不正な場合に、サーバー側でそのまま例外画面に遷移せず、クライアントトップ (`/?oauth_error=...`) にリダイレクトするよう変更しました。
- クライアント起動時に `oauth_error` クエリを検知し、通常UI上でエラーポップアップを表示した上でURLからクエリを除去するようにしました。

## 変更内容
### Backend
- `packages/backend/src/server/index.ts`
  - `mastoRouter.get("/oauth/authorize")` で `client_id` を必須化。
  - `client_id` のbase64デコード結果を `URL` として検証し、`http/https` 以外を拒否。
  - 不正時は `/?oauth_error=invalid_client_id` へリダイレクト。
  - 既存の `console.log(ctx.request.req)` は削除。

### Client
- `packages/client/src/init.ts`
  - `initializeLoginId` で `oauth_error` クエリを処理。
  - `oauth_error` がある場合は通常クライアント画面で `alert` を表示。
  - `history.replaceState` でクエリを除去し、エラー表示後にURLをクリーンに維持。

## 副作用・影響
- これまで `/oauth/authorize` に不正パラメータでアクセスした際は白いエラー画面に見えることがありましたが、今後はトップ画面に戻る挙動になります。
- `oauth_error` を利用するため、同名クエリを外部で用途分離せず使っている場合は表示ポップアップが発生します（通常運用では想定外）。

## 動作確認
- 静的確認のみ（テスト・実行は未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965e4bc5fc8326b8352e2667bd173e)