### PR TITLE
fix: OAuth連携時のinvalid originを解消

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -17,13 +17,22 @@ function getUserToken(ctx: Koa.BaseContext): string | null {
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {
-	function normalizeUrl(url?: string): string {
-		return url ? (url.endsWith("/") ? url.substr(0, url.length - 1) : url) : "";
+	function getOrigin(url: string | string[] | undefined): string | null {
+		if (typeof url !== "string") {
+			return null;
+		}
+
+		try {
+			return new URL(url).origin;
+		} catch {
+			return null;
+		}
 	}
 
-	const referer = ctx.headers["referer"];
+	const requestOrigin = getOrigin(ctx.headers["origin"]) ?? getOrigin(ctx.headers["referer"]);
+	const configuredOrigin = getOrigin(config.url);
 
-	return normalizeUrl(referer) === normalizeUrl(config.url);
+	return requestOrigin != null && configuredOrigin != null && requestOrigin === configuredOrigin;
 }
 
 // Init router

--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -17,13 +17,22 @@ function getUserToken(ctx: Koa.BaseContext): string | null {
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {
-	function normalizeUrl(url?: string): string {
-		return url ? (url.endsWith("/") ? url.substr(0, url.length - 1) : url) : "";
+	function getOrigin(url: string | string[] | undefined): string | null {
+		if (typeof url !== "string") {
+			return null;
+		}
+
+		try {
+			return new URL(url).origin;
+		} catch {
+			return null;
+		}
 	}
 
-	const referer = ctx.headers["referer"];
+	const requestOrigin = getOrigin(ctx.headers["origin"]) ?? getOrigin(ctx.headers["referer"]);
+	const configuredOrigin = getOrigin(config.url);
 
-	return normalizeUrl(referer) === normalizeUrl(config.url);
+	return requestOrigin != null && configuredOrigin != null && requestOrigin === configuredOrigin;
 }
 
 function getRedisValue(key: string): Promise<string | null> {

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -17,13 +17,22 @@ function getUserToken(ctx: Koa.BaseContext): string | null {
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {
-	function normalizeUrl(url?: string): string {
-		return url ? (url.endsWith("/") ? url.slice(0, -1) : url) : "";
+	function getOrigin(url: string | string[] | undefined): string | null {
+		if (typeof url !== "string") {
+			return null;
+		}
+
+		try {
+			return new URL(url).origin;
+		} catch {
+			return null;
+		}
 	}
 
-	const referer = ctx.headers["referer"];
+	const requestOrigin = getOrigin(ctx.headers["origin"]) ?? getOrigin(ctx.headers["referer"]);
+	const configuredOrigin = getOrigin(config.url);
 
-	return normalizeUrl(referer) === normalizeUrl(config.url);
+	return requestOrigin != null && configuredOrigin != null && requestOrigin === configuredOrigin;
 }
 
 function getRedisValue(key: string): Promise<string | null> {

--- a/packages/backend/src/server/api/service/twitter.ts
+++ b/packages/backend/src/server/api/service/twitter.ts
@@ -16,17 +16,22 @@ function getUserToken(ctx: Koa.BaseContext): string | null {
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {
-	function normalizeUrl(url?: string): string {
-		return url == null
-			? ""
-			: url.endsWith("/")
-			? url.substr(0, url.length - 1)
-			: url;
+	function getOrigin(url: string | string[] | undefined): string | null {
+		if (typeof url !== "string") {
+			return null;
+		}
+
+		try {
+			return new URL(url).origin;
+		} catch {
+			return null;
+		}
 	}
 
-	const referer = ctx.headers["referer"];
+	const requestOrigin = getOrigin(ctx.headers["origin"]) ?? getOrigin(ctx.headers["referer"]);
+	const configuredOrigin = getOrigin(config.url);
 
-	return normalizeUrl(referer) === normalizeUrl(config.url);
+	return requestOrigin != null && configuredOrigin != null && requestOrigin === configuredOrigin;
 }
 
 // Init router


### PR DESCRIPTION
## 概要
OAuth連携（接続/切断）時のorigin検証ロジックを修正し、正当なリクエストでも`invalid origin`になるケースを解消しました。

## 変更内容
- 対象ファイル
  - `packages/backend/src/server/api/service/discord.ts`
  - `packages/backend/src/server/api/service/github.ts`
  - `packages/backend/src/server/api/service/google.ts`
  - `packages/backend/src/server/api/service/twitter.ts`
- `compareOrigin`を以下の仕様に統一
  - `Origin`ヘッダーを優先して判定
  - `Origin`が無い場合は`Referer`をフォールバック
  - 比較時は文字列全体ではなく`URL(...).origin`同士を比較（パス付きRefererでも一致判定可能）
  - URLパース失敗時は不正として扱う

## 背景
従来は`Referer`文字列全体と`config.url`を比較していたため、`Referer`にパスが含まれる通常の画面遷移からの操作で不一致となり、`invalid origin`が発生していました。

## 期待される効果
- OAuth接続/切断操作が、同一オリジンからの正常な操作で通るようになります。

## 想定される副作用
- `Origin`/`Referer`が送信されないクライアント（厳格なプライバシー設定・一部プロキシ経由等）では従来同様に失敗します。
- 検証を`origin`単位にしたため、同一オリジン配下のどのパスからでも許可されます（意図した挙動）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965ea3d3688326ab636ec916d99093)