### PR TITLE
fix(client): エラーログ初期化のハングを回避

### DIFF
--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -76,6 +76,16 @@ let waitMessages: string[] = [];
 const wait = async (ms: number) =>
 	new Promise((resolve) => setTimeout(resolve, ms));
 
+const withTimeout = async <T>(promise: Promise<T>, ms: number, message: string) =>
+	await Promise.race([
+		promise,
+		new Promise<T>((_, reject) => {
+			setTimeout(() => {
+				reject(new Error(message));
+			}, ms);
+		}),
+	]);
+
 // ヘックスカラーコードをRGBAに変換する関数
 const hexToRgb = (hex: string) => {
 	if (/^#[0-9A-Fa-f]{6}$/i.test(hex) || /^#[0-9A-Fa-f]{8}$/i.test(hex)) {
@@ -96,34 +106,45 @@ const hexToRgb = (hex: string) => {
 const initializeErrorLogging = async () => {
 	const waitMsg = "エラーログ出力機能を初期化中...";
 	waitMessages.push(waitMsg);
-	const currentDate = new Date();
-	const formattedDate = `${currentDate.toLocaleDateString()} ${currentDate.toLocaleTimeString()}`;
 
-	await set("errorLog", [`${formattedDate} - Calckey v${version}`]);
+	try {
+		const currentDate = new Date();
+		const formattedDate = `${currentDate.toLocaleDateString()} ${currentDate.toLocaleTimeString()}`;
 
-	const logError = async (message: string) => {
-		const logtext = `${formattedDate} - ${message}`;
-		let currentLogs = (await get("errorLog")) || [];
-		currentLogs.push(logtext);
-		if (currentLogs.length > 50) {
-			currentLogs = currentLogs.slice(-50);
-		}
-		await set("errorLog", currentLogs);
-	};
-
-	window.addEventListener("error", async (event) => {
-		await logError(
-			`${event.message} at ${event.filename}:${event.lineno}:${event.colno}`,
+		await withTimeout(
+			set("errorLog", [`${formattedDate} - Calckey v${version}`]),
+			3000,
+			"errorLog initialization timed out",
 		);
-	});
 
-	window.addEventListener("unhandledrejection", async (event) => {
-		const reason =
-			typeof event.reason === "object"
-				? JSON.stringify(event.reason)
-				: event.reason;
-		await logError(`Unhandled promise rejection: ${reason}`);
-	});
+		const logError = async (message: string) => {
+			const logtext = `${formattedDate} - ${message}`;
+			let currentLogs =
+				(await withTimeout(get("errorLog"), 2000, "errorLog read timed out")) ||
+				[];
+			currentLogs.push(logtext);
+			if (currentLogs.length > 50) {
+				currentLogs = currentLogs.slice(-50);
+			}
+			await withTimeout(set("errorLog", currentLogs), 2000, "errorLog write timed out");
+		};
+
+		window.addEventListener("error", async (event) => {
+			await logError(
+				`${event.message} at ${event.filename}:${event.lineno}:${event.colno}`,
+			);
+		});
+
+		window.addEventListener("unhandledrejection", async (event) => {
+			const reason =
+				typeof event.reason === "object"
+					? JSON.stringify(event.reason)
+					: event.reason;
+			await logError(`Unhandled promise rejection: ${reason}`);
+		});
+	} catch (error) {
+		console.error("Failed to initialize error logging", error);
+	}
 
 	if (_DEV_) {
 		console.warn("Development mode!!!");


### PR DESCRIPTION
### Motivation
- 起動時に `エラーログ出力機能を初期化中...` の表示でアプリがスタックするケースを回避するために変更しました。 
- IndexedDB やフォールバックのストレージが応答しない環境でもアプリ本体の起動を継続させる必要がありました。

### Description
- `withTimeout` ヘルパーを追加して任意の `Promise` にタイムアウトを適用するようにしました (`Promise.race` を使用) 。
- `initializeErrorLogging` 内の `set`/`get` 呼び出しを `withTimeout` 経由で呼び出すようにし、初期化処理を `try/catch` で保護して失敗時は `console.error` を出力して起動を継続するようにしました。
- 変更ファイル: `packages/client/src/init.ts` 。
- 想定副作用: ストレージアクセスが遅い環境ではタイムアウトによりそのセッションのエラーログ収集が無効化され、その時点のエラーがログに残らない可能性があります。

### Testing
- `pnpm --filter client run lint` を実行しましたが、`rome` が見つからず (`ENOENT`) ロントチェックは失敗し、自動整形/静的チェックは実行できませんでした。
- その他の自動テストやビルドはローカル `node_modules` 未インストールのため実行していません（変更はコミット済み）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996642ede70832691d403dd4fb9c333)