### PR TITLE
fix(sw): avoid service worker offline fallback for /api/* (prevents OAuth callback replacement)

### DIFF
--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -76,6 +76,11 @@ async function offlineContentHTML() {
 }
 
 self.addEventListener("fetch", (ev) => {
+	const requestUrl = new URL(ev.request.url);
+	if (requestUrl.pathname.startsWith("/api/")) {
+		return;
+	}
+
 	let isHTMLRequest = false;
 	if (ev.request.headers.get("sec-fetch-dest") === "document") {
 		isHTMLRequest = true;


### PR DESCRIPTION
### Motivation
- 外部サービスの OAuth リダイレクト（例: `/api/go/cb`, `/api/gh/cb` など）がブラウザでドキュメントナビゲーション扱いになった場合に、Service Worker がオフラインフォールバック（「サーバに接続できません」画面）を返してしまい、認証ログインが失敗する事象を防ぐため。
- `/api/*` は API 用エンドポイントなので、オフライン表示で置き換えるべきではないという意図です。

### Description
- `packages/sw/src/sw.ts` の `fetch` イベントハンドラにて、`new URL(ev.request.url).pathname` が `/api/` で始まる場合に早期に処理を抜ける判定を追加しました（`/api/*` リクエストは SW のナビゲーション向けオフラインフォールバック対象外とする）。
- 変更により OAuth コールバック等の API パスがオフライン HTML に置き換わるのを防ぎます。
- 影響箇所は主に `packages/sw/src/sw.ts` の fetch ハンドラ周りのみです。
- 想定する副作用として、意図的に `/api/*` をオフラインフォールバックで代替していたケースは挙動が変わります。

### Testing
- 実行した自動化テスト: `pnpm --filter sw run lint` を実行しましたが、ローカル環境に依存する `node_modules` が存在しないため `rome` コマンドが見つからず失敗しました（依存未導入のため検証不能）。
- CI 相当の実行はこの環境では未実行のため、実運用環境／CI 上で `sw` パッケージのビルドとブラウザでの OAuth フロー確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996685a0d3c8326aed34d490b4ec758)