### PR TITLE
OAuthサインイン時のRedis一時キャッシュを開始/終了時に確実に破棄する修正

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -165,6 +165,19 @@ router.get("/connect/discord", async (ctx) => {
 });
 
 router.get("/signin/discord", async (ctx) => {
+	const previousSessid = ctx.cookies.get("signin_with_discord_sid");
+	if (previousSessid) {
+		const previousStateRaw = await getRedisValue(previousSessid);
+		await deleteRedisKey(previousSessid);
+
+		const previousState = previousStateRaw
+			? parseJsonSafely<{ state: string }>(previousStateRaw)
+			: null;
+		if (previousState) {
+			await deleteRedisKey(`discord:signin:state:${previousState.state}`);
+		}
+	}
+
 	const sessid = uuid();
 	const state = uuid();
 
@@ -214,6 +227,10 @@ router.get("/dc/cb", async (ctx) => {
 			(await getRedisValue(`discord:signin:state:${callbackState}`));
 
 		if (!savedState) {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`discord:signin:state:${callbackState}`);
 			ctx.throw(400, "invalid session - 3");
 			return;
 		}
@@ -231,85 +248,87 @@ router.get("/dc/cb", async (ctx) => {
 			return;
 		}
 
-		if (sessid) {
-			await deleteRedisKey(sessid);
-		}
-		await deleteRedisKey(`discord:signin:state:${state}`);
-
-		const { accessToken, refreshToken, expiresDate } = await new Promise<any>(
-			(res, rej) =>
-				oauth2!.getOAuthAccessToken(
-					code,
-					{
-						grant_type: "authorization_code",
-						redirect_uri,
-					},
-					(err, accessToken, refreshToken, result) => {
-						if (err) {
-							rej(err);
-						} else if (result.error) {
-							rej(result.error);
-						} else {
-							res({
-								accessToken,
-								refreshToken,
-								expiresDate: Date.now() + Number(result.expires_in) * 1000,
-							});
-						}
-					},
-				),
-		);
-
-		const { id, username, discriminator } = (await getJson(
-			"https://discord.com/api/users/@me",
-			"*/*",
-			10 * 1000,
-			{
-				Authorization: `Bearer ${accessToken}`,
-			},
-		)) as Record<string, unknown>;
-
-		if (
-			typeof id !== "string" ||
-			typeof username !== "string" ||
-			typeof discriminator !== "string"
-		) {
-			ctx.throw(400, "invalid session - 4");
-			return;
-		}
-
-		const profile = await UserProfiles.createQueryBuilder()
-			.where("\"integrations\"->'discord'->>'id' = :id", { id: id })
-			.andWhere('"userHost" IS NULL')
-			.getOne();
-
-		if (profile == null) {
-			ctx.throw(
-				404,
-				`@${username}#${discriminator}と連携しているMisskeyアカウントはありませんでした...`,
+		try {
+			const { accessToken, refreshToken, expiresDate } = await new Promise<any>(
+				(res, rej) =>
+					oauth2!.getOAuthAccessToken(
+						code,
+						{
+							grant_type: "authorization_code",
+							redirect_uri,
+						},
+						(err, accessToken, refreshToken, result) => {
+							if (err) {
+								rej(err);
+							} else if (result.error) {
+								rej(result.error);
+							} else {
+								res({
+									accessToken,
+									refreshToken,
+									expiresDate: Date.now() + Number(result.expires_in) * 1000,
+								});
+							}
+						},
+					),
 			);
-			return;
-		}
 
-		await UserProfiles.update(profile.userId, {
-			integrations: {
-				...profile.integrations,
-				discord: {
-					id: id,
-					accessToken: accessToken,
-					refreshToken: refreshToken,
-					expiresDate: expiresDate,
-					username: username,
-					discriminator: discriminator,
+			const { id, username, discriminator } = (await getJson(
+				"https://discord.com/api/users/@me",
+				"*/*",
+				10 * 1000,
+				{
+					Authorization: `Bearer ${accessToken}`,
 				},
-			},
-		});
+			)) as Record<string, unknown>;
 
-		signin(
-			ctx,
-			(await Users.findOneBy({ id: profile.userId })) as ILocalUser,
-			true,
-		);
+			if (
+				typeof id !== "string" ||
+				typeof username !== "string" ||
+				typeof discriminator !== "string"
+			) {
+				ctx.throw(400, "invalid session - 4");
+				return;
+			}
+
+			const profile = await UserProfiles.createQueryBuilder()
+				.where("\"integrations\"->'discord'->>'id' = :id", { id: id })
+				.andWhere('"userHost" IS NULL')
+				.getOne();
+
+			if (profile == null) {
+				ctx.throw(
+					404,
+					`@${username}#${discriminator}と連携しているMisskeyアカウントはありませんでした...`,
+				);
+				return;
+			}
+
+			await UserProfiles.update(profile.userId, {
+				integrations: {
+					...profile.integrations,
+					discord: {
+						id: id,
+						accessToken: accessToken,
+						refreshToken: refreshToken,
+						expiresDate: expiresDate,
+						username: username,
+						discriminator: discriminator,
+					},
+				},
+			});
+
+			signin(
+				ctx,
+				(await Users.findOneBy({ id: profile.userId })) as ILocalUser,
+				true,
+			);
+		} finally {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`discord:signin:state:${callbackState}`);
+		}
 	} else {
 		const code = ctx.query.code;
 
@@ -337,81 +356,83 @@ router.get("/dc/cb", async (ctx) => {
 			return;
 		}
 
-		await deleteRedisKey(userToken);
+		try {
+			const { accessToken, refreshToken, expiresDate } = await new Promise<any>(
+				(res, rej) =>
+					oauth2!.getOAuthAccessToken(
+						code,
+						{
+							grant_type: "authorization_code",
+							redirect_uri,
+						},
+						(err, accessToken, refreshToken, result) => {
+							if (err) {
+								rej(err);
+							} else if (result.error) {
+								rej(result.error);
+							} else {
+								res({
+									accessToken,
+									refreshToken,
+									expiresDate: Date.now() + Number(result.expires_in) * 1000,
+								});
+							}
+						},
+					),
+			);
 
-		const { accessToken, refreshToken, expiresDate } = await new Promise<any>(
-			(res, rej) =>
-				oauth2!.getOAuthAccessToken(
-					code,
-					{
-						grant_type: "authorization_code",
-						redirect_uri,
-					},
-					(err, accessToken, refreshToken, result) => {
-						if (err) {
-							rej(err);
-						} else if (result.error) {
-							rej(result.error);
-						} else {
-							res({
-								accessToken,
-								refreshToken,
-								expiresDate: Date.now() + Number(result.expires_in) * 1000,
-							});
-						}
-					},
-				),
-		);
-
-		const { id, username, discriminator } = (await getJson(
-			"https://discord.com/api/users/@me",
-			"*/*",
-			10 * 1000,
-			{
-				Authorization: `Bearer ${accessToken}`,
-			},
-		)) as Record<string, unknown>;
-		if (
-			typeof id !== "string" ||
-			typeof username !== "string" ||
-			typeof discriminator !== "string"
-		) {
-			ctx.throw(400, "invalid session - 7");
-			return;
-		}
-
-		const user = await Users.findOneByOrFail({
-			host: IsNull(),
-			token: userToken,
-		});
-
-		const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
-
-		await UserProfiles.update(user.id, {
-			integrations: {
-				...profile.integrations,
-				discord: {
-					accessToken: accessToken,
-					refreshToken: refreshToken,
-					expiresDate: expiresDate,
-					id: id,
-					username: username,
-					discriminator: discriminator,
+			const { id, username, discriminator } = (await getJson(
+				"https://discord.com/api/users/@me",
+				"*/*",
+				10 * 1000,
+				{
+					Authorization: `Bearer ${accessToken}`,
 				},
-			},
-		});
+			)) as Record<string, unknown>;
+			if (
+				typeof id !== "string" ||
+				typeof username !== "string" ||
+				typeof discriminator !== "string"
+			) {
+				ctx.throw(400, "invalid session - 7");
+				return;
+			}
 
-		ctx.body = `Discord: @${username}#${discriminator} を、Misskey: @${user.username} に接続しました！`;
+			const user = await Users.findOneByOrFail({
+				host: IsNull(),
+				token: userToken,
+			});
 
-		// Publish i updated event
-		publishMainStream(
-			user.id,
-			"meUpdated",
-			await Users.pack(user, user, {
-				detail: true,
-				includeSecrets: true,
-			}),
-		);
+			const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
+
+			await UserProfiles.update(user.id, {
+				integrations: {
+					...profile.integrations,
+					discord: {
+						accessToken: accessToken,
+						refreshToken: refreshToken,
+						expiresDate: expiresDate,
+						id: id,
+						username: username,
+						discriminator: discriminator,
+					},
+				},
+			});
+
+			ctx.body = `Discord: @${username}#${discriminator} を、Misskey: @${user.username} に接続しました！`;
+
+			// Publish i updated event
+			publishMainStream(
+				user.id,
+				"meUpdated",
+				await Users.pack(user, user, {
+					detail: true,
+					includeSecrets: true,
+				}),
+			);
+		} finally {
+			await deleteRedisKey(userToken);
+		}
 	}
 });
 

--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -168,6 +168,19 @@ router.get("/connect/github", async (ctx) => {
 });
 
 router.get("/signin/github", async (ctx) => {
+	const previousSessid = ctx.cookies.get("signin_with_github_sid");
+	if (previousSessid) {
+		const previousStateRaw = await getRedisValue(previousSessid);
+		await deleteRedisKey(previousSessid);
+
+		const previousState = previousStateRaw
+			? parseJsonSafely<{ state: string }>(previousStateRaw)
+			: null;
+		if (previousState) {
+			await deleteRedisKey(`github:signin:state:${previousState.state}`);
+		}
+	}
+
 	const sessid = uuid();
 	const state = uuid();
 
@@ -216,6 +229,10 @@ router.get("/gh/cb", async (ctx) => {
 			(await getRedisValue(`github:signin:state:${callbackState}`));
 
 		if (!savedState) {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`github:signin:state:${callbackState}`);
 			ctx.throw(400, "invalid session");
 			return;
 		}
@@ -237,60 +254,62 @@ router.get("/gh/cb", async (ctx) => {
 			return;
 		}
 
-		if (sessid) {
-			await deleteRedisKey(sessid);
-		}
-		await deleteRedisKey(`github:signin:state:${state}`);
-
-		const { accessToken } = await new Promise<any>((res, rej) =>
-			oauth2!.getOAuthAccessToken(
-				code,
-				{
-					redirect_uri,
-				},
-				(err, accessToken, refresh, result) => {
-					if (err) {
-						rej(err);
-					} else if (result.error) {
-						rej(result.error);
-					} else {
-						res({ accessToken });
-					}
-				},
-			),
-		);
-
-		const { login, id } = (await getJson(
-			"https://api.github.com/user",
-			"application/vnd.github.v3+json",
-			10 * 1000,
-			{
-				Authorization: `bearer ${accessToken}`,
-			},
-		)) as Record<string, unknown>;
-		if (typeof login !== "string" || typeof id !== "string") {
-			ctx.throw(400, "invalid session");
-			return;
-		}
-
-		const link = await UserProfiles.createQueryBuilder()
-			.where("\"integrations\"->'github'->>'id' = :id", { id: id })
-			.andWhere('"userHost" IS NULL')
-			.getOne();
-
-		if (link == null) {
-			ctx.throw(
-				404,
-				`@${login}と連携しているMisskeyアカウントはありませんでした...`,
+		try {
+			const { accessToken } = await new Promise<any>((res, rej) =>
+				oauth2!.getOAuthAccessToken(
+					code,
+					{
+						redirect_uri,
+					},
+					(err, accessToken, refresh, result) => {
+						if (err) {
+							rej(err);
+						} else if (result.error) {
+							rej(result.error);
+						} else {
+							res({ accessToken });
+						}
+					},
+				),
 			);
-			return;
-		}
 
-		signin(
-			ctx,
-			(await Users.findOneBy({ id: link.userId })) as ILocalUser,
-			true,
-		);
+			const { login, id } = (await getJson(
+				"https://api.github.com/user",
+				"application/vnd.github.v3+json",
+				10 * 1000,
+				{
+					Authorization: `bearer ${accessToken}`,
+				},
+			)) as Record<string, unknown>;
+			if (typeof login !== "string" || typeof id !== "string") {
+				ctx.throw(400, "invalid session");
+				return;
+			}
+
+			const link = await UserProfiles.createQueryBuilder()
+				.where("\"integrations\"->'github'->>'id' = :id", { id: id })
+				.andWhere('"userHost" IS NULL')
+				.getOne();
+
+			if (link == null) {
+				ctx.throw(
+					404,
+					`@${login}と連携しているMisskeyアカウントはありませんでした...`,
+				);
+				return;
+			}
+
+			signin(
+				ctx,
+				(await Users.findOneBy({ id: link.userId })) as ILocalUser,
+				true,
+			);
+		} finally {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`github:signin:state:${callbackState}`);
+		}
 	} else {
 		const code = ctx.query.code;
 
@@ -323,67 +342,69 @@ router.get("/gh/cb", async (ctx) => {
 			return;
 		}
 
-		await deleteRedisKey(userToken);
+		try {
+			const { accessToken } = await new Promise<any>((res, rej) =>
+				oauth2!.getOAuthAccessToken(
+					code,
+					{ redirect_uri },
+					(err, accessToken, refresh, result) => {
+						if (err) {
+							rej(err);
+						} else if (result.error) {
+							rej(result.error);
+						} else {
+							res({ accessToken });
+						}
+					},
+				),
+			);
 
-		const { accessToken } = await new Promise<any>((res, rej) =>
-			oauth2!.getOAuthAccessToken(
-				code,
-				{ redirect_uri },
-				(err, accessToken, refresh, result) => {
-					if (err) {
-						rej(err);
-					} else if (result.error) {
-						rej(result.error);
-					} else {
-						res({ accessToken });
-					}
+			const { login, id } = (await getJson(
+				"https://api.github.com/user",
+				"application/vnd.github.v3+json",
+				10 * 1000,
+				{
+					Authorization: `bearer ${accessToken}`,
 				},
-			),
-		);
+			)) as Record<string, unknown>;
 
-		const { login, id } = (await getJson(
-			"https://api.github.com/user",
-			"application/vnd.github.v3+json",
-			10 * 1000,
-			{
-				Authorization: `bearer ${accessToken}`,
-			},
-		)) as Record<string, unknown>;
+			if (typeof login !== "string" || typeof id !== "string") {
+				ctx.throw(400, "invalid session");
+				return;
+			}
 
-		if (typeof login !== "string" || typeof id !== "string") {
-			ctx.throw(400, "invalid session");
-			return;
+			const user = await Users.findOneByOrFail({
+				host: IsNull(),
+				token: userToken,
+			});
+
+			const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
+
+			await UserProfiles.update(user.id, {
+				integrations: {
+					...profile.integrations,
+					github: {
+						accessToken: accessToken,
+						id: id,
+						login: login,
+					},
+				},
+			});
+
+			ctx.body = `GitHub: @${login} を、Misskey: @${user.username} に接続しました！`;
+
+			// Publish i updated event
+			publishMainStream(
+				user.id,
+				"meUpdated",
+				await Users.pack(user, user, {
+					detail: true,
+					includeSecrets: true,
+				}),
+			);
+		} finally {
+			await deleteRedisKey(userToken);
 		}
-
-		const user = await Users.findOneByOrFail({
-			host: IsNull(),
-			token: userToken,
-		});
-
-		const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
-
-		await UserProfiles.update(user.id, {
-			integrations: {
-				...profile.integrations,
-				github: {
-					accessToken: accessToken,
-					id: id,
-					login: login,
-				},
-			},
-		});
-
-		ctx.body = `GitHub: @${login} を、Misskey: @${user.username} に接続しました！`;
-
-		// Publish i updated event
-		publishMainStream(
-			user.id,
-			"meUpdated",
-			await Users.pack(user, user, {
-				detail: true,
-				includeSecrets: true,
-			}),
-		);
 	}
 });
 

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -223,6 +223,19 @@ router.get("/connect/google", async (ctx) => {
 });
 
 router.get("/signin/google", async (ctx) => {
+	const previousSessid = ctx.cookies.get("signin_with_google_sid");
+	if (previousSessid) {
+		const previousStateRaw = await getRedisValue(previousSessid);
+		await deleteRedisKey(previousSessid);
+
+		const previousState = previousStateRaw
+			? parseJsonSafely<{ state: string }>(previousStateRaw)
+			: null;
+		if (previousState) {
+			await deleteRedisKey(`google:signin:state:${previousState.state}`);
+		}
+	}
+
 	const sessid = uuid();
 	const state = uuid();
 
@@ -279,10 +292,87 @@ router.get("/go/cb", async (ctx) => {
 			savedStateByCookie ??
 			(await getRedisValue(`google:signin:state:${callbackState}`));
 		if (!savedState) {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`google:signin:state:${callbackState}`);
 			ctx.throw(400, "invalid session");
 			return;
 		}
 
+		try {
+			const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
+			if (!savedStateObject) {
+				ctx.throw(400, "invalid session");
+				return;
+			}
+
+			const { redirect_uri, state } = savedStateObject;
+			if (callbackState !== state) {
+				ctx.throw(400, "invalid session");
+				return;
+			}
+
+			const accessToken = await getGoogleAccessToken(oauthConfig, code, redirect_uri);
+
+			const { sub, name, email } = (await getJson(
+				"https://www.googleapis.com/oauth2/v3/userinfo",
+				"application/json",
+				10 * 1000,
+				{ Authorization: `Bearer ${accessToken}` },
+			)) as Record<string, unknown>;
+
+			if (typeof sub !== "string") {
+				ctx.throw(400, "invalid session");
+				return;
+			}
+
+			const profile = await UserProfiles.createQueryBuilder()
+				.where("\"integrations\"->'google'->>'id' = :id", { id: sub })
+				.andWhere('"userHost" IS NULL')
+				.getOne();
+
+			if (!profile) {
+				ctx.throw(
+					404,
+					`${typeof email === "string" ? email : sub}と連携しているMisskeyアカウントはありませんでした...`,
+				);
+				return;
+			}
+
+			await UserProfiles.update(profile.userId, {
+				integrations: {
+					...profile.integrations,
+					google: {
+						id: sub,
+						accessToken,
+						name: typeof name === "string" ? name : null,
+						email: typeof email === "string" ? email : null,
+					},
+				},
+			});
+
+			signin(
+				ctx,
+				(await Users.findOneBy({ id: profile.userId })) as ILocalUser,
+				true,
+			);
+		} finally {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`google:signin:state:${callbackState}`);
+		}
+		return;
+	}
+
+	const savedState = await getRedisValue(userToken);
+	if (!savedState) {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	try {
 		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
 		if (!savedStateObject) {
 			ctx.throw(400, "invalid session");
@@ -290,15 +380,10 @@ router.get("/go/cb", async (ctx) => {
 		}
 
 		const { redirect_uri, state } = savedStateObject;
-		if (callbackState !== state) {
+		if (ctx.query.state !== state) {
 			ctx.throw(400, "invalid session");
 			return;
 		}
-
-		if (sessid) {
-			await deleteRedisKey(sessid);
-		}
-		await deleteRedisKey(`google:signin:state:${state}`);
 
 		const accessToken = await getGoogleAccessToken(oauthConfig, code, redirect_uri);
 
@@ -314,20 +399,13 @@ router.get("/go/cb", async (ctx) => {
 			return;
 		}
 
-		const profile = await UserProfiles.createQueryBuilder()
-			.where("\"integrations\"->'google'->>'id' = :id", { id: sub })
-			.andWhere('"userHost" IS NULL')
-			.getOne();
+		const user = await Users.findOneByOrFail({
+			host: IsNull(),
+			token: userToken,
+		});
+		const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
 
-		if (!profile) {
-			ctx.throw(
-				404,
-				`${typeof email === "string" ? email : sub}と連携しているMisskeyアカウントはありませんでした...`,
-			);
-			return;
-		}
-
-		await UserProfiles.update(profile.userId, {
+		await UserProfiles.update(user.id, {
 			integrations: {
 				...profile.integrations,
 				google: {
@@ -339,76 +417,19 @@ router.get("/go/cb", async (ctx) => {
 			},
 		});
 
-		signin(
-			ctx,
-			(await Users.findOneBy({ id: profile.userId })) as ILocalUser,
-			true,
+		ctx.body = `Google: ${typeof email === "string" ? email : sub} を、Misskey: @${user.username} に接続しました！`;
+
+		publishMainStream(
+			user.id,
+			"meUpdated",
+			await Users.pack(user, user, {
+				detail: true,
+				includeSecrets: true,
+			}),
 		);
-		return;
+	} finally {
+		await deleteRedisKey(userToken);
 	}
-
-	const savedState = await getRedisValue(userToken);
-	if (!savedState) {
-		ctx.throw(400, "invalid session");
-		return;
-	}
-
-	const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
-	if (!savedStateObject) {
-		ctx.throw(400, "invalid session");
-		return;
-	}
-
-	const { redirect_uri, state } = savedStateObject;
-	if (ctx.query.state !== state) {
-		ctx.throw(400, "invalid session");
-		return;
-	}
-
-	await deleteRedisKey(userToken);
-
-	const accessToken = await getGoogleAccessToken(oauthConfig, code, redirect_uri);
-
-	const { sub, name, email } = (await getJson(
-		"https://www.googleapis.com/oauth2/v3/userinfo",
-		"application/json",
-		10 * 1000,
-		{ Authorization: `Bearer ${accessToken}` },
-	)) as Record<string, unknown>;
-
-	if (typeof sub !== "string") {
-		ctx.throw(400, "invalid session");
-		return;
-	}
-
-	const user = await Users.findOneByOrFail({
-		host: IsNull(),
-		token: userToken,
-	});
-	const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
-
-	await UserProfiles.update(user.id, {
-		integrations: {
-			...profile.integrations,
-			google: {
-				id: sub,
-				accessToken,
-				name: typeof name === "string" ? name : null,
-				email: typeof email === "string" ? email : null,
-			},
-		},
-	});
-
-	ctx.body = `Google: ${typeof email === "string" ? email : sub} を、Misskey: @${user.username} に接続しました！`;
-
-	publishMainStream(
-		user.id,
-		"meUpdated",
-		await Users.pack(user, user, {
-			detail: true,
-			includeSecrets: true,
-		}),
-	);
 });
 
 export default router;

--- a/packages/backend/src/server/api/service/twitter.ts
+++ b/packages/backend/src/server/api/service/twitter.ts
@@ -167,6 +167,22 @@ router.get("/connect/twitter", async (ctx) => {
 });
 
 router.get("/signin/twitter", async (ctx) => {
+	const previousSessid = ctx.cookies.get("signin_with_twitter_sid");
+	if (previousSessid) {
+		const previousTwCtxRaw = await getRedisValue(previousSessid);
+		await deleteRedisKey(previousSessid);
+
+		const previousTwCtx = previousTwCtxRaw
+			? parseJsonSafely<{ url?: string }>(previousTwCtxRaw)
+			: null;
+		const previousOAuthToken = previousTwCtx?.url
+			? getOAuthTokenFromUrl(previousTwCtx.url)
+			: null;
+		if (previousOAuthToken) {
+			await deleteRedisKey(`twitter:signin:oauth-token:${previousOAuthToken}`);
+		}
+	}
+
 	const twAuth = await getTwAuth();
 	const twCtx = await twAuth!.begin();
 
@@ -213,44 +229,50 @@ router.get("/tw/cb", async (ctx) => {
 			(await getRedisValue(`twitter:signin:oauth-token:${oauthToken}`));
 
 		if (!twCtx) {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`twitter:signin:oauth-token:${oauthToken}`);
 			ctx.throw(400, "invalid session");
 			return;
 		}
 
-		if (sessid) {
-			await deleteRedisKey(sessid);
-		}
-		await deleteRedisKey(`twitter:signin:oauth-token:${oauthToken}`);
+		try {
+			const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
 
-		const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
+			if (!parsedTwCtx) {
+				ctx.throw(400, "invalid session");
+				return;
+			}
 
-		if (!parsedTwCtx) {
-			ctx.throw(400, "invalid session");
-			return;
-		}
+			const result = await twAuth!.done(parsedTwCtx, verifier);
 
-		const result = await twAuth!.done(parsedTwCtx, verifier);
+			const link = await UserProfiles.createQueryBuilder()
+				.where("\"integrations\"->'twitter'->>'userId' = :id", {
+					id: result.userId,
+				})
+				.andWhere('"userHost" IS NULL')
+				.getOne();
 
-		const link = await UserProfiles.createQueryBuilder()
-			.where("\"integrations\"->'twitter'->>'userId' = :id", {
-				id: result.userId,
-			})
-			.andWhere('"userHost" IS NULL')
-			.getOne();
+			if (link == null) {
+				ctx.throw(
+					404,
+					`@${result.screenName}と連携しているMisskeyアカウントはありませんでした...`,
+				);
+				return;
+			}
 
-		if (link == null) {
-			ctx.throw(
-				404,
-				`@${result.screenName}と連携しているMisskeyアカウントはありませんでした...`,
+			signin(
+				ctx,
+				(await Users.findOneBy({ id: link.userId })) as ILocalUser,
+				true,
 			);
-			return;
+		} finally {
+			if (sessid) {
+				await deleteRedisKey(sessid);
+			}
+			await deleteRedisKey(`twitter:signin:oauth-token:${oauthToken}`);
 		}
-
-		signin(
-			ctx,
-			(await Users.findOneBy({ id: link.userId })) as ILocalUser,
-			true,
-		);
 	} else {
 		const verifier = ctx.query.oauth_verifier;
 
@@ -266,47 +288,49 @@ router.get("/tw/cb", async (ctx) => {
 			return;
 		}
 
-		await deleteRedisKey(userToken);
+		try {
+			const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
 
-		const parsedTwCtx = parseJsonSafely<Record<string, unknown>>(twCtx);
+			if (!parsedTwCtx) {
+				ctx.throw(400, "invalid session");
+				return;
+			}
 
-		if (!parsedTwCtx) {
-			ctx.throw(400, "invalid session");
-			return;
-		}
+			const result = await twAuth!.done(parsedTwCtx, verifier);
 
-		const result = await twAuth!.done(parsedTwCtx, verifier);
+			const user = await Users.findOneByOrFail({
+				host: IsNull(),
+				token: userToken,
+			});
 
-		const user = await Users.findOneByOrFail({
-			host: IsNull(),
-			token: userToken,
-		});
+			const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
 
-		const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
-
-		await UserProfiles.update(user.id, {
-			integrations: {
-				...profile.integrations,
-				twitter: {
-					accessToken: result.accessToken,
-					accessTokenSecret: result.accessTokenSecret,
-					userId: result.userId,
-					screenName: result.screenName,
+			await UserProfiles.update(user.id, {
+				integrations: {
+					...profile.integrations,
+					twitter: {
+						accessToken: result.accessToken,
+						accessTokenSecret: result.accessTokenSecret,
+						userId: result.userId,
+						screenName: result.screenName,
+					},
 				},
-			},
-		});
+			});
 
-		ctx.body = `Twitter: @${result.screenName} を、Misskey: @${user.username} に接続しました！`;
+			ctx.body = `Twitter: @${result.screenName} を、Misskey: @${user.username} に接続しました！`;
 
-		// Publish i updated event
-		publishMainStream(
-			user.id,
-			"meUpdated",
-			await Users.pack(user, user, {
-				detail: true,
-				includeSecrets: true,
-			}),
-		);
+			// Publish i updated event
+			publishMainStream(
+				user.id,
+				"meUpdated",
+				await Users.pack(user, user, {
+					detail: true,
+					includeSecrets: true,
+				}),
+			);
+		} finally {
+			await deleteRedisKey(userToken);
+		}
 	}
 });
 


### PR DESCRIPTION
### Motivation
- 同一ブラウザでOAuthサインインを再開したときや認証が失敗/完了したときに古い `state` / `oauth_token` がRedisに残り次の試行を妨げる問題を防ぐため。 

### Description
- `/signin/*` ハンドラで、既存のセッション cookie（`signin_with_google_sid` / `signin_with_github_sid` / `signin_with_discord_sid` / `signin_with_twitter_sid`）が残っている場合は先に対応するRedisキーを削除する処理を追加しました。 
- 各OAuthコールバック（Google `/go/cb`、GitHub `/gh/cb`、Discord `/dc/cb`、Twitter `/tw/cb`）に `try/finally` を導入し、正常/異常に関わらず関連するRedisキー（`*:signin:state:*` や `twitter:signin:oauth-token:*`、およびユーザー側の一時キー）を必ず削除するようにしました。 
- 不正/参照不能セッション時でも該当キーの削除を先に試みてから `invalid session` を返すように調整しました。 
- 変更対象ファイル: `packages/backend/src/server/api/service/{google,github,discord,twitter}.ts`。 

### Testing
- `git diff --check` による差分チェックは問題ありませんでした（成功）。
- ソースの簡易構文バランス確認（ブレースの整合性）を行った `python` スクリプトは全ファイルで整合（成功）でした。 
- `pnpm --filter backend run lint` は実行環境に `node_modules` が無く `rome` が見つからず `ENOENT` となったため実行できませんでした（環境依存のため未実行）。 
- Node 環境での簡易評価は ES module の取り扱い設定に依存して実行できなかったため、ランタイム検証は行えていません（環境依存）。 

影響範囲・副作用: 同一ブラウザで並行して同プロバイダのOAuthフローを開始した場合、後から開始したフローが先のフローのキャッシュを消すため先に開始したフローが `invalid session` になりやすくなる点と、Redisへの削除操作が増える点に留意してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996697fe2608326b7279f667a96e56e)