### PR TITLE
Restrict SW offline fallback to app UI routes only

### DIFF
--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -75,11 +75,33 @@ async function offlineContentHTML() {
 	return `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><meta content="width=device-width,initial-scale=1"name="viewport"><title>${messages.title}</title><style>body{background-color:#0c1210;color:#dee7e4;font-family:Hiragino Maru Gothic Pro,BIZ UDGothic,Roboto,HelveticaNeue,Arial,sans-serif;line-height:1.35;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:24px;box-sizing:border-box}.icon{max-width:120px;width:100%;height:auto;margin-bottom:20px;}.message{text-align:center;font-size:20px;font-weight:700;margin-bottom:20px}.version{text-align:center;font-size:90%;margin-bottom:20px}button{padding:7px 14px;min-width:100px;font-weight:700;font-family:Hiragino Maru Gothic Pro,BIZ UDGothic,Roboto,HelveticaNeue,Arial,sans-serif;line-height:1.35;border-radius:99rem;background-color:#b4e900;color:#192320;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent}button:hover{background-color:#c6ff03}</style></head><body><svg class="icon"fill="none"height="24"stroke="currentColor"stroke-linecap="round"stroke-linejoin="round"stroke-width="2"viewBox="0 0 24 24"width="24"xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z"fill="none"stroke="none"/><path d="M9.58 5.548c.24 -.11 .492 -.207 .752 -.286c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 .957 -.383 1.824 -1.003 2.454m-2.997 1.033h-11.343c-2.572 -.004 -4.657 -2.011 -4.657 -4.487c0 -2.475 2.085 -4.482 4.657 -4.482c.13 -.582 .37 -1.128 .7 -1.62"/><path d="M3 3l18 18"/></svg><div class="message">${messages.header}</div><div class="version">v${_VERSION_}</div><button onclick="reloadPage()">${messages.reload}</button><script>function reloadPage(){location.reload(!0)}</script></body></html>`;
 }
 
+const APP_ROUTE_PREFIXES = [
+	"/notes/",
+	"/posts/",
+	"/users/",
+	"/channels/",
+	"/clips/",
+	"/gallery/",
+	"/light",
+	"/@",
+] as const;
+
+const APP_ROUTE_EXACT = new Set([
+	"/",
+	"/bios",
+	"/cli",
+	"/flush",
+	"/sc",
+]);
+
+function isAppRoute(pathname: string): boolean {
+	if (APP_ROUTE_EXACT.has(pathname)) return true;
+
+	return APP_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
 self.addEventListener("fetch", (ev) => {
 	const requestUrl = new URL(ev.request.url);
-	if (requestUrl.pathname.startsWith("/api/")) {
-		return;
-	}
 
 	let isHTMLRequest = false;
 	if (ev.request.headers.get("sec-fetch-dest") === "document") {
@@ -90,7 +112,9 @@ self.addEventListener("fetch", (ev) => {
 		isHTMLRequest = true;
 	}
 
-	if (!isHTMLRequest) return;
+	if (!isHTMLRequest || !isAppRoute(requestUrl.pathname)) return;
+
+	// 新規 UI ルートを backend 側に追加した際は isAppRoute も必ず更新すること。
 	ev.respondWith(respondToNavigation(ev.request));
 });
 


### PR DESCRIPTION
### Motivation
- Service Worker の現行のオフライン HTML フォールバックが除外リストベースで広すぎ、API や静的配信などを誤って置換する可能性があるため、許可リストベースで画面ルートのみフォールバックするように制限します。 
- バックエンドの画面配信ルート（例: `/`, `/notes/`, `/users/`, `/channels/`, `/clips/`, `/gallery/`, `/light`, `/@...` など）を基準に対象を限定します。 
- 想定される副作用として、バックエンドに新しい UI ルートを追加しても `isAppRoute` を更新しないと当該ルートがオフライン時にオフラインページへフォールバックしなくなるため、運用での同期が必要になります。 

### Description
- `packages/sw/src/sw.ts` に `APP_ROUTE_PREFIXES` と `APP_ROUTE_EXACT` を追加して画面配信ルートの許可リストを定義しました。 
- `isAppRoute(pathname)` を追加し、`isHTMLRequest` 判定に加えて `isAppRoute(requestUrl.pathname)` が `true` の場合のみ `respondWith(respondToNavigation(...))` を実行するように変更しました。 
- これにより `/api/` や OAuth、`.well-known`、静的アセットなどの非 UI ルートは Service Worker で置き換えず素通しになります。 
- コード中に「新規 UI ルート追加時は `isAppRoute` を更新すること」という運用コメントを追加しました。 

### Testing
- 変更ファイルは `packages/sw/src/sw.ts` のみで、差分はコミット済みです。 
- `pnpm -C packages/sw lint` を実行しましたが、ローカルの `node_modules` / `rome` が存在しないため `rome` 実行に失敗しリンティングは環境依存で失敗しました。 
- ローカルビルド／ランタイム統合テストは行っておらず、実行環境でのデプロイ後にオフライン挙動（UI ルートでのフォールバック、非 UI ルートの素通し）が期待通りか確認してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966ae216848326874b0655ac0f8a63)