### PR TITLE
OAuth コールバックの igi クッキー解析を修正

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -13,7 +13,7 @@ import { redisClient } from "../../../db/redis.js";
 import signin from "../common/signin.js";
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
-	return ((ctx.headers["cookie"] || "").match(/igi=(\w+)/) || [null, null])[1];
+	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {

--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -13,7 +13,7 @@ import { redisClient } from "../../../db/redis.js";
 import signin from "../common/signin.js";
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
-	return ((ctx.headers["cookie"] || "").match(/igi=(\w+)/) || [null, null])[1];
+	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -12,7 +12,7 @@ import { redisClient } from "../../../db/redis.js";
 import signin from "../common/signin.js";
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
-	return ((ctx.headers["cookie"] || "").match(/igi=(\w+)/) || [null, null])[1];
+	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {

--- a/packages/backend/src/server/api/service/twitter.ts
+++ b/packages/backend/src/server/api/service/twitter.ts
@@ -12,7 +12,7 @@ import signin from "../common/signin.js";
 import { redisClient } from "../../../db/redis.js";
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
-	return ((ctx.headers["cookie"] || "").match(/igi=(\w+)/) || [null, null])[1];
+	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.BaseContext): boolean {


### PR DESCRIPTION
### Motivation
- Discord の OAuth コールバックで発生する `invalid session - 6` の原因となる、`igi` クッキー値の不完全な抽出（`\w+` による制限）を修正するため。
- OAuth フローを提供する各プロバイダ間で同一の挙動に揃え、コールバック時に Redis で保存した state が正しく復元されるようにするため。

### Description
- `igi=(\w+)` をより堅牢なパターン `(?:^|;\s*)igi=([^;]+)` に変更して、クッキー内の `igi` 値をセミコロン区切りまで正しく取得するようにしました。変更対象ファイルは `packages/backend/src/server/api/service/discord.ts`、`packages/backend/src/server/api/service/github.ts`、`packages/backend/src/server/api/service/google.ts`、`packages/backend/src/server/api/service/twitter.ts` です。
- この変更により、トークンに `-` 等の非単語文字が含まれる場合でも正しく取得できるようになり、OAuth コールバック時の state 参照漏れが改善されます。
- 副作用としては、これまで `\w+` によって切られていたトークン全体を扱うようになるため、以前は部分一致で問題が起きていたケースは修正されますが、クッキーが意図しないフォーマットで送信される場合は従来同様 `null` と評価される可能性があります。API の外部仕様やストレージの構造は変更していません。

### Testing
- 実行した自動検査は `pnpm --filter backend lint` のみで、依存関係（`node_modules`）が導入されていない環境のため `rome` コマンドが見つからず失敗しました（実行結果: 失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966d509c70832691be4a8103e7bdc4)