### PR TITLE
fix: GitHub/Google/Twitter の connect フローに state/oauth_token フォールバックを追加

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -159,6 +159,11 @@ router.get("/connect/discord", async (ctx) => {
 	};
 
 	await setRedisValue(userToken, JSON.stringify(params), 600);
+	await setRedisValue(
+		`discord:connect:state:${params.state}`,
+		JSON.stringify(params),
+		600,
+	);
 
 	const oauth2 = await getOAuth2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
@@ -331,13 +336,23 @@ router.get("/dc/cb", async (ctx) => {
 		}
 	} else {
 		const code = ctx.query.code;
+		const callbackState = ctx.query.state;
 
 		if (!code || typeof code !== "string") {
 			ctx.throw(400, "invalid session - 5");
 			return;
 		}
 
-		const savedState = await getRedisValue(userToken);
+		if (!callbackState || typeof callbackState !== "string") {
+			ctx.throw(400, "invalid session - 6");
+			return;
+		}
+
+		const savedStateByUserToken = await getRedisValue(userToken);
+		const savedStateByState = await getRedisValue(
+			`discord:connect:state:${callbackState}`,
+		);
+		const savedState = savedStateByUserToken ?? savedStateByState;
 		if (!savedState) {
 			ctx.throw(400, "invalid session - 6");
 			return;
@@ -351,7 +366,7 @@ router.get("/dc/cb", async (ctx) => {
 
 		const { redirect_uri, state } = savedStateObject;
 
-		if (ctx.query.state !== state) {
+		if (callbackState !== state) {
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
@@ -432,6 +447,7 @@ router.get("/dc/cb", async (ctx) => {
 			);
 		} finally {
 			await deleteRedisKey(userToken);
+			await deleteRedisKey(`discord:connect:state:${callbackState}`);
 		}
 	}
 });

--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -162,6 +162,7 @@ router.get("/connect/github", async (ctx) => {
 	};
 
 	await setRedisValue(userToken, JSON.stringify(params), 600);
+	await setRedisValue(`github:connect:state:${params.state}`, JSON.stringify(params), 600);
 
 	const oauth2 = await getOath2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
@@ -312,13 +313,21 @@ router.get("/gh/cb", async (ctx) => {
 		}
 	} else {
 		const code = ctx.query.code;
+		const callbackState = ctx.query.state;
 
 		if (!code || typeof code !== "string") {
 			ctx.throw(400, "invalid session");
 			return;
 		}
 
-		const savedState = await getRedisValue(userToken);
+		if (!callbackState || typeof callbackState !== "string") {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const savedStateByUserToken = await getRedisValue(userToken);
+		const savedStateByState = await getRedisValue(`github:connect:state:${callbackState}`);
+		const savedState = savedStateByUserToken ?? savedStateByState;
 
 		if (!savedState) {
 			ctx.throw(400, "invalid session");
@@ -337,7 +346,7 @@ router.get("/gh/cb", async (ctx) => {
 
 		const { redirect_uri, state } = savedStateObject;
 
-		if (ctx.query.state !== state) {
+		if (callbackState !== state) {
 			ctx.throw(400, "invalid session");
 			return;
 		}
@@ -404,6 +413,7 @@ router.get("/gh/cb", async (ctx) => {
 			);
 		} finally {
 			await deleteRedisKey(userToken);
+			await deleteRedisKey(`github:connect:state:${callbackState}`);
 		}
 	}
 });

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -212,6 +212,7 @@ router.get("/connect/google", async (ctx) => {
 	};
 
 	await setRedisValue(userToken, JSON.stringify(params), 600);
+	await setRedisValue(`google:connect:state:${params.state}`, JSON.stringify(params), 600);
 
 	const oauthConfig = await getGoogleOAuthConfig();
 	if (!oauthConfig) {
@@ -366,7 +367,15 @@ router.get("/go/cb", async (ctx) => {
 		return;
 	}
 
-	const savedState = await getRedisValue(userToken);
+	const callbackState = ctx.query.state;
+	if (!callbackState || typeof callbackState !== "string") {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
+	const savedStateByUserToken = await getRedisValue(userToken);
+	const savedStateByState = await getRedisValue(`google:connect:state:${callbackState}`);
+	const savedState = savedStateByUserToken ?? savedStateByState;
 	if (!savedState) {
 		ctx.throw(400, "invalid session");
 		return;
@@ -380,7 +389,7 @@ router.get("/go/cb", async (ctx) => {
 		}
 
 		const { redirect_uri, state } = savedStateObject;
-		if (ctx.query.state !== state) {
+		if (callbackState !== state) {
 			ctx.throw(400, "invalid session");
 			return;
 		}
@@ -429,6 +438,7 @@ router.get("/go/cb", async (ctx) => {
 		);
 	} finally {
 		await deleteRedisKey(userToken);
+		await deleteRedisKey(`google:connect:state:${callbackState}`);
 	}
 });
 

--- a/packages/backend/src/server/api/service/twitter.ts
+++ b/packages/backend/src/server/api/service/twitter.ts
@@ -162,7 +162,13 @@ router.get("/connect/twitter", async (ctx) => {
 
 	const twAuth = await getTwAuth();
 	const twCtx = await twAuth!.begin();
+	const oauthToken = getOAuthTokenFromUrl(twCtx.url);
+
 	await setRedisValue(userToken, JSON.stringify(twCtx), 600);
+	if (oauthToken) {
+		await setRedisValue(`twitter:connect:oauth-token:${oauthToken}`, JSON.stringify(twCtx), 600);
+	}
+
 	ctx.redirect(twCtx.url);
 });
 
@@ -281,7 +287,15 @@ router.get("/tw/cb", async (ctx) => {
 			return;
 		}
 
-		const twCtx = await getRedisValue(userToken);
+		const oauthToken = ctx.query.oauth_token;
+		if (!oauthToken || typeof oauthToken !== "string") {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
+		const twCtxByUserToken = await getRedisValue(userToken);
+		const twCtxByOAuthToken = await getRedisValue(`twitter:connect:oauth-token:${oauthToken}`);
+		const twCtx = twCtxByUserToken ?? twCtxByOAuthToken;
 
 		if (!twCtx) {
 			ctx.throw(400, "invalid session");
@@ -330,6 +344,7 @@ router.get("/tw/cb", async (ctx) => {
 			);
 		} finally {
 			await deleteRedisKey(userToken);
+			await deleteRedisKey(`twitter:connect:oauth-token:${oauthToken}`);
 		}
 	}
 });


### PR DESCRIPTION
### Motivation
- OAuth の `connect` → `callback` フローで `userToken` 側の一時状態が欠落すると接続失敗（`invalid session` 系）が発生するため、Discord で導入した復元ロジックを他サービスにも適用する目的です。 
- 同様の欠落は GitHub / Google / Twitter でも発生し得るため、各プロバイダで復元性を統一して向上させます。 
- 副作用としては Redis に書き込む一時キーが1つ増えるため書き込み/削除がわずかに増え（TTL は既存の 600 秒を使用）、コールバックで `state`/`oauth_token` を必須にするため不正または壊れたコールバックはより厳密に弾かれます。 

### Description
- `packages/backend/src/server/api/service/github.ts` の `GET /connect/github` で `userToken` に加えて `github:connect:state:<state>` にも一時状態を保存するようにしました。 
- `packages/backend/src/server/api/service/google.ts` の `GET /connect/google` で `userToken` に加えて `google:connect:state:<state>` にも一時状態を保存するようにしました。 
- `packages/backend/src/server/api/service/twitter.ts` の `GET /connect/twitter` で `userToken` に加えて OAuth1 の `oauth_token` 抽出値をキーにした `twitter:connect:oauth-token:<oauth_token>` を保存するようにしました。 
- 各コールバック（サインイン済み分岐）では `state`（または Twitter は `oauth_token`）を必須チェックし、`userToken` での取得に失敗した場合はサービス固有のフォールバックキーから復元し、`finally` ブロックで両方のキーを確実に削除するように修正しました。 

変更対象ファイル: `packages/backend/src/server/api/service/github.ts`, `packages/backend/src/server/api/service/google.ts`, `packages/backend/src/server/api/service/twitter.ts`. 

### Testing
- 実行した自動検査: `pnpm --filter backend run lint` を実行しましたが、開発環境に `rome`（`node_modules`）が無いため `spawn rome ENOENT` エラーで失敗しました。 
- それ以外の自動テストはこの環境では実行しておらず、ローカル/CI 環境での linter と統合テスト実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966f2e080c83268e67c9bda2a361e2)