### PR TITLE
Add diagnostic logging for Discord OAuth callback state validation

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -3,6 +3,7 @@ import Router from "@koa/router";
 import { OAuth2 } from "oauth";
 import { v4 as uuid } from "uuid";
 import { IsNull } from "typeorm";
+import Logger from "@/services/logger.js";
 import { getJson } from "@/misc/fetch.js";
 import config from "@/config/index.js";
 import { publishMainStream } from "@/services/stream.js";
@@ -11,6 +12,28 @@ import { Users, UserProfiles } from "@/models/index.js";
 import type { ILocalUser } from "@/models/entities/user.js";
 import { redisClient } from "../../../db/redis.js";
 import signin from "../common/signin.js";
+
+const logger = new Logger("discord-oauth");
+
+function maskToken(token: string | null | undefined): string {
+	if (!token) return "none";
+	if (token.length <= 8) return `${token[0]}***`;
+	return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}
+
+function getRequestOriginForLog(ctx: Koa.BaseContext): string {
+	const origin = ctx.headers["origin"];
+	if (typeof origin === "string") return origin;
+	const referer = ctx.headers["referer"];
+	if (typeof referer === "string") {
+		try {
+			return new URL(referer).origin;
+		} catch {
+			return "invalid referer";
+		}
+	}
+	return "none";
+}
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
 	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
@@ -208,19 +231,35 @@ router.get("/signin/discord", async (ctx) => {
 
 router.get("/dc/cb", async (ctx) => {
 	const userToken = getUserToken(ctx);
+	const callbackState = ctx.query.state;
+	const code = ctx.query.code;
 
 	const oauth2 = await getOAuth2();
 
-	if (!userToken) {
-		const code = ctx.query.code;
+	logger.info("Discord OAuth callback requested", {
+		path: ctx.path,
+		hasUserToken: Boolean(userToken),
+		maskedUserToken: maskToken(userToken),
+		hasCode: typeof code === "string" && code.length > 0,
+		hasState: typeof callbackState === "string" && callbackState.length > 0,
+		stateLength: typeof callbackState === "string" ? callbackState.length : null,
+		requestOrigin: getRequestOriginForLog(ctx),
+	});
 
+	if (!userToken) {
 		if (!code || typeof code !== "string") {
+			logger.warn("Discord sign-in callback rejected: code missing", {
+				reason: "invalid session - 2",
+				hasState: typeof callbackState === "string",
+			});
 			ctx.throw(400, "invalid session - 2");
 			return;
 		}
 
-		const callbackState = ctx.query.state;
 		if (!callbackState || typeof callbackState !== "string") {
+			logger.warn("Discord sign-in callback rejected: state missing", {
+				reason: "invalid session - 1",
+			});
 			ctx.throw(400, "invalid session - 1");
 			return;
 		}
@@ -232,6 +271,12 @@ router.get("/dc/cb", async (ctx) => {
 			(await getRedisValue(`discord:signin:state:${callbackState}`));
 
 		if (!savedState) {
+			logger.warn("Discord sign-in callback rejected: state not found", {
+				reason: "invalid session - 3",
+				hasSessid: Boolean(sessid),
+				maskedSessid: maskToken(sessid),
+				callbackState,
+			});
 			if (sessid) {
 				await deleteRedisKey(sessid);
 			}
@@ -242,6 +287,10 @@ router.get("/dc/cb", async (ctx) => {
 
 		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
 		if (!savedStateObject) {
+			logger.warn("Discord sign-in callback rejected: saved state parse failed", {
+				reason: "invalid session - 3",
+				callbackState,
+			});
 			ctx.throw(400, "invalid session - 3");
 			return;
 		}
@@ -249,6 +298,11 @@ router.get("/dc/cb", async (ctx) => {
 		const { redirect_uri, state } = savedStateObject;
 
 		if (callbackState !== state) {
+			logger.warn("Discord sign-in callback rejected: state mismatch", {
+				reason: "invalid session - 3",
+				callbackState,
+				savedState: state,
+			});
 			ctx.throw(400, "invalid session - 3");
 			return;
 		}
@@ -335,15 +389,21 @@ router.get("/dc/cb", async (ctx) => {
 			await deleteRedisKey(`discord:signin:state:${callbackState}`);
 		}
 	} else {
-		const code = ctx.query.code;
-		const callbackState = ctx.query.state;
-
 		if (!code || typeof code !== "string") {
+			logger.warn("Discord connect callback rejected: code missing", {
+				reason: "invalid session - 5",
+				hasState: typeof callbackState === "string",
+				maskedUserToken: maskToken(userToken),
+			});
 			ctx.throw(400, "invalid session - 5");
 			return;
 		}
 
 		if (!callbackState || typeof callbackState !== "string") {
+			logger.warn("Discord connect callback rejected: state missing", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
@@ -354,12 +414,24 @@ router.get("/dc/cb", async (ctx) => {
 		);
 		const savedState = savedStateByUserToken ?? savedStateByState;
 		if (!savedState) {
+			logger.warn("Discord connect callback rejected: no saved state", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+				hasSavedStateByUserToken: Boolean(savedStateByUserToken),
+				hasSavedStateByState: Boolean(savedStateByState),
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
 
 		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
 		if (!savedStateObject) {
+			logger.warn("Discord connect callback rejected: saved state parse failed", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
@@ -367,6 +439,12 @@ router.get("/dc/cb", async (ctx) => {
 		const { redirect_uri, state } = savedStateObject;
 
 		if (callbackState !== state) {
+			logger.warn("Discord connect callback rejected: state mismatch", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+				savedState: state,
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}


### PR DESCRIPTION
## Summary
- add a dedicated `discord-oauth` logger in `packages/backend/src/server/api/service/discord.ts`
- add sanitized callback-entry logs for `/api/dc/cb` (presence of token/code/state, state length, request origin)
- add warning logs for every `invalid session` rejection branch in Discord sign-in/connect callback flows, especially `invalid session - 6`

## Why
Discord login/connect is still failing with `invalid session - 6` in some environments. This change adds enough observability to determine whether the failure is caused by:
- missing callback query values,
- missing Redis state records,
- JSON parse failure of saved state, or
- state mismatch between callback and stored session.

## Notes
- sensitive values are masked in logs (`maskToken`) to reduce leakage risk.
- no behavior changes were introduced in auth/session validation logic.

## Validation
- static inspection of the updated route confirmed logs are emitted at callback entry and each failure branch.
- no runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967b83c0fc8326bf2a389e7f04271a)