### PR TITLE
Discord OAuth の接続状態保存とコールバック診断ログを強化

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -3,6 +3,7 @@ import Router from "@koa/router";
 import { OAuth2 } from "oauth";
 import { v4 as uuid } from "uuid";
 import { IsNull } from "typeorm";
+import Logger from "@/services/logger.js";
 import { getJson } from "@/misc/fetch.js";
 import config from "@/config/index.js";
 import { publishMainStream } from "@/services/stream.js";
@@ -11,6 +12,40 @@ import { Users, UserProfiles } from "@/models/index.js";
 import type { ILocalUser } from "@/models/entities/user.js";
 import { redisClient } from "../../../db/redis.js";
 import signin from "../common/signin.js";
+
+const logger = new Logger("discord-oauth");
+
+function appendLogContext(message: string, context: Record<string, unknown>): string {
+	return `${message} ${JSON.stringify(context)}`;
+}
+
+function logInfo(message: string, context: Record<string, unknown>): void {
+	logger.info(appendLogContext(message, context));
+}
+
+function logWarn(message: string, context: Record<string, unknown>): void {
+	logger.warn(appendLogContext(message, context));
+}
+
+function maskToken(token: string | null | undefined): string {
+	if (!token) return "none";
+	if (token.length <= 8) return `${token[0]}***`;
+	return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}
+
+function getRequestOriginForLog(ctx: Koa.BaseContext): string {
+	const origin = ctx.headers["origin"];
+	if (typeof origin === "string") return origin;
+	const referer = ctx.headers["referer"];
+	if (typeof referer === "string") {
+		try {
+			return new URL(referer).origin;
+		} catch {
+			return "invalid referer";
+		}
+	}
+	return "none";
+}
 
 function getUserToken(ctx: Koa.BaseContext): string | null {
 	return ((ctx.headers["cookie"] || "").match(/(?:^|;\s*)igi=([^;]+)/) || [null, null])[1];
@@ -38,6 +73,19 @@ function compareOrigin(ctx: Koa.BaseContext): boolean {
 function getRedisValue(key: string): Promise<string | null> {
 	return new Promise((resolve, reject) => {
 		redisClient.get(key, (err, value) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+
+			resolve(value);
+		});
+	});
+}
+
+function getRedisTtl(key: string): Promise<number> {
+	return new Promise((resolve, reject) => {
+		redisClient.ttl(key, (err, value) => {
 			if (err) {
 				reject(err);
 				return;
@@ -165,6 +213,23 @@ router.get("/connect/discord", async (ctx) => {
 		600,
 	);
 
+	const stateKey = `discord:connect:state:${params.state}`;
+	const [savedByUserToken, savedByState, userTokenTtl, stateTtl] = await Promise.all([
+		getRedisValue(userToken),
+		getRedisValue(stateKey),
+		getRedisTtl(userToken),
+		getRedisTtl(stateKey),
+	]);
+	logInfo("Discord connect state stored", {
+		maskedUserToken: maskToken(userToken),
+		state: params.state,
+		hasSavedByUserToken: Boolean(savedByUserToken),
+		hasSavedByState: Boolean(savedByState),
+		userTokenTtl,
+		stateTtl,
+		requestOrigin: getRequestOriginForLog(ctx),
+	});
+
 	const oauth2 = await getOAuth2();
 	ctx.redirect(oauth2!.getAuthorizeUrl(params));
 });
@@ -208,19 +273,35 @@ router.get("/signin/discord", async (ctx) => {
 
 router.get("/dc/cb", async (ctx) => {
 	const userToken = getUserToken(ctx);
+	const callbackState = ctx.query.state;
+	const code = ctx.query.code;
 
 	const oauth2 = await getOAuth2();
 
-	if (!userToken) {
-		const code = ctx.query.code;
+	logInfo("Discord OAuth callback requested", {
+		path: ctx.path,
+		hasUserToken: Boolean(userToken),
+		maskedUserToken: maskToken(userToken),
+		hasCode: typeof code === "string" && code.length > 0,
+		hasState: typeof callbackState === "string" && callbackState.length > 0,
+		stateLength: typeof callbackState === "string" ? callbackState.length : null,
+		requestOrigin: getRequestOriginForLog(ctx),
+	});
 
+	if (!userToken) {
 		if (!code || typeof code !== "string") {
+			logWarn("Discord sign-in callback rejected: code missing", {
+				reason: "invalid session - 2",
+				hasState: typeof callbackState === "string",
+			});
 			ctx.throw(400, "invalid session - 2");
 			return;
 		}
 
-		const callbackState = ctx.query.state;
 		if (!callbackState || typeof callbackState !== "string") {
+			logWarn("Discord sign-in callback rejected: state missing", {
+				reason: "invalid session - 1",
+			});
 			ctx.throw(400, "invalid session - 1");
 			return;
 		}
@@ -232,6 +313,12 @@ router.get("/dc/cb", async (ctx) => {
 			(await getRedisValue(`discord:signin:state:${callbackState}`));
 
 		if (!savedState) {
+			logWarn("Discord sign-in callback rejected: state not found", {
+				reason: "invalid session - 3",
+				hasSessid: Boolean(sessid),
+				maskedSessid: maskToken(sessid),
+				callbackState,
+			});
 			if (sessid) {
 				await deleteRedisKey(sessid);
 			}
@@ -242,6 +329,10 @@ router.get("/dc/cb", async (ctx) => {
 
 		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
 		if (!savedStateObject) {
+			logWarn("Discord sign-in callback rejected: saved state parse failed", {
+				reason: "invalid session - 3",
+				callbackState,
+			});
 			ctx.throw(400, "invalid session - 3");
 			return;
 		}
@@ -249,6 +340,11 @@ router.get("/dc/cb", async (ctx) => {
 		const { redirect_uri, state } = savedStateObject;
 
 		if (callbackState !== state) {
+			logWarn("Discord sign-in callback rejected: state mismatch", {
+				reason: "invalid session - 3",
+				callbackState,
+				savedState: state,
+			});
 			ctx.throw(400, "invalid session - 3");
 			return;
 		}
@@ -335,15 +431,21 @@ router.get("/dc/cb", async (ctx) => {
 			await deleteRedisKey(`discord:signin:state:${callbackState}`);
 		}
 	} else {
-		const code = ctx.query.code;
-		const callbackState = ctx.query.state;
-
 		if (!code || typeof code !== "string") {
+			logWarn("Discord connect callback rejected: code missing", {
+				reason: "invalid session - 5",
+				hasState: typeof callbackState === "string",
+				maskedUserToken: maskToken(userToken),
+			});
 			ctx.throw(400, "invalid session - 5");
 			return;
 		}
 
 		if (!callbackState || typeof callbackState !== "string") {
+			logWarn("Discord connect callback rejected: state missing", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
@@ -354,12 +456,24 @@ router.get("/dc/cb", async (ctx) => {
 		);
 		const savedState = savedStateByUserToken ?? savedStateByState;
 		if (!savedState) {
+			logWarn("Discord connect callback rejected: no saved state", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+				hasSavedStateByUserToken: Boolean(savedStateByUserToken),
+				hasSavedStateByState: Boolean(savedStateByState),
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
 
 		const savedStateObject = parseJsonSafely<{ redirect_uri: string; state: string }>(savedState);
 		if (!savedStateObject) {
+			logWarn("Discord connect callback rejected: saved state parse failed", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}
@@ -367,6 +481,12 @@ router.get("/dc/cb", async (ctx) => {
 		const { redirect_uri, state } = savedStateObject;
 
 		if (callbackState !== state) {
+			logWarn("Discord connect callback rejected: state mismatch", {
+				reason: "invalid session - 6",
+				maskedUserToken: maskToken(userToken),
+				callbackState,
+				savedState: state,
+			});
 			ctx.throw(400, "invalid session - 6");
 			return;
 		}


### PR DESCRIPTION
### Motivation
- 本番環境で `/dc/cb` の `invalid session - 6` が発生しており、`journalctl` 上で `info`/`warn` のコンテキストフィールドが見えないため原因調査が困難だったので、コールバックの診断情報を確実に取得できるようにするための変更です。 
- `/connect/discord` で状態を Redis に保存した直後に保存成否と TTL を検証するログを追加して「保存できているか/TTL が即時に変」かを即座に把握できるようにします。

### Description
- `packages/backend/src/server/api/service/discord.ts` に `appendLogContext`/`logInfo`/`logWarn` を追加して、コンテキストを `JSON.stringify` してメッセージ本体へ埋め込む方式にし、既存の `logger.info`/`logger.warn` 呼び出しをこれらに切り替えました。 
- Redis 周りに `getRedisTtl` ヘルパーを追加し、`/connect/discord` の `setRedisValue` 後に両キーの再読込と TTL を `Promise.all` で取得して `logInfo("Discord connect state stored", {...})` を出力する検証を入れました。 
- `/dc/cb` 側のコールバック診断ログ（サインイン／コネクトの各 `invalid session` 分岐を含む）を新しいログヘルパで出力するように変更し、`maskedUserToken` や `callbackState` 等の調査用情報をログに含めるようにしました。 
- 副作用としてログ量が増加し、調査目的で `state` をログに含めているためログ取扱い上の注意が必要であり、必要なら `state` マスキングを追加する必要があります。

### Testing
- `pnpm -C packages/backend run lint src/server/api/service/discord.ts` を実行しましたが、`rome`（`node_modules` が未導入）が存在せずリンター実行は失敗しました（依存未インストールによる実行不可）。
- ソース差分の静的確認として `rg` およびファイル表示（`nl`/`sed`）で変更箇所を検査し、`appendLogContext`/`logInfo`/`logWarn`・`getRedisTtl`・`Discord connect state stored` 出力が正しく挿入されていることを確認しました。 
- 変更はコミット済みで、コードの動作確認（ランタイムの統合テストや本番検証）はこの環境では未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967b83c0fc8326bf2a389e7f04271a)