### PR TITLE
OAuth stateプレフィックス判定をGitHub/Googleへ展開しconnectガードを追加

### DIFF
--- a/packages/backend/src/server/api/service/discord.ts
+++ b/packages/backend/src/server/api/service/discord.ts
@@ -130,6 +130,13 @@ function parseJsonSafely<T>(value: string): T | null {
 	}
 }
 
+function detectOAuthFlowFromState(state: unknown): "signin" | "connect" | "unknown" {
+	if (typeof state !== "string") return "unknown";
+	if (state.startsWith("signin:")) return "signin";
+	if (state.startsWith("connect:")) return "connect";
+	return "unknown";
+}
+
 // Init router
 const router = new Router();
 
@@ -202,7 +209,7 @@ router.get("/connect/discord", async (ctx) => {
 	const params = {
 		redirect_uri: `${config.url}/api/dc/cb`,
 		scope: ["identify"],
-		state: uuid(),
+		state: `connect:${uuid()}`,
 		response_type: "code",
 	};
 
@@ -249,7 +256,7 @@ router.get("/signin/discord", async (ctx) => {
 	}
 
 	const sessid = uuid();
-	const state = uuid();
+	const state = `signin:${uuid()}`;
 
 	const params = {
 		redirect_uri: `${config.url}/api/dc/cb`,
@@ -275,6 +282,18 @@ router.get("/dc/cb", async (ctx) => {
 	const userToken = getUserToken(ctx);
 	const callbackState = ctx.query.state;
 	const code = ctx.query.code;
+	const stateFlow = detectOAuthFlowFromState(callbackState);
+	const shouldUseSignInFlow =
+		stateFlow === "signin" || (stateFlow === "unknown" && !userToken);
+	const shouldUseConnectFlow = stateFlow === "connect" || !shouldUseSignInFlow;
+	const stateFlowHint =
+		stateFlow === "signin"
+			? "state-prefix-signin"
+			: stateFlow === "connect"
+				? "state-prefix-connect"
+				: userToken
+					? "legacy-fallback-user-token"
+					: "legacy-fallback-no-user-token";
 
 	const oauth2 = await getOAuth2();
 
@@ -285,10 +304,11 @@ router.get("/dc/cb", async (ctx) => {
 		hasCode: typeof code === "string" && code.length > 0,
 		hasState: typeof callbackState === "string" && callbackState.length > 0,
 		stateLength: typeof callbackState === "string" ? callbackState.length : null,
+		stateFlowHint,
 		requestOrigin: getRequestOriginForLog(ctx),
 	});
 
-	if (!userToken) {
+	if (shouldUseSignInFlow) {
 		if (!code || typeof code !== "string") {
 			logWarn("Discord sign-in callback rejected: code missing", {
 				reason: "invalid session - 2",
@@ -430,7 +450,12 @@ router.get("/dc/cb", async (ctx) => {
 			}
 			await deleteRedisKey(`discord:signin:state:${callbackState}`);
 		}
-	} else {
+	} else if (shouldUseConnectFlow) {
+		if (!userToken) {
+			ctx.throw(400, "invalid session - 6");
+			return;
+		}
+
 		if (!code || typeof code !== "string") {
 			logWarn("Discord connect callback rejected: code missing", {
 				reason: "invalid session - 5",

--- a/packages/backend/src/server/api/service/github.ts
+++ b/packages/backend/src/server/api/service/github.ts
@@ -82,6 +82,13 @@ function parseJsonSafely<T>(value: string): T | null {
 	}
 }
 
+function detectOAuthFlowFromState(state: unknown): "signin" | "connect" | "unknown" {
+	if (typeof state !== "string") return "unknown";
+	if (state.startsWith("signin:")) return "signin";
+	if (state.startsWith("connect:")) return "connect";
+	return "unknown";
+}
+
 // Init router
 const router = new Router();
 
@@ -158,7 +165,7 @@ router.get("/connect/github", async (ctx) => {
 	const params = {
 		redirect_uri: `${config.url}/api/gh/cb`,
 		scope: ["read:user"],
-		state: uuid(),
+		state: `connect:${uuid()}`,
 	};
 
 	await setRedisValue(userToken, JSON.stringify(params), 600);
@@ -183,7 +190,7 @@ router.get("/signin/github", async (ctx) => {
 	}
 
 	const sessid = uuid();
-	const state = uuid();
+	const state = `signin:${uuid()}`;
 
 	const params = {
 		redirect_uri: `${config.url}/api/gh/cb`,
@@ -206,10 +213,14 @@ router.get("/signin/github", async (ctx) => {
 
 router.get("/gh/cb", async (ctx) => {
 	const userToken = getUserToken(ctx);
+	const callbackState = ctx.query.state;
+	const stateFlow = detectOAuthFlowFromState(callbackState);
+	const shouldUseSignInFlow =
+		stateFlow === "signin" || (stateFlow === "unknown" && !userToken);
 
 	const oauth2 = await getOath2();
 
-	if (!userToken) {
+	if (shouldUseSignInFlow) {
 		const code = ctx.query.code;
 
 		if (!code || typeof code !== "string") {
@@ -217,7 +228,6 @@ router.get("/gh/cb", async (ctx) => {
 			return;
 		}
 
-		const callbackState = ctx.query.state;
 		if (!callbackState || typeof callbackState !== "string") {
 			ctx.throw(400, "invalid session");
 			return;
@@ -312,8 +322,12 @@ router.get("/gh/cb", async (ctx) => {
 			await deleteRedisKey(`github:signin:state:${callbackState}`);
 		}
 	} else {
+		if (!userToken) {
+			ctx.throw(400, "invalid session");
+			return;
+		}
+
 		const code = ctx.query.code;
-		const callbackState = ctx.query.state;
 
 		if (!code || typeof code !== "string") {
 			ctx.throw(400, "invalid session");

--- a/packages/backend/src/server/api/service/google.ts
+++ b/packages/backend/src/server/api/service/google.ts
@@ -81,6 +81,13 @@ function parseJsonSafely<T>(value: string): T | null {
 	}
 }
 
+function detectOAuthFlowFromState(state: unknown): "signin" | "connect" | "unknown" {
+	if (typeof state !== "string") return "unknown";
+	if (state.startsWith("signin:")) return "signin";
+	if (state.startsWith("connect:")) return "connect";
+	return "unknown";
+}
+
 const router = new Router();
 const GOOGLE_SCOPE = "openid profile email";
 
@@ -207,7 +214,7 @@ router.get("/connect/google", async (ctx) => {
 	const params = {
 		redirect_uri: getGoogleCallbackUrl(),
 		scope: GOOGLE_SCOPE,
-		state: uuid(),
+		state: `connect:${uuid()}`,
 		response_type: "code",
 	};
 
@@ -238,7 +245,7 @@ router.get("/signin/google", async (ctx) => {
 	}
 
 	const sessid = uuid();
-	const state = uuid();
+	const state = `signin:${uuid()}`;
 
 	const params = {
 		redirect_uri: getGoogleCallbackUrl(),
@@ -267,6 +274,10 @@ router.get("/signin/google", async (ctx) => {
 
 router.get("/go/cb", async (ctx) => {
 	const userToken = getUserToken(ctx);
+	const callbackState = ctx.query.state;
+	const stateFlow = detectOAuthFlowFromState(callbackState);
+	const shouldUseSignInFlow =
+		stateFlow === "signin" || (stateFlow === "unknown" && !userToken);
 	const oauthConfig = await getGoogleOAuthConfig();
 
 	if (!oauthConfig) {
@@ -280,8 +291,7 @@ router.get("/go/cb", async (ctx) => {
 		return;
 	}
 
-	if (!userToken) {
-		const callbackState = ctx.query.state;
+	if (shouldUseSignInFlow) {
 		if (!callbackState || typeof callbackState !== "string") {
 			ctx.throw(400, "invalid session");
 			return;
@@ -367,7 +377,11 @@ router.get("/go/cb", async (ctx) => {
 		return;
 	}
 
-	const callbackState = ctx.query.state;
+	if (!userToken) {
+		ctx.throw(400, "invalid session");
+		return;
+	}
+
 	if (!callbackState || typeof callbackState !== "string") {
 		ctx.throw(400, "invalid session");
 		return;


### PR DESCRIPTION
### Motivation
- Discordで導入済みの `state` プレフィックス（`signin:<uuid>` / `connect:<uuid>`）によるフロー判定を、誤ってsign-inとconnectが入れ替わる問題を他のOAuthにも広げて根本的に防ぐため、GitHub/Googleにも同様の対応を適用しました。 
- sign-in開始時に古い `igi` Cookie が残っているとcallbackで誤判定されるケースを排除し、接続（connect）処理が不正に実行されるのを防止するための追加ガードを入れました。

### Description
- `detectOAuthFlowFromState(state)` を `discord` / `github` / `google` の各サービスに追加し、`signin` / `connect` / `unknown` を判定するロジックを実装しました。 
- `state` の生成を下記形式に統一しました: `signin:<uuid>`（`/signin/*`）および `connect:<uuid>`（`/connect/*`）。 
- コールバック（`/dc/cb`, `/gh/cb`, `/go/cb`）の分岐ロジックを「(1) プレフィックス優先判定 → (2) プレフィックスなしは既存のCookie/Redisベースのフォールバック」という順序に変更しました。 
- `connect` 側に到達した場合で `igi` Cookie に相当する `userToken` が無いリクエストは即時拒否するガードを追加し、Discordではログに `stateFlowHint` を付与して診断しやすくしました。 
- 変更対象ファイル: `packages/backend/src/server/api/service/discord.ts`, `.../github.ts`, `.../google.ts`。

### Testing
- 自動チェックとして `pnpm --filter backend run lint` を実行しようとしましたが、`node_modules` が展開されておらず `rome` コマンドが見つからなかったため `spawn rome ENOENT` エラーで実行できませんでした。 (失敗)
- 変更はローカルで該当ソースファイルに適用・コミット済みであり、CI上では `pnpm install` 後に `pnpm --filter backend run lint` とビルドを実行して問題ないことを確認することを推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968c4b9a0c83269d7e4214fb924a54)