### PR TITLE
Add adaptive queue throttling based on queue and DB load

### DIFF
--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -69,6 +69,14 @@ export type Source = {
 	inboxJobPerSec?: number;
 	deliverJobMaxAttempts?: number;
 	inboxJobMaxAttempts?: number;
+	queueAdaptiveThrottle?: {
+		enabled?: boolean;
+		latencyThresholdMs?: number;
+		baseDelayMs?: number;
+		maxDelayMs?: number;
+		dbSlowQueryThresholdMs?: number;
+		dbPollIntervalMs?: number;
+	};
 
 	syslog: {
 		host: string;

--- a/packages/backend/src/db/postgre.ts
+++ b/packages/backend/src/db/postgre.ts
@@ -82,6 +82,7 @@ import { entities as charts } from "@/services/chart/entities.js";
 import { envOption } from "../env.js";
 import { dbLogger } from "./logger.js";
 import { redisClient } from "./redis.js";
+import { notifyDbSlowQuery } from "@/queue/adaptive-queue-throttle.js";
 
 const sqlLogger = dbLogger.createSubLogger("sql", "gray", false);
 
@@ -102,6 +103,7 @@ class MyCustomLogger implements Logger {
 	}
 
 	public logQuerySlow(time: number, query: string, parameters?: any[]) {
+		notifyDbSlowQuery(time);
 		sqlLogger.warn(this.highlight(query));
 	}
 

--- a/packages/backend/src/queue/adaptive-queue-throttle.ts
+++ b/packages/backend/src/queue/adaptive-queue-throttle.ts
@@ -1,0 +1,101 @@
+import type Bull from "bull";
+import config from "@/config/index.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type Processor<T> = (job: Bull.Job<T>) => Promise<unknown>;
+
+type QueueState = {
+	latencyEma: number;
+	errorEma: number;
+};
+
+type AdaptiveThrottleConfig = {
+	enabled: boolean;
+	latencyThresholdMs: number;
+	baseDelayMs: number;
+	maxDelayMs: number;
+	errorPenalty: number;
+	dbSlowQueryThresholdMs: number;
+	dbSlowCooldownMs: number;
+};
+
+const throttleConfig: AdaptiveThrottleConfig = {
+	enabled: config.queueAdaptiveThrottle?.enabled ?? true,
+	latencyThresholdMs: config.queueAdaptiveThrottle?.latencyThresholdMs ?? 1500,
+	baseDelayMs: config.queueAdaptiveThrottle?.baseDelayMs ?? 250,
+	maxDelayMs: config.queueAdaptiveThrottle?.maxDelayMs ?? 5000,
+	errorPenalty: 2,
+	dbSlowQueryThresholdMs: config.queueAdaptiveThrottle?.dbSlowQueryThresholdMs ?? 1000,
+	dbSlowCooldownMs: config.queueAdaptiveThrottle?.dbPollIntervalMs ?? 10000,
+};
+
+const states = new Map<string, QueueState>();
+let lastDbSlowAt = 0;
+
+const getState = (queueName: string) => {
+	let state = states.get(queueName);
+	if (state == null) {
+		state = {
+			latencyEma: 0,
+			errorEma: 0,
+		};
+		states.set(queueName, state);
+	}
+	return state;
+};
+
+const calcQueueDelayMs = (state: QueueState) => {
+	const latencyPressure =
+		state.latencyEma <= throttleConfig.latencyThresholdMs
+			? 0
+			: (state.latencyEma - throttleConfig.latencyThresholdMs) /
+				throttleConfig.latencyThresholdMs;
+	const pressure = latencyPressure + state.errorEma * throttleConfig.errorPenalty;
+	return Math.min(
+		throttleConfig.maxDelayMs,
+		Math.round(throttleConfig.baseDelayMs * pressure),
+	);
+};
+
+const calcDbDelayMs = () => {
+	if (lastDbSlowAt === 0) return 0;
+	const elapsed = Date.now() - lastDbSlowAt;
+	if (elapsed >= throttleConfig.dbSlowCooldownMs) return 0;
+	const rate = 1 - elapsed / throttleConfig.dbSlowCooldownMs;
+	return Math.round(throttleConfig.maxDelayMs * rate);
+};
+
+export function notifyDbSlowQuery(timeMs: number) {
+	if (!throttleConfig.enabled) return;
+	if (timeMs < throttleConfig.dbSlowQueryThresholdMs) return;
+	lastDbSlowAt = Date.now();
+}
+
+export function adaptiveQueueWrap<T>(queueName: string, processor: Processor<T>): Processor<T> {
+	if (!throttleConfig.enabled) return processor;
+
+	return async (job: Bull.Job<T>) => {
+		const state = getState(queueName);
+		const queueDelay = calcQueueDelayMs(state);
+		const delayMs = Math.min(throttleConfig.maxDelayMs, queueDelay + calcDbDelayMs());
+
+		if (delayMs > 0) await sleep(delayMs);
+
+		const startAt = Date.now();
+		try {
+			const result = await processor(job);
+			const latency = Date.now() - startAt;
+			state.latencyEma =
+				state.latencyEma === 0 ? latency : state.latencyEma * 0.8 + latency * 0.2;
+			state.errorEma = state.errorEma * 0.8;
+			return result;
+		} catch (error) {
+			const latency = Date.now() - startAt;
+			state.latencyEma =
+				state.latencyEma === 0 ? latency : state.latencyEma * 0.8 + latency * 0.2;
+			state.errorEma = state.errorEma * 0.8 + 0.2;
+			throw error;
+		}
+	};
+}

--- a/packages/backend/src/queue/index.ts
+++ b/packages/backend/src/queue/index.ts
@@ -19,6 +19,7 @@ import { endedPollNotification } from "./processors/ended-poll-notification.js";
 import { queueLogger } from "./logger.js";
 import { getJobInfo } from "./get-job-info.js";
 import { clearDelayedRetry, markDelayedRetry } from "./delayed-retry-reason.js";
+import { adaptiveQueueWrap } from "./adaptive-queue-throttle.js";
 import {
 	systemQueue,
 	dbQueue,
@@ -519,14 +520,26 @@ export function webhookDeliver(
 export default function () {
 	if (envOption.onlyServer) return;
 
-	deliverQueue.process(config.deliverJobConcurrency || 128, processDeliver);
-	inboxQueue.process(config.inboxJobConcurrency || 16, processInbox);
+	deliverQueue.process(
+		config.deliverJobConcurrency || 128,
+		adaptiveQueueWrap("deliver", processDeliver),
+	);
+	inboxQueue.process(
+		config.inboxJobConcurrency || 16,
+		adaptiveQueueWrap("inbox", processInbox),
+	);
 	endedPollNotificationQueue.process(endedPollNotification);
-	webhookDeliverQueue.process(64, processWebhookDeliver);
-	noteApDeliverQueue.process(config.deliverJobConcurrency || 128, processNoteApDeliver);
-	processDb(dbQueue);
-	processObjectStorage(objectStorageQueue);
-	processBackground(backgroundQueue);
+	webhookDeliverQueue.process(
+		64,
+		adaptiveQueueWrap("webhookDeliver", processWebhookDeliver),
+	);
+	noteApDeliverQueue.process(
+		config.deliverJobConcurrency || 128,
+		adaptiveQueueWrap("noteApDeliver", processNoteApDeliver),
+	);
+	processDb(dbQueue, adaptiveQueueWrap);
+	processObjectStorage(objectStorageQueue, adaptiveQueueWrap);
+	processBackground(backgroundQueue, adaptiveQueueWrap);
 
 	systemQueue.add(
 		"tickCharts",
@@ -592,25 +605,25 @@ export default function () {
 		},
 	);
 
-        systemQueue.add(
-                "cleanAntennaNotes",
-                {},
-                {
-                        repeat: { cron: "0 15 * * *" },
-                        jobId: "clean-antennanotes",
-                },
-        );
+	systemQueue.add(
+		"cleanAntennaNotes",
+		{},
+		{
+			repeat: { cron: "0 15 * * *" },
+			jobId: "clean-antennanotes",
+		},
+	);
 
-        systemQueue.add(
-                "checkSuspendedInstances",
-                {},
-                {
-                        repeat: { cron: "0 4 * * *" },
-                        jobId: "check-suspended-instances",
-                },
-        );
+	systemQueue.add(
+		"checkSuspendedInstances",
+		{},
+		{
+			repeat: { cron: "0 4 * * *" },
+			jobId: "check-suspended-instances",
+		},
+	);
 
-        processSystemQueue(systemQueue);
+	processSystemQueue(systemQueue, adaptiveQueueWrap);
 }
 
 export function destroy() {

--- a/packages/backend/src/queue/processors/background/index.ts
+++ b/packages/backend/src/queue/processors/background/index.ts
@@ -1,12 +1,21 @@
 import type Bull from "bull";
 import indexAllNotes from "./index-all-notes.js";
 
+type QueueProcessorWrapper = <T>(
+	queueName: string,
+	processor: Bull.ProcessPromiseFunction<T>,
+) => Bull.ProcessPromiseFunction<T>;
+
 const jobs = {
 	indexAllNotes,
 } as Record<string, Bull.ProcessCallbackFunction<Record<string, unknown>>>;
 
-export default function (q: Bull.Queue) {
+export default function (
+	q: Bull.Queue,
+	wrapProcessor?: QueueProcessorWrapper,
+) {
 	for (const [k, v] of Object.entries(jobs)) {
-		q.process(k, 16, v);
+		const processor = wrapProcessor ? wrapProcessor("background", v as Bull.ProcessPromiseFunction<Record<string, unknown>>) : v;
+		q.process(k, 16, processor);
 	}
 }

--- a/packages/backend/src/queue/processors/db/index.ts
+++ b/packages/backend/src/queue/processors/db/index.ts
@@ -15,6 +15,11 @@ import { importPosts } from "./import-posts.js";
 import { importBlocking } from "./import-blocking.js";
 import { importCustomEmojis } from "./import-custom-emojis.js";
 
+type QueueProcessorWrapper = <T>(
+	queueName: string,
+	processor: Bull.ProcessPromiseFunction<T>,
+) => Bull.ProcessPromiseFunction<T>;
+
 const jobs = {
 	deleteDriveFiles,
 	exportCustomEmojis,
@@ -36,8 +41,12 @@ const jobs = {
 	| Bull.ProcessPromiseFunction<DbJobData>
 >;
 
-export default function (dbQueue: Bull.Queue<DbJobData>) {
+export default function (
+	dbQueue: Bull.Queue<DbJobData>,
+	wrapProcessor?: QueueProcessorWrapper,
+) {
 	for (const [k, v] of Object.entries(jobs)) {
-		dbQueue.process(k, v);
+		const processor = wrapProcessor ? wrapProcessor("db", v as Bull.ProcessPromiseFunction<DbJobData>) : v;
+		dbQueue.process(k, processor);
 	}
 }

--- a/packages/backend/src/queue/processors/object-storage/index.ts
+++ b/packages/backend/src/queue/processors/object-storage/index.ts
@@ -3,6 +3,11 @@ import type { ObjectStorageJobData } from "@/queue/types.js";
 import deleteFile from "./delete-file.js";
 import cleanRemoteFiles from "./clean-remote-files.js";
 
+type QueueProcessorWrapper = <T>(
+	queueName: string,
+	processor: Bull.ProcessPromiseFunction<T>,
+) => Bull.ProcessPromiseFunction<T>;
+
 const jobs = {
 	deleteFile,
 	cleanRemoteFiles,
@@ -12,8 +17,12 @@ const jobs = {
 	| Bull.ProcessPromiseFunction<ObjectStorageJobData>
 >;
 
-export default function (q: Bull.Queue) {
+export default function (
+	q: Bull.Queue,
+	wrapProcessor?: QueueProcessorWrapper,
+) {
 	for (const [k, v] of Object.entries(jobs)) {
-		q.process(k, 16, v);
+		const processor = wrapProcessor ? wrapProcessor("objectStorage", v as Bull.ProcessPromiseFunction<ObjectStorageJobData>) : v;
+		q.process(k, 16, processor);
 	}
 }

--- a/packages/backend/src/queue/processors/system/index.ts
+++ b/packages/backend/src/queue/processors/system/index.ts
@@ -9,6 +9,11 @@ import { cleanReactions } from "./clean-reactions.js";
 import { cleanAntennaNotes } from "./clean-antennaNote.js";
 import { checkSuspendedInstances } from "./check-suspended-instances.js";
 
+type QueueProcessorWrapper = <T>(
+	queueName: string,
+	processor: Bull.ProcessPromiseFunction<T>,
+) => Bull.ProcessPromiseFunction<T>;
+
 const jobs = {
 	tickCharts,
 	resyncCharts,
@@ -16,17 +21,21 @@ const jobs = {
 	checkExpiredMutings,
 	clean,
 	cleanEmojis,
-        cleanReactions,
-        cleanAntennaNotes,
-        checkSuspendedInstances,
+	cleanReactions,
+	cleanAntennaNotes,
+	checkSuspendedInstances,
 } as Record<
 	string,
 	| Bull.ProcessCallbackFunction<Record<string, unknown>>
 	| Bull.ProcessPromiseFunction<Record<string, unknown>>
 >;
 
-export default function (dbQueue: Bull.Queue<Record<string, unknown>>) {
+export default function (
+	dbQueue: Bull.Queue<Record<string, unknown>>,
+	wrapProcessor?: QueueProcessorWrapper,
+) {
 	for (const [k, v] of Object.entries(jobs)) {
-		dbQueue.process(k, v);
+		const processor = wrapProcessor ? wrapProcessor("system", v as Bull.ProcessPromiseFunction<Record<string, unknown>>) : v;
+		dbQueue.process(k, processor);
 	}
 }


### PR DESCRIPTION
### Motivation
- APIやDBの応答が遅いときにキュー消化を自動で抑制し、DBや外部APIへの過負荷を和らげるための仕組みを追加するため。

### Description
- 新規に `packages/backend/src/queue/adaptive-queue-throttle.ts` を追加し、各キューごとに処理時間EMAとエラーEMAを算出してジョブ実行前に遅延を挿入する `adaptiveQueueWrap` を実装しました。
- TypeORMログの `logQuerySlow` から `notifyDbSlowQuery` を呼び出すようにして、遅いSQL検出時にキュー全体の遅延を一時付与する連携を追加しました（変更箇所: `packages/backend/src/db/postgre.ts`）。
- 主要キューのプロセッサにラッパーを適用するために `packages/backend/src/queue/index.ts` を更新し、`deliver`/`inbox`/`webhookDeliver`/`noteApDeliver` に加え `db`/`objectStorage`/`background`/`system` のプロセッサ登録をラップ可能にしました（各プロセッサモジュールの署名をオプションの `wrapProcessor` を受け取るよう変更）。
- 設定タイプに `queueAdaptiveThrottle` を追加して閾値や遅延上限、DB遅延検知の閾値などをチューニング可能にしました（`packages/backend/src/config/types.ts`）。
- 副作用: この仕組みはジョブを破棄するのではなく「実行前に待機」を入れる方式のため、負荷は緩和されるがキュー上の滞留時間（エンドツーエンド遅延）が増加する可能性がある点に注意してください。DBが不安定な期間は複数キューが同時に抑制され、復旧後もクールダウン期間分遅延が残ります。

### Testing
- 自動チェックとして `pnpm --filter backend run lint` を実行しましたが、この実行環境では依存関係がインストールされておらず `rome ENOENT` エラーで実行できませんでした（失敗）。
- 変更はローカルで整合性を確認しコミット済みであり（コミット: `cf3945d`）、ビルド・統合テストは依存解決後に実行して確認する必要があります。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988162a3488326ba67e75f3849dc93)