### PR TITLE
fix: MkPostForm のテンプレート構文エラーを修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -34,7 +34,8 @@
 					v-if="!$store.state.hiddenTextCount"
 					class="text-count"
 					:class="{ over: textLength > maxTextLength }"
-					>{{
+					>
+					{{
 						maxTextLength - textLength > 999
 							? textLength
 							: i18n.t("remainingLength", {


### PR DESCRIPTION
### Motivation
- Vue テンプレート内の `<span>` 開始タグの終端 `>` とマスタッシュ開始 `{{` が同一行で繋がっており、Vue コンパイラが `Whitespace was expected.` の構文エラーを出していたため修正しました。 

### Description
- `packages/client/src/components/MkPostForm.vue` の該当箇所で `>{{` を行分割して `>` と `{{` を別行に分離し、テンプレートのタグ境界を正しました（`>{{` → `>` 改行 `{{`）。副作用として表示やロジックへの影響は基本的にありませんが、この環境ではビルド未実行のため他箇所に起因するビルドエラーの有無は未確認です。 

### Testing
- `pnpm --filter client run build` を実行してビルド確認を試みましたが、`vite ENOENT`（`node_modules` 未導入）により実行不可であったため、自動ビルドはこの環境では成功・失敗ともに確認できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a175bf5fc8326b48250db63a50ef7)