### PR TITLE
fix: Swarmボタンの tooltip クォート不正を修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -34,7 +34,8 @@
 					v-if="!$store.state.hiddenTextCount"
 					class="text-count"
 					:class="{ over: textLength > maxTextLength }"
-					>{{
+					>
+					{{
 						maxTextLength - textLength > 999
 							? textLength
 							: i18n.t("remainingLength", {
@@ -361,7 +362,7 @@
 				</button>
 				<button
 					v-if="showSwarmButton"
-					v-tooltip=""Swarm""
+					v-tooltip="'Swarm'"
 					class="_button"
 					@click="openSwarmCheckins"
 				>


### PR DESCRIPTION
### Motivation
- Vue テンプレート内で `v-tooltip=""Swarm""` のように属性のクォートが壊れており、Vue コンパイラが `Whitespace was expected.` エラーを出していたため修正しました。

### Description
- `packages/client/src/components/MkPostForm.vue` の `v-tooltip=""Swarm""` を `v-tooltip="'Swarm'"` に置換してテンプレート構文を正しました。ツールチップ文字列のクォート方法を修正するのみで、投稿処理や状態管理等のロジック変更は行っておらず、UI ロジックへの影響は想定していません。

### Testing
- `pnpm --filter client run build` を試行しましたが、`vite ENOENT`（`node_modules` 未導入）により実行不可で、ビルド確認は現環境では完了できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a175bf5fc8326b48250db63a50ef7)