### PR TITLE
fix: 投稿フォーム周辺のtooltip初期化時クラッシュを防止

### DIFF
--- a/packages/client/src/directives/tooltip.ts
+++ b/packages/client/src/directives/tooltip.ts
@@ -29,6 +29,8 @@ function isElementHidden(el: HTMLElement): boolean {
 
 export default {
 	mounted(el: HTMLElement, binding, vn) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const delay = binding.modifiers.noDelay ? 0 : 100;
 
 		const self = ((el as any)._tooltipDirective_ = {} as any);
@@ -146,12 +148,18 @@ export default {
 	},
 
 	updated(el, binding) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const self = el._tooltipDirective_;
+		if (!self) return;
 		self.text = binding.value as string;
 	},
 
 	unmounted(el, binding, vn) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const self = el._tooltipDirective_;
+		if (!self) return;
 		window.clearInterval(self.checkTimer);
 		if (self.close) {
 			// Check if self.close is defined


### PR DESCRIPTION
### Motivation
- 2/22 に入った `MkPostForm.vue` 周辺の変更で投稿フォームに付与される `v-tooltip` ディレクティブがライフサイクルの競合で非 `HTMLElement` や未初期化の内部状態に対して `addEventListener` 等を呼び出し、`TypeError: Cannot read properties of undefined (reading 'addEventListener')` を誘発する可能性があったため対策する。 

### Description
- `packages/client/src/directives/tooltip.ts` にて `mounted` / `updated` / `unmounted` の各ハンドラ開始時に `el instanceof HTMLElement` のチェックを追加し、期待する要素でない場合は早期 return するようにした。 
- `updated` と `unmounted` では内部状態 `_tooltipDirective_`（`self`）の存在確認も追加して未初期化参照を回避している。 
- 副作用として、誤ったノードに `v-tooltip` が付与された場合に例外を出さず無視する挙動になるため、開発時の異常検知はやや弱まる可能性がある。 

### Testing
- ビルド実行として `pnpm --filter client run build` を試行したが、依存未インストール環境のため実行不可（`vite` が見つからず失敗）。 
- 依存導入に `pnpm install` を実行したが、`pnpm-lock.yaml` の破損警告と SSH 経由の GitHub 依存取得失敗により完了せず（ネットワーク/lockfile 問題で失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1973ec4c83269ac1cfce6552913b)