### PR TITLE
fix: get-size / tooltip ディレクティブのライフサイクルガード追加でクラッシュ回避

### DIFF
--- a/packages/client/src/directives/get-size.ts
+++ b/packages/client/src/directives/get-size.ts
@@ -9,12 +9,17 @@ const mountings = new Map<
 	}
 >();
 
+function isResizeHandler(value: unknown): value is (w: number, h: number) => void {
+	return typeof value === "function";
+}
+
 function calc(src: Element) {
 	const info = mountings.get(src);
 	const height = src.clientHeight;
 	const width = src.clientWidth;
 
 	if (!info) return;
+	if (!isResizeHandler(info.fn)) return;
 
 	// アクティベート前などでsrcが描画されていない場合
 	if (!height) {
@@ -37,6 +42,8 @@ function calc(src: Element) {
 
 export default {
 	mounted(src, binding, vn) {
+		if (!isResizeHandler(binding.value)) return;
+
 		const resize = new ResizeObserver((entries, observer) => {
 			calc(src);
 		});
@@ -46,8 +53,19 @@ export default {
 		calc(src);
 	},
 
+	updated(src, binding, vn) {
+		const info = mountings.get(src);
+		if (!info) return;
+		if (!isResizeHandler(binding.value)) return;
+
+		mountings.set(src, { ...info, fn: binding.value });
+		calc(src);
+	},
+
 	unmounted(src, binding, vn) {
-		binding.value(0, 0);
+		if (isResizeHandler(binding.value)) {
+			binding.value(0, 0);
+		}
 		const info = mountings.get(src);
 		if (!info) return;
 		info.resize.disconnect();

--- a/packages/client/src/directives/tooltip.ts
+++ b/packages/client/src/directives/tooltip.ts
@@ -29,6 +29,8 @@ function isElementHidden(el: HTMLElement): boolean {
 
 export default {
 	mounted(el: HTMLElement, binding, vn) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const delay = binding.modifiers.noDelay ? 0 : 100;
 
 		const self = ((el as any)._tooltipDirective_ = {} as any);
@@ -146,12 +148,18 @@ export default {
 	},
 
 	updated(el, binding) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const self = el._tooltipDirective_;
+		if (!self) return;
 		self.text = binding.value as string;
 	},
 
 	unmounted(el, binding, vn) {
+		if (!(el instanceof HTMLElement)) return;
+
 		const self = el._tooltipDirective_;
+		if (!self) return;
 		window.clearInterval(self.checkTimer);
 		if (self.close) {
 			// Check if self.close is defined


### PR DESCRIPTION
### Motivation
- ディレクティブのライフサイクル競合で想定外の値（非HTMLElement / 非関数）が入り、`this.fn is not a function` や `addEventListener` 呼び出しでランタイム例外が発生する問題を防止するため。 
- 指定ミスやレンダリングタイミングのずれによるクラッシュを抑え、アプリの耐障害性を高めることを目的とします。

### Description
- `packages/client/src/directives/get-size.ts` に `isResizeHandler` 型ガードを追加し、`binding.value` が関数でない場合は早期 `return` して無視するようにした。`calc` 実行時にも `info.fn` が関数であることを確認してから呼び出すようにした。`updated` ハンドラを追加して、関数が渡された場合のみ `fn` を差し替えるようにした。`unmounted` の `binding.value(0, 0)` 呼び出しも関数判定付きに変更した。
- `packages/client/src/directives/tooltip.ts` に `el instanceof HTMLElement` チェックを `mounted` / `updated` / `unmounted` のそれぞれの冒頭に追加し、期待する要素でない場合は早期に処理を中断するようにした。加えて内部状態 `_tooltipDirective_`（`self`）の存在確認を追加して、未初期化参照や未定義の関数呼び出しを回避するようにした。
- 想定される副作用として、誤った引数やノードが渡された場合に従来のように例外で即時に検出される代わりに、無視して進行する挙動になるため、開発時の異常顕在化がやや弱まる可能性があることを明記した。

### Testing
- `pnpm --filter client run build` を実行してビルド検証を試みたが、`node_modules` 未導入により `vite` が見つからずビルドは失敗したため（`spawn vite ENOENT`）、ビルドベースの自動検証は未実行のままです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1973ec4c83269ac1cfce6552913b)