### PR TITLE
fix(client): correct broken span closing tag in MkPostForm.vue

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -41,8 +41,8 @@
 							: i18n.t("remainingLength", {
 									n: maxTextLength - textLength,
 							  })
-					}}</span
-				>
+					}}
+				</span>
 				<span v-if="localOnly && isChannel" class="local-only"
 					><i class="ph-hand-fist ph-bold ph-lg"></i
 				></span>


### PR DESCRIPTION
### Motivation
- 2/22 の変更で投稿フォームが描画されない事象が発生していたため、`MkPostForm.vue` のテンプレートを重点確認して DOM 構造を正しく復元するために修正しました。 

### Description
- `packages/client/src/components/MkPostForm.vue` のテキストカウント表示部分で分割されていた閉じタグを `}}</span` + `>` から正しい `}}` + `</span>` に修正し、テンプレートのパース不整合を解消しました（コミット済み）。

### Testing
- `git blame` で該当行が 2/22 の変更由来であることを確認済み（成功）。
- `pnpm --filter client run build` はローカルで `vite` が見つからず失敗し（失敗）、`pnpm install` はリポジトリの `git+ssh://` 依存取得で SSH 接続不可のため失敗しました（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1f31868083269617a410d87ab729)