### PR TITLE
fix(client): 投稿フォーム表示阻害の原因を修正

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -415,14 +415,14 @@
 
 <script lang="ts" setup>
 import {
-        unref,
-        inject,
-        watch,
-        nextTick,
-        onMounted,
-        onUnmounted,
-        defineAsyncComponent,
-        computed,
+	unref,
+	inject,
+	watch,
+	nextTick,
+	onMounted,
+	onUnmounted,
+	defineAsyncComponent,
+	computed,
 } from "vue";
 import * as mfm from "mfm-js";
 import * as misskey from "calckey-js";
@@ -465,7 +465,6 @@ import {
 	evaluateUploadWaitState,
 	sleepMs,
 } from "@/components/MkPostForm/uploadWaitState";
-import { id } from "date-fns/locale";
 
 const modal = inject("modal");
 
@@ -512,8 +511,10 @@ const isNowPlayingSupported =
 
 const nowPlayingMediaInfo = $computed(() => {
 	if (!isNowPlayingSupported) return null;
+	const mediaSession = navigator.mediaSession;
+	if (!mediaSession) return null;
 
-	const metadata = navigator.mediaSession.metadata;
+	const metadata = mediaSession.metadata;
 	if (!metadata) return null;
 
 	const mediaInfo = [metadata.title, metadata.artist, metadata.album]


### PR DESCRIPTION
### Motivation
- 2/22 の変更（Swarm / NowPlaying 周辺）で `MkPostForm.vue` のレンダリング時に実行時例外が起き、投稿フォームが表示されない事象が発生する可能性があったため重点調査して修正しました。
- 開発環境や一部ブラウザで `navigator.mediaSession.metadata` への参照が未定義になるケースを防ぎ、投稿フォームの描画安定性を高める目的です。

### Description
- `packages/client/src/components/MkPostForm.vue` にて `navigator.mediaSession` を一時変数 `mediaSession` に取り出し `null` チェックを行ってから `metadata` にアクセスするよう変更しました（`mediaSession` の存在チェックを追加）。
- 未使用だった `import { id } from "date-fns/locale";` を削除してノイズを除去しました。
- import ブロックのインデントを既存スタイルに合わせて整えました（コード整形・可読性改善）。
- 想定副作用としては、`mediaSession` が利用不可な環境では NowPlaying 情報が安全に `null` 扱いとなり、NowPlaying ボタンの表示条件が「利用不可側」に倒れるため NowPlaying 機能関連ボタンが非表示／無効化される可能性がありますが、投稿フォーム本体の挙動には影響しない想定です。

### Testing
- 対象ファイル差分と履歴を `git diff` / `git show` で確認して該当行の修正を検証しました（成功）。
- `pnpm --filter client run build` を実行しましたが `node_modules` 未生成のため `vite` 実行エラーで失敗しました（`spawn vite ENOENT`）。
- `pnpm install` と `pnpm --filter client install` はロックファイル警告と `git+ssh` 形式の依存取得でネットワーク制約により失敗しました（`ssh: connect to host github.com port 22: Network is unreachable` 等）。
- 上記の環境制約下でもファイル単体の静的差分確認と実行時クラッシュ要因の潰し込みは行い、修正をコミットしました（`git commit` 実行済み）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1f31868083269617a410d87ab729)