### PR TITLE
投稿フォーム表示時のクラッシュを errorlog に記録するよう改善

### DIFF
--- a/packages/client/src/os.ts
+++ b/packages/client/src/os.ts
@@ -963,13 +963,38 @@ export function post(props: Record<string, any> = {}) {
 				resolve();
 				dispose();
 			},
-		}).then((res) => {
-			dispose = res.dispose;
-		});
+		})
+			.then((res) => {
+				dispose = res.dispose;
+			})
+			.catch(async (error) => {
+				const postFormError = error instanceof Error ? error : new Error(String(error));
+				await appendErrorLog(
+					`PostFormDisplayError: ${JSON.stringify({
+						message: postFormError.message,
+						stack: postFormError.stack,
+						props,
+					})}`,
+				);
+				reject(error);
+			});
 	});
 }
 
 export const deckGlobalEvents = new EventEmitter();
+
+async function appendErrorLog(message: string) {
+	const currentDate = new Date();
+	const formattedDate = `${currentDate.toLocaleDateString()} ${currentDate.toLocaleTimeString()}`;
+	let currentLogs = (await get("errorLog")) || [];
+	currentLogs.push(`${formattedDate} - ${message}`);
+
+	if (currentLogs.length > 50) {
+		currentLogs = currentLogs.slice(-50);
+	}
+
+	await set("errorLog", currentLogs);
+}
 
 async function errortoast(res, body, endpoint, parameter) {
 	const message = 
@@ -983,11 +1008,8 @@ async function errortoast(res, body, endpoint, parameter) {
 		toast(`${[res.status, message].join(" ")}`);
 	}
 
-	const currentDate = new Date();
-	const formattedDate = `${currentDate.toLocaleDateString()} ${currentDate.toLocaleTimeString()}`;
-
 	// エラーログのテキストを生成
-	const logtext = `${formattedDate} - ApiError: ${
+	const logtext = `ApiError: ${
 		res.status
 	} - ${JSON.stringify({
 		...body,
@@ -995,14 +1017,7 @@ async function errortoast(res, body, endpoint, parameter) {
 		parameter: Object.keys(parameter).length ? parameter : undefined,
 	})}`;
 
-	let currentLogs = (await get("errorLog")) || [];
-	currentLogs.push(logtext);
-
-	if (currentLogs.length > 50) {
-		currentLogs = currentLogs.slice(-50);
-	}
-
-	await set("errorLog", currentLogs);
+	await appendErrorLog(logtext);
 }
 
 /*


### PR DESCRIPTION
### Motivation
- 投稿フォーム表示中に発生するクラッシュをアプリ内の `errorlog` に収集し、後から原因追跡できるようにするため。 

### Description
- `packages/client/src/os.ts` に `appendErrorLog(message: string)` を追加し、日時付与・最大50件保持のローテーションで `errorLog` に追記する共通処理を実装しました。 
- `post(props)` の `popup(...)` 呼び出しに `.catch(...)` を追加し、失敗時に `PostFormDisplayError`（`message` / `stack` / `props`）を `appendErrorLog` 経由で保存した上で元のエラーを `reject` するようにしました。 
- 既存の API エラー記録処理（`errortoast`）を `appendErrorLog` に切り替え、ログ保存方式を統一しました。 

### Testing
- クライアントの静的チェックコマンド `pnpm --filter client run lint` を実行しましたが、依存が未インストールの環境（`node_modules` 不在、`rome` が見つからない）のため実行できず失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a21a9d02c832683feeba876467e3d)