### PR TITLE
管理画面からSwarm連携を有効化・設定できるように変更

### DIFF
--- a/packages/backend/migration/1737000000000-add-swarm-integration.js
+++ b/packages/backend/migration/1737000000000-add-swarm-integration.js
@@ -1,0 +1,21 @@
+export class addSwarmIntegration1737000000000 {
+	name = "addSwarmIntegration1737000000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "enableSwarmIntegration" boolean NOT NULL DEFAULT false`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "swarmClientId" character varying(128)`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "swarmClientSecret" character varying(128)`,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "swarmClientSecret"`);
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "swarmClientId"`);
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "enableSwarmIntegration"`);
+	}
+}

--- a/packages/backend/src/models/entities/meta.ts
+++ b/packages/backend/src/models/entities/meta.ts
@@ -397,6 +397,23 @@ export class Meta {
 	})
 	public googleClientSecret: string | null;
 
+	@Column('boolean', {
+		default: false,
+	})
+	public enableSwarmIntegration: boolean;
+
+	@Column('varchar', {
+		length: 128,
+		nullable: true,
+	})
+	public swarmClientId: string | null;
+
+	@Column('varchar', {
+		length: 128,
+		nullable: true,
+	})
+	public swarmClientSecret: string | null;
+
 	@Column('varchar', {
 		length: 128,
 		nullable: true,

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -189,6 +189,11 @@ export const meta = {
 				optional: false,
 				nullable: false,
 			},
+			enableSwarmIntegration: {
+				type: "boolean",
+				optional: false,
+				nullable: false,
+			},
 			enableServiceWorker: {
 				type: "boolean",
 				optional: false,
@@ -370,6 +375,16 @@ export const meta = {
 				optional: true,
 				nullable: true,
 			},
+			swarmClientId: {
+				type: "string",
+				optional: true,
+				nullable: true,
+			},
+			swarmClientSecret: {
+				type: "string",
+				optional: true,
+				nullable: true,
+			},
 			summaryProxy: {
 				type: "string",
 				optional: true,
@@ -537,6 +552,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		enableGithubIntegration: instance.enableGithubIntegration,
 		enableDiscordIntegration: instance.enableDiscordIntegration,
 		enableGoogleIntegration: instance.enableGoogleIntegration,
+		enableSwarmIntegration: instance.enableSwarmIntegration,
 		enableServiceWorker: instance.enableServiceWorker,
 		translatorAvailable:
 			instance.deeplAuthKey != null || instance.libreTranslateApiUrl != null,
@@ -571,6 +587,8 @@ export default define(meta, paramDef, async (ps, me) => {
 		discordClientSecret: instance.discordClientSecret,
 		googleClientId: instance.googleClientId,
 		googleClientSecret: instance.googleClientSecret,
+		swarmClientId: instance.swarmClientId,
+		swarmClientSecret: instance.swarmClientSecret,
 		summalyProxy: instance.summalyProxy,
 		email: instance.email,
 		smtpSecure: instance.smtpSecure,

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -146,6 +146,9 @@ export const paramDef = {
 		enableGoogleIntegration: { type: "boolean" },
 		googleClientId: { type: "string", nullable: true },
 		googleClientSecret: { type: "string", nullable: true },
+		enableSwarmIntegration: { type: "boolean" },
+		swarmClientId: { type: "string", nullable: true },
+		swarmClientSecret: { type: "string", nullable: true },
 		enableEmail: { type: "boolean" },
 		email: { type: "string", nullable: true },
 		smtpSecure: { type: "boolean" },
@@ -429,6 +432,18 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	if (ps.googleClientSecret !== undefined) {
 		set.googleClientSecret = ps.googleClientSecret;
+	}
+
+	if (ps.enableSwarmIntegration !== undefined) {
+		set.enableSwarmIntegration = ps.enableSwarmIntegration;
+	}
+
+	if (ps.swarmClientId !== undefined) {
+		set.swarmClientId = ps.swarmClientId;
+	}
+
+	if (ps.swarmClientSecret !== undefined) {
+		set.swarmClientSecret = ps.swarmClientSecret;
 	}
 
 	if (ps.enableEmail !== undefined) {

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -287,6 +287,11 @@ export const meta = {
 				optional: false,
 				nullable: false,
 			},
+			enableSwarmIntegration: {
+				type: "boolean",
+				optional: false,
+				nullable: false,
+			},
 			enableServiceWorker: {
 				type: "boolean",
 				optional: false,
@@ -518,6 +523,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		enableGithubIntegration: instance.enableGithubIntegration,
 		enableDiscordIntegration: instance.enableDiscordIntegration,
 		enableGoogleIntegration: instance.enableGoogleIntegration,
+		enableSwarmIntegration: instance.enableSwarmIntegration,
 
 		enableServiceWorker: instance.enableServiceWorker,
 
@@ -564,6 +570,7 @@ export default define(meta, paramDef, async (ps, me) => {
 			github: instance.enableGithubIntegration,
 			discord: instance.enableDiscordIntegration,
 			google: instance.enableGoogleIntegration,
+			swarm: instance.enableSwarmIntegration,
 			serviceWorker: instance.enableServiceWorker,
 			miauth: true,
 		};

--- a/packages/backend/src/server/api/service/swarm.ts
+++ b/packages/backend/src/server/api/service/swarm.ts
@@ -4,6 +4,7 @@ import { OAuth2 } from "oauth";
 import { v4 as uuid } from "uuid";
 import { IsNull } from "typeorm";
 import config from "@/config/index.js";
+import { fetchMeta } from "@/misc/fetch-meta.js";
 import { publishMainStream } from "@/services/stream.js";
 import { Users, UserProfiles } from "@/models/index.js";
 import { redisClient } from "../../../db/redis.js";
@@ -87,13 +88,19 @@ function detectOAuthFlowFromState(state: unknown): "signin" | "connect" | "unkno
 
 const router = new Router();
 
-function getOAuth2() {
-	const clientId = process.env.SWARM_CLIENT_ID;
-	const clientSecret = process.env.SWARM_CLIENT_SECRET;
-	if (!clientId || !clientSecret) return null;
+async function getOAuth2() {
+	const meta = await fetchMeta(true);
+	if (
+		!meta.enableSwarmIntegration ||
+		!meta.swarmClientId ||
+		!meta.swarmClientSecret
+	) {
+		return null;
+	}
+
 	return new OAuth2(
-		clientId,
-		clientSecret,
+		meta.swarmClientId,
+		meta.swarmClientSecret,
 		"https://foursquare.com/",
 		"oauth2/authenticate",
 		"oauth2/access_token",
@@ -128,7 +135,7 @@ router.get("/connect/swarm", async (ctx) => {
 		return;
 	}
 
-	const oauth2 = getOAuth2();
+	const oauth2 = await getOAuth2();
 	if (!oauth2) {
 		ctx.throw(503, "swarm oauth is not configured");
 		return;
@@ -171,7 +178,7 @@ router.get("/swarm/cb", async (ctx) => {
 		return;
 	}
 
-	const oauth2 = getOAuth2();
+	const oauth2 = await getOAuth2();
 	if (!oauth2) {
 		ctx.throw(503, "swarm oauth is not configured");
 		return;

--- a/packages/calckey-js/src/entities.ts
+++ b/packages/calckey-js/src/entities.ts
@@ -317,6 +317,7 @@ export type LiteInstanceMetadata = {
 	enableGithubIntegration: boolean;
 	enableDiscordIntegration: boolean;
 	enableGoogleIntegration: boolean;
+	enableSwarmIntegration: boolean;
 	enableServiceWorker: boolean;
 	emojiUpdatedAt: DateString | null;
 	emojis: CustomEmoji[];

--- a/packages/client/src/pages/admin/integrations.swarm.vue
+++ b/packages/client/src/pages/admin/integrations.swarm.vue
@@ -1,0 +1,69 @@
+<template>
+	<FormSuspense :p="init">
+		<div class="_formRoot">
+			<FormSwitch v-model="enableSwarmIntegration" class="_formBlock">
+				<template #label>{{ i18n.ts.enable }}</template>
+			</FormSwitch>
+
+			<template v-if="enableSwarmIntegration">
+				<FormInfo class="_formBlock"
+					>Callback URL: {{ `${uri}/api/swarm/cb` }}</FormInfo
+				>
+
+				<FormInput v-model="swarmClientId" class="_formBlock">
+					<template #prefix
+						><i class="ph-key ph-bold ph-lg"></i
+					></template>
+					<template #label>Client ID</template>
+				</FormInput>
+
+				<FormInput v-model="swarmClientSecret" class="_formBlock">
+					<template #prefix
+						><i class="ph-key ph-bold ph-lg"></i
+					></template>
+					<template #label>Client Secret</template>
+				</FormInput>
+			</template>
+
+			<FormButton primary class="_formBlock" @click="save"
+				><i class="ph-floppy-disk-back ph-bold ph-lg"></i>
+				{{ i18n.ts.save }}</FormButton
+			>
+		</div>
+	</FormSuspense>
+</template>
+
+<script lang="ts" setup>
+import {} from "vue";
+import FormSwitch from "@/components/form/switch.vue";
+import FormInput from "@/components/form/input.vue";
+import FormButton from "@/components/MkButton.vue";
+import FormInfo from "@/components/MkInfo.vue";
+import FormSuspense from "@/components/form/suspense.vue";
+import * as os from "@/os";
+import { fetchInstance } from "@/instance";
+import { i18n } from "@/i18n";
+
+let uri: string = $ref("");
+let enableSwarmIntegration: boolean = $ref(false);
+let swarmClientId: string | null = $ref(null);
+let swarmClientSecret: string | null = $ref(null);
+
+async function init() {
+	const meta = await os.api("admin/meta");
+	uri = meta.uri;
+	enableSwarmIntegration = meta.enableSwarmIntegration;
+	swarmClientId = meta.swarmClientId;
+	swarmClientSecret = meta.swarmClientSecret;
+}
+
+function save() {
+	os.apiWithDialog("admin/update-meta", {
+		enableSwarmIntegration,
+		swarmClientId,
+		swarmClientSecret,
+	}).then(() => {
+		fetchInstance();
+	});
+}
+</script>

--- a/packages/client/src/pages/admin/integrations.vue
+++ b/packages/client/src/pages/admin/integrations.vue
@@ -42,6 +42,16 @@
 					}}</template>
 					<XDiscord />
 				</FormFolder>
+				<FormFolder class="_formBlock">
+					<template #icon
+						><i class="ph-map-pin-line ph-bold ph-lg"></i
+					></template>
+					<template #label>Swarm</template>
+					<template #suffix>{{
+						enableSwarmIntegration ? i18n.ts.enabled : i18n.ts.disabled
+					}}</template>
+					<XSwarm />
+				</FormFolder>
 			</FormSuspense>
 		</MkSpacer>
 	</MkStickyContainer>
@@ -52,6 +62,7 @@ import {} from "vue";
 import XGithub from "./integrations.github.vue";
 import XDiscord from "./integrations.discord.vue";
 import XGoogle from "./integrations.google.vue";
+import XSwarm from "./integrations.swarm.vue";
 import FormSuspense from "@/components/form/suspense.vue";
 import FormFolder from "@/components/form/folder.vue";
 import * as os from "@/os";
@@ -62,6 +73,7 @@ let enableTwitterIntegration: boolean = $ref(false);
 let enableGithubIntegration: boolean = $ref(false);
 let enableDiscordIntegration: boolean = $ref(false);
 let enableGoogleIntegration: boolean = $ref(false);
+let enableSwarmIntegration: boolean = $ref(false);
 
 async function init() {
 	const meta = await os.api("admin/meta");
@@ -69,6 +81,7 @@ async function init() {
 	enableGithubIntegration = meta.enableGithubIntegration;
 	enableDiscordIntegration = meta.enableDiscordIntegration;
 	enableGoogleIntegration = meta.enableGoogleIntegration;
+	enableSwarmIntegration = meta.enableSwarmIntegration;
 }
 
 const headerActions = $computed(() => []);

--- a/packages/client/src/pages/settings/integration.vue
+++ b/packages/client/src/pages/settings/integration.vue
@@ -68,7 +68,7 @@
 			}}</MkButton>
 		</FormSection>
 
-		<FormSection>
+		<FormSection v-if="instance.enableSwarmIntegration">
 			<template #label><i class="ph-map-pin-line ph-bold ph-lg"></i> Swarm</template>
 			<p v-if="integrations.swarm?.accessToken">{{ i18n.ts.connectedTo }}: Swarm</p>
 			<p v-else>{{ i18n.ts.notConnected }}</p>


### PR DESCRIPTION
### Motivation
- Swarm連携を他サービス（GitHub/Discord/Google等）と同様に管理画面で有効化・OAuthクレデンシャルを設定できるようにするための変更です。 
- 運用面で環境変数依存ではなくインスタンス設定（DB）で管理したいという要望に対応します。 
- 副作用として既存環境で`SWARM_CLIENT_ID`/`SWARM_CLIENT_SECRET`のみで運用している場合は、管理画面（またはDB）へ同等の設定を移行しないと連携が無効化される点に注意が必要です。  

### Description
- DBスキーマとモデルを拡張し、`Meta`エンティティに `enableSwarmIntegration` / `swarmClientId` / `swarmClientSecret` を追加し、マイグレーション `1737000000000-add-swarm-integration.js` を追加しました。 
- 管理API側に `admin/update-meta` と `admin/meta` のパラメータ・返却項目を追加して、管理画面からSwarm設定を保存／取得できるようにしました（`admin/update-meta` に更新処理を追加）。 
- サービス実装側で環境変数ではなく保存済み設定を参照するようにし、Swarmサービスで `fetchMeta(true)` を利用して `swarmClientId` / `swarmClientSecret` / `enableSwarmIntegration` を読み込むように変更しました（`packages/backend/src/server/api/service/swarm.ts` の OAuth 初期化を同期→非同期化）。 
- クライアント側の管理画面 `integrations.swarm.vue` を他連携と同様のUI（Enable スイッチ + Client ID / Client Secret 入力 + 保存ボタン）に置き換え、ユー設定ページでは `instance.enableSwarmIntegration` による条件表示へ合わせました（型定義 `calckey-js` 側にも `enableSwarmIntegration` を追加）。 

### Testing
- `pnpm --filter backend run lint` を実行しましたが、`rome` が見つからず（`node_modules` 未構築）のため実行失敗しました。 
- Playwright を使って管理画面のスクリーンショット取得を試みましたが、ローカルサーバー未起動で `ERR_EMPTY_RESPONSE` により失敗しました。 
- 変更はローカルでファイル差分として作成・コミット済みで、マイグレーションファイルも追加されています（コミット済み）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2a6afa548326ba015c10231ef628)