### PR TITLE
Fix Swarm OAuth authorization endpoint

### DIFF
--- a/packages/backend/src/server/api/service/swarm.ts
+++ b/packages/backend/src/server/api/service/swarm.ts
@@ -102,7 +102,7 @@ async function getOAuth2() {
 		meta.swarmClientId,
 		meta.swarmClientSecret,
 		"https://foursquare.com/",
-		"oauth2/authenticate",
+		"oauth2/authorize",
 		"oauth2/access_token",
 	);
 }


### PR DESCRIPTION
### Motivation
- `Swarm`（Foursquare）との連携で生成された認可URLがFoursquareの技術的問題ページに遷移してしまうため、認可エンドポイントのパスを正すことでアカウント連携を正常化する。 

### Description
- `packages/backend/src/server/api/service/swarm.ts` の `OAuth2` 初期化で第4引数を `oauth2/authenticate` から `oauth2/authorize` に変更し、認可リクエスト先のみを修正して `redirect_uri`（`/api/swarm/cb`）やトークン交換処理は変更していない; 将来的にFoursquare側で仕様変更があれば再対応が必要となる可能性がある。 

### Testing
- 自動検査として `pnpm --filter backend run lint` を実行したが、環境に `node_modules` がなく `rome` コマンドが見つからず実行できなかったため検証は未完了である。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a31fcfc4c832683f290b0123bf28a)