### PR TITLE
fix: チャンネル固定投稿でピン解除メニューを表示

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -917,6 +917,7 @@ function onContextmenu(ev: MouseEvent): void {
 				isDeleted,
 				currentClipPage,
 				info,
+				pinned: props.pinned,
 			}),
 			ev
 		).then(focus);
@@ -933,6 +934,7 @@ function menu(viaKeyboard = false): void {
 			isDeleted,
 			currentClipPage,
 			info,
+			pinned: props.pinned,
 		}),
 		menuButton.value,
 		{

--- a/packages/client/src/components/MkNoteDetailed.vue
+++ b/packages/client/src/components/MkNoteDetailed.vue
@@ -253,6 +253,7 @@ function onContextmenu(ev: MouseEvent): void {
 				menuButton,
 				isDeleted,
 				info,
+				pinned: props.pinned,
 			}),
 			ev
 		).then(focus);
@@ -268,6 +269,7 @@ function menu(viaKeyboard = false): void {
 			menuButton,
 			isDeleted,
 			info,
+			pinned: props.pinned,
 		}),
 		menuButton.value,
 		{

--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -19,6 +19,7 @@ export function getNoteMenu(props: {
 	isDeleted: Ref<boolean>;
 	currentClipPage?: Ref<misskey.entities.Clip>;
 	info?: Ref<any>;
+	pinned?: boolean;
 }) {
 	const isRenote =
 		props.note.renote != null &&
@@ -32,6 +33,8 @@ export function getNoteMenu(props: {
 			: props.note;
 	const hasTranslatableText =
 		typeof appearNote.text === "string" && appearNote.text.trim().length > 0;
+	const isPinnedNote =
+		($i.pinnedNoteIds || []).includes(appearNote.id) || props.pinned === true;
 
 	function del(): void {
 		os.confirm({
@@ -613,7 +616,7 @@ export function getNoteMenu(props: {
 							},
 				) : undefined,
 				...(appearNote.userId === $i.id
-					? ($i.pinnedNoteIds || []).includes(appearNote.id)
+					? isPinnedNote
 						? [
 								{
 									icon: "ph-caret-double-up ph-bold ph-lg",
@@ -883,7 +886,7 @@ export function getNoteMenu(props: {
 							},
 				),
 				...(appearNote.userId === $i.id
-					? ($i.pinnedNoteIds || []).includes(appearNote.id)
+					? isPinnedNote
 						? [
 								{
 									icon: "ph-caret-double-up ph-bold ph-lg",


### PR DESCRIPTION
### Motivation
- チャンネルで「固定表示」されている投稿を表示しているとき、メニューがユーザーの`$i.pinnedNoteIds`だけを参照していて「ピン解除／上部ピン留め」を表示できない問題を修正するため。

### Description
- `getNoteMenu` に `pinned?: boolean` 引数を追加して、呼び出し側の描画コンテキストから固定状態を受け取るようにしました。
- `getNoteMenu` 内で `isPinnedNote` を `($i.pinnedNoteIds || []).includes(appearNote.id) || props.pinned === true` として判定するように変更しました。
- `MkNote.vue` と `MkNoteDetailed.vue` の `getNoteMenu` 呼び出しに `pinned: props.pinned` を渡すようにしました。
- 副作用として、`props.pinned === true` で描画している他の画面でもメニューに「ピン解除／上部ピン留め」が表示されるようになりますが、メニューの表示条件はもともと投稿の所有者確認（`appearNote.userId === $i.id` 等）と組み合わされるため、権限周りの挙動（API 呼び出し先）は変更していません。

### Testing
- `pnpm --filter client lint` を実行しましたが、`node_modules` 未インストールで `rome` が見つからず失敗しました（実行環境依存の失敗）。
- Playwright を使ってローカルでのレンダリング確認を試みましたが、ローカルサーバーが起動していないため `ERR_EMPTY_RESPONSE` で失敗しました。
- ソース変更はコミット済みです（クライアント側の `get-note-menu.ts`, `MkNote.vue`, `MkNoteDetailed.vue` を更新）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a267c28688326a1dd0346ef47e455)