### PR TITLE
リノート表示時のピン解除メニューが表示されない不具合を修正

### DIFF
--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -267,10 +267,13 @@ export function getNoteMenu(props: {
 	}
 
 	function togglePin(pin: boolean): void {
+		const pinTargetNoteId =
+			props.note.userId === $i?.id ? props.note.id : appearNote.id;
+
 		os.apiWithDialog(
 			pin ? "i/pin" : "i/unpin",
 			{
-				noteId: appearNote.id,
+				noteId: pinTargetNoteId,
 			},
 			undefined,
 		).catch((res) => {
@@ -281,6 +284,18 @@ export function getNoteMenu(props: {
 				});
 			}
 		});
+	}
+
+	function isPinnedByMe(): boolean {
+		const pinnedNoteIds = $i?.pinnedNoteIds || [];
+		return (
+			pinnedNoteIds.includes(props.note.id) ||
+			pinnedNoteIds.includes(appearNote.id)
+		);
+	}
+
+	function canPinByMe(): boolean {
+		return props.note.userId === $i?.id || appearNote.userId === $i?.id;
 	}
 
 	async function clip(): Promise<void> {
@@ -612,8 +627,8 @@ export function getNoteMenu(props: {
 								action: () => toggleThreadMute(true),
 							},
 				) : undefined,
-				...(appearNote.userId === $i.id
-					? ($i.pinnedNoteIds || []).includes(appearNote.id)
+				...(canPinByMe()
+					? isPinnedByMe()
 						? [
 								{
 									icon: "ph-caret-double-up ph-bold ph-lg",
@@ -882,8 +897,8 @@ export function getNoteMenu(props: {
 								action: () => toggleThreadMute(true),
 							},
 				),
-				...(appearNote.userId === $i.id
-					? ($i.pinnedNoteIds || []).includes(appearNote.id)
+				...(canPinByMe()
+					? isPinnedByMe()
 						? [
 								{
 									icon: "ph-caret-double-up ph-bold ph-lg",


### PR DESCRIPTION
### Motivation
- 表示がリノート（引用元ノートを表示）になっている場合でも、実際にピンしている自分のオリジナル投稿を正しい `noteId` で `i/pin` / `i/unpin` できるようにするための修正です。 
- メニュー内のピン状態判定を表示ノートIDだけで判断していたため、解除メニューが出ないケースが発生していました。 
- 副作用としては、メニュー判定で `props.note.id` と `appearNote.id` の両方を参照するため表示判定対象が増えますが、配列参照のみのため実運用上の負荷増は軽微です。 

### Description
- `packages/client/src/scripts/get-note-menu.ts` にて、`togglePin` を修正してピン/アンピン時に送る `noteId` を表示ノート (`appearNote.id`) ではなく、自分の投稿であれば `props.note.id` を優先するようにしました。 
- メニュー表示判定を共通化するために `isPinnedByMe()` と `canPinByMe()` を追加し、`props.note.id` と `appearNote.id` の両方を考慮するように置換しました。 
- これらの判定はノートメニューの両方の分岐に適用し、リノート表示時でも「ピン留め解除」が正しく表示されるように統一しました。 

### Testing
- `pnpm --filter client lint` を実行しましたが、環境に `node_modules`（`rome`）が無いため実行できずエラーになりました。 
- Playwright を使ったローカル確認（スクリーンショット取得）を試みましたが、対象サーバーが起動しておらず `ERR_EMPTY_RESPONSE` で失敗しました。 
- 上記のとおり自動テスト環境が整っていないため、動作確認は開発環境での起動後に実施してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a267c28688326a1dd0346ef47e455)