### PR TITLE
fix(backend): align Swarm OAuth flow with Foursquare authentication docs

### DIFF
--- a/packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts
+++ b/packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts
@@ -71,7 +71,10 @@ export default define(meta, paramDef, async (ps, me) => {
 	}
 
 	const response = await getJson(
-		`https://api.foursquare.com/v2/users/self/checkins?oauth_token=${encodeURIComponent(token)}&v=20240101&limit=${ps.limit}&offset=${ps.offset}`,
+		`https://api.foursquare.com/v2/users/self/checkins?v=20240101&limit=${ps.limit}&offset=${ps.offset}`,
+		"application/json, */*",
+		10000,
+		{ Authorization: `Bearer ${token}` },
 	) as SwarmCheckinResponse;
 
 	const items = response.response?.checkins?.items ?? [];

--- a/packages/backend/src/server/api/service/swarm.ts
+++ b/packages/backend/src/server/api/service/swarm.ts
@@ -102,7 +102,7 @@ async function getOAuth2() {
 		meta.swarmClientId,
 		meta.swarmClientSecret,
 		"https://foursquare.com/",
-		"oauth2/authorize",
+		"oauth2/authenticate",
 		"oauth2/access_token",
 	);
 }
@@ -148,6 +148,7 @@ router.get("/connect/swarm", async (ctx) => {
 	}
 
 	const params = {
+		response_type: "code",
 		redirect_uri: `${config.url}/api/swarm/cb`,
 		state: `connect:${uuid()}`,
 	};


### PR DESCRIPTION
### Motivation
- Foursquare の 3rd-party 認証仕様に合わせて、チェックイン取得時の認証方式とOAuth開始フローの挙動を正しく整合させるため。以前の変更でBearer化は行われたが、認可開始（authorize）まわりが未調整だったため追加修正を行った。

### Description
- チェックイン取得APIの呼び出しから `oauth_token` クエリを削除し、`Authorization: Bearer <token>` ヘッダーでトークンを送るようにした（`packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts`）。
- OAuth ライブラリ初期化時の認可エンドポイントを `oauth2/authorize` から `oauth2/authenticate` に変更した（`packages/backend/src/server/api/service/swarm.ts`）。
- 認可URL生成時に `response_type: "code"` を明示的に追加して Authorization Code フローのパラメータを明確化した（`/connect/swarm` の `params` に追加）。
- 既存のコールバック／state 管理、及びアクセストークン取得（`getOAuthAccessToken`）ロジックは維持しているため、トークン交換のフロー自体は引き続き Authorization Code を利用する。副作用として認可画面の表示や挙動が `authenticate` 側で変わる可能性があることを注記している。

### Testing
- `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行したが、環境に `@types/node` がないため型チェックは失敗した（`TS2688`）。
- 以前の変更時に `curl -I https://foursquare.com/oauth2/*` 相当のエンドポイント確認を行い `200 OK` を確認しているため、外部エンドポイント自体の存在チェックは成功している。
- 実際のエンドツーエンド OAuth 認可（ブラウザ経由での /connect/swarm → Foursquare UI → コールバック受信）についてはこの実行環境では未実行のため、アプリ設定（Client ID/Secret と登録済みリダイレクトURI）が正しいことを前提に動作する想定である。

影響として、Foursquare 側の表示や同意フローの見え方が変わる可能性がある点と、環境依存の型定義不足により静的型チェックが現環境で通っていない点を留意してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b891e2a388326862900f9e7b70a63)