### PR TITLE
Swarm未連携時の表示設定更新をバックエンドで安全にno-op化

### DIFF
--- a/packages/backend/src/server/api/endpoints/i/swarm/update-settings.ts
+++ b/packages/backend/src/server/api/endpoints/i/swarm/update-settings.ts
@@ -18,11 +18,18 @@ export const paramDef = {
 
 export default define(meta, paramDef, async (ps, me) => {
 	const profile = await UserProfiles.findOneByOrFail({ userId: me.id });
-	const swarm = profile.integrations.swarm ?? {};
+	const integrations = profile.integrations ?? {};
+	const swarm = integrations.swarm ?? {};
+
+	if (!swarm.accessToken) {
+		return {
+			showPostFormButton: false,
+		};
+	}
 
 	await UserProfiles.update(me.id, {
 		integrations: {
-			...profile.integrations,
+			...integrations,
 			swarm: {
 				...swarm,
 				showPostFormButton: ps.showPostFormButton,

--- a/packages/backend/src/server/api/service/swarm.ts
+++ b/packages/backend/src/server/api/service/swarm.ts
@@ -124,6 +124,7 @@ router.get("/disconnect/swarm", async (ctx) => {
 
 	profile.integrations.swarm = undefined;
 	await UserProfiles.update(user.id, { integrations: profile.integrations });
+	await Users.invalidateMeDetailedBaseCache(user.id);
 
 	ctx.body = "Swarmの連携を解除しました :v:";
 	publishMainStream(user.id, "meUpdated", await Users.pack(user, user, { detail: true, includeSecrets: true }));
@@ -231,6 +232,7 @@ router.get("/swarm/cb", async (ctx) => {
 			},
 		},
 	});
+	await Users.invalidateMeDetailedBaseCache(user.id);
 
 	publishMainStream(user.id, "meUpdated", await Users.pack(user, user, { detail: true, includeSecrets: true }));
 	ctx.redirect(`${config.url}/settings/integration`);


### PR DESCRIPTION
### Motivation
- フロントでは未連携時に Swarm の投稿フォームボタン表示スイッチを操作不可に戻しつつ、バックエンドは古いクライアント等から `i/swarm/update-settings` が叩かれてもエラーにしないようにして堅牢化するためです。 
- Swarm 接続/切断時に `me` の詳細キャッシュが古いまま表示される問題に対応するため、接続・切断の処理後にキャッシュ無効化を行う意図があります。 
- 副作用として、未連携状態で `i/swarm/update-settings` を呼ぶと変更は保存されず常に `{ showPostFormButton: false }` を返す（no-op）挙動になる点に注意が必要です。

### Description
- `packages/client/src/pages/settings/integration.vue` の `FormSwitch` に `:disabled="!integrations.swarm?.accessToken"` を追加して未連携時はスイッチを無効化しました。 
- `packages/backend/src/server/api/endpoints/i/swarm/update-settings.ts` で `profile.integrations` を防御的に扱い、`swarm.accessToken` が無ければ DB 更新を行わず早期に `showPostFormButton: false` を返すようにしました。 
- `packages/backend/src/server/api/service/swarm.ts` の Swarm 接続コールバックと切断処理の直後に `Users.invalidateMeDetailedBaseCache(user.id)` を呼び出して `me` の詳細キャッシュを明示的に無効化するようにしました。 

### Testing
- `pnpm --filter backend run lint` を実行しましたが、`rome` が見つからず（`node_modules` 未インストール） lint は実行できませんでした。 
- 他の自動テストは実行しておらず、手動の動作確認は行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8c440e788326b656261227a46170)