### PR TITLE
fix: sanitize offset for Swarm recent checkins API call

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -363,7 +363,7 @@
 					v-if="showSwarmButton"
 					v-tooltip="i18n.ts.swarm"
 					class="_button"
-					@click="openSwarmCheckins"
+					@click="() => void openSwarmCheckins()"
 				>
 					<i class="ph-map-pin-line ph-bold ph-lg"></i>
 				</button>
@@ -2543,6 +2543,7 @@ async function uploadSwarmPhoto(photoUrl: string | null): Promise<void> {
 }
 
 async function openSwarmCheckins(offset = 0): Promise<void> {
+	const safeOffset = Number.isInteger(offset) && offset >= 0 ? offset : 0;
 	let result: {
 		items: Array<{
 			id: string;
@@ -2558,7 +2559,7 @@ async function openSwarmCheckins(offset = 0): Promise<void> {
 	try {
 		result = (await os.api("i/swarm/recent-checkins", {
 			limit: 10,
-			offset,
+			offset: safeOffset,
 		})) as {
 			items: Array<{
 				id: string;
@@ -2593,7 +2594,7 @@ async function openSwarmCheckins(offset = 0): Promise<void> {
 		menuItems.push({
 			text: i18n.ts.loadMore,
 			action: () => {
-				void openSwarmCheckins(offset + 10);
+				void openSwarmCheckins(safeOffset + 10);
 			},
 		});
 	}


### PR DESCRIPTION
### Motivation
- `i/swarm/recent-checkins` が `offset` に整数を要求するため、クリックイベントなどでオブジェクトが渡ると `INVALID_PARAM` (400) になっていた問題を防止するために修正しました。

### Description
- `packages/client/src/components/MkPostForm.vue` の Swarm ボタンのクリックハンドラを `@click="() => void openSwarmCheckins()"` に変更して、暗黙的なイベント引数が `offset` として渡らないようにしました。 
- `openSwarmCheckins` 内で `offset` を `safeOffset` として `Number.isInteger(offset) && offset >= 0 ? offset : 0` に正規化し、API 呼び出しと「もっと見る」 (`load more`) の再帰呼び出しで `safeOffset` を使用するようにしました。 
- 影響範囲は `packages/client/src/components/MkPostForm.vue` のみで、UI 表示は変えずに入力値の型安全性を高めています。
- 副作用として、不正な `offset` を与えた呼び出しは 0 に丸められるため、異常値指定が無視されますが API 要求の失敗は防げます。 

### Testing
- `pnpm -C packages/client exec rome check src/components/MkPostForm.vue` を実行しましたが、環境に `rome` が無く `ENOENT` で実行できませんでした。 (静的チェックは実行不可)
- 変更ファイルを `git add` / `git commit` してコミットが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8e9660948326b570a4bf8f506175)