### PR TITLE
Swarmチェックイン写真を本人投稿のみ取得するよう修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts
+++ b/packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts
@@ -10,21 +10,26 @@ type SwarmCheckinResponse = {
 				id: string;
 				createdAt?: number;
 				shout?: string;
+				url?: string;
 				canonicalUrl?: string;
 				checkinShortUrl?: string;
+				checkinUrl?: string;
+				photos?: {
+					items?: Array<{
+						prefix?: string;
+						suffix?: string;
+					}>;
+				};
 				venue?: {
 					name?: string;
+					localizedName?: string;
+					nameJa?: string;
+					name_ja?: string;
+					url?: string;
+					canonicalUrl?: string;
 					location?: {
 						city?: string;
 						state?: string;
-					};
-					photos?: {
-						groups?: Array<{
-							items?: Array<{
-								prefix?: string;
-								suffix?: string;
-							}>;
-						}>;
 					};
 				};
 			}>;
@@ -54,10 +59,28 @@ function compactLocation(city?: string, state?: string): string {
 type CheckinItem = NonNullable<NonNullable<NonNullable<SwarmCheckinResponse["response"]>["checkins"]>["items"]>[number];
 
 function getVenuePhotoUrl(checkin: CheckinItem): string | null {
-	const firstGroup = checkin.venue?.photos?.groups?.find((group) => (group.items?.length ?? 0) > 0);
-	const firstPhoto = firstGroup?.items?.[0];
-	if (!firstPhoto?.prefix || !firstPhoto?.suffix) return null;
-	return `${firstPhoto.prefix}original${firstPhoto.suffix}`;
+	const firstCheckinPhoto = checkin.photos?.items?.[0];
+	if (!firstCheckinPhoto?.prefix || !firstCheckinPhoto?.suffix) return null;
+	return `${firstCheckinPhoto.prefix}original${firstCheckinPhoto.suffix}`;
+}
+
+function getPreferredVenueName(checkin: CheckinItem): string {
+	const venue = checkin.venue;
+	if (!venue) return "";
+
+	return venue.name_ja ?? venue.nameJa ?? venue.localizedName ?? venue.name ?? "";
+}
+
+function getCheckinUrl(checkin: CheckinItem): string {
+	return (
+		checkin.checkinShortUrl ??
+		checkin.checkinUrl ??
+		checkin.url ??
+		checkin.canonicalUrl ??
+		checkin.venue?.url ??
+		checkin.venue?.canonicalUrl ??
+		""
+	);
 }
 
 export default define(meta, paramDef, async (ps, me) => {
@@ -71,7 +94,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	}
 
 	const response = await getJson(
-		`https://api.foursquare.com/v2/users/self/checkins?v=20240101&limit=${ps.limit}&offset=${ps.offset}`,
+		`https://api.foursquare.com/v2/users/self/checkins?v=20240101&locale=ja&limit=${ps.limit}&offset=${ps.offset}`,
 		"application/json, */*",
 		10000,
 		{ Authorization: `Bearer ${token}` },
@@ -85,9 +108,9 @@ export default define(meta, paramDef, async (ps, me) => {
 			id: item.id,
 			createdAt: item.createdAt ?? null,
 			comment: item.shout ?? "",
-			venueName: item.venue?.name ?? "",
+			venueName: getPreferredVenueName(item),
 			location: compactLocation(item.venue?.location?.city, item.venue?.location?.state),
-			url: item.checkinShortUrl ?? item.canonicalUrl ?? "",
+			url: getCheckinUrl(item),
 			photoUrl: getVenuePhotoUrl(item),
 		})),
 		hasMore: ps.offset + items.length < count,


### PR DESCRIPTION
### Motivation
- チェックインに紐づく写真として `venue` 側の写真をフォールバックで使うと、チェックイン者本人が投稿していない画像が添付されてしまうため、それを防ぐ目的で修正しています。 
- 以前の変更で導入した日本語ロケール優先や URL フォールバックの扱いは維持する意図です。 

### Description
- レスポンス型定義から `venue.photos` を削除し、型と実装の整合性を取っています（ファイル: `packages/backend/src/server/api/endpoints/i/swarm/recent-checkins.ts`）。
- `getVenuePhotoUrl` をチェックイン本体の `checkin.photos.items` の先頭のみ参照するように変更し、`venue.photos` へのフォールバック処理を完全に除去しました。 
- 会場名取得の日本語優先ロジック（`name_ja` → `nameJa` → `localizedName` → `name`）と URL のフォールバック順は維持しています。 
- 副作用として、チェックイン本体に写真が存在しない場合は `photoUrl` が `null` になり、以前のように会場写真で補完されなくなる点があります。 

### Testing
- `pnpm -C packages/backend lint` を実行しましたが、実行環境で `rome` が見つからず失敗しました（`node_modules` 未展開の環境要因）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b914f883483268a5ec959c07c7ed3)