### PR TITLE
Hide location from recent check-in selection labels

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -2585,7 +2585,7 @@ async function openSwarmCheckins(offset = 0): Promise<void> {
 	}
 
 	const menuItems = result.items.map((item) => ({
-		text: `${item.venueName}${item.location ? ` (${item.location})` : ""}`,
+		text: item.venueName,
 		action: async () => {
 			const insertText = buildSwarmText(item);
 			text = text.trim().length === 0 ? insertText : `${text}\n\n${insertText}`;


### PR DESCRIPTION
### Motivation
- チェックイン履歴選択画面で `location` を表示せず名前（`venueName`）のみを見せることで選択UIを簡潔にするための変更であり、同名の店舗が複数ある場合に識別しにくくなる可能性という副作用が考えられます。 

### Description
- `packages/client/src/components/MkPostForm.vue` の `openSwarmCheckins` 内でメニュー項目のラベルを ```${item.venueName}${item.location ? ` (${item.location})` : ""}``` から ``item.venueName`` に変更しました（選択時に表示されるテキストのみを変更、投稿挿入ロジックはそのままです）。

### Testing
- 自動テストとして `pnpm -C packages/client lint` を実行しましたが、`rome` が見つからず `node_modules` 未インストールのため `ENOENT` エラーで失敗し、Playwright を使ったスクリーンショット取得試行もローカルサーバー未起動のため `ERR_EMPTY_RESPONSE` で失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba52dbec48326a8e94f8a8cef7eb2)