### PR TITLE
fix: URLプレビューの短縮URL解決を全体対応へ拡張

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -63,16 +63,20 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
       : `Getting preview of ${url}@${lang} ...`
   );
 
+  const redirectedUrl = await resolveShortUrlIfNeeded(url);
+  const effectiveUrl = redirectedUrl ?? url;
+
   // SteamのApp IDを取得
-  const steamAppId = isSteamUrl(url);
-  const steamPackageId = isSteamPackageUrl(url);
-	const steamBundleId = isSteamBundleUrl(url);
-  const VRCWorldId = isVRCUrl(url);
-  let amazonFetchUrl = url;
-  let amazonProduct = isAmazonProductUrl(url);
+  const steamAppId = isSteamUrl(effectiveUrl);
+  const steamPackageId = isSteamPackageUrl(effectiveUrl);
+	const steamBundleId = isSteamBundleUrl(effectiveUrl);
+  const VRCWorldId = isVRCUrl(effectiveUrl);
+  let amazonFetchUrl = effectiveUrl;
+  let amazonProduct = isAmazonProductUrl(effectiveUrl);
+  const summaryFetchUrl = effectiveUrl;
 
   if (!amazonProduct) {
-    const resolvedAmazonUrl = await resolveAmazonShortUrl(url);
+    const resolvedAmazonUrl = await resolveAmazonShortUrl(effectiveUrl);
     if (resolvedAmazonUrl) {
       amazonFetchUrl = resolvedAmazonUrl;
       amazonProduct = isAmazonProductUrl(amazonFetchUrl);
@@ -509,11 +513,11 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
     const summary = meta.summalyProxy
       ? await getJson(
           `${meta.summalyProxy}?${query({
-            url: url,
+            url: summaryFetchUrl,
             lang: lang ?? "en-US",
           })}`
         )
-      : await summaly.default(url, {
+      : await summaly.default(summaryFetchUrl, {
           followRedirects: false,
           lang: lang ?? "en-US",
         });
@@ -726,6 +730,113 @@ async function resolveAmazonShortUrl(originalUrl: string): Promise<string | null
   }
 
   return null;
+}
+
+async function resolveShortUrlIfNeeded(originalUrl: string): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(originalUrl);
+  } catch (error) {
+    logger.warn("Invalid URL:", error);
+    return null;
+  }
+
+  if (!isLikelyShortenerUrl(parsed)) {
+    return null;
+  }
+
+  try {
+    const headResponse = await getResponse({
+      url: originalUrl,
+      method: "HEAD",
+      headers: {
+        "User-Agent": config.userAgent,
+        Accept: "*/*",
+      },
+      timeout: 5000,
+    });
+
+    const finalUrl = extractFinalUrl(originalUrl, headResponse);
+    if (finalUrl && finalUrl !== originalUrl) {
+      return finalUrl;
+    }
+  } catch (error) {
+    logger.debug(`HEAD request failed for ${originalUrl}: ${error}`);
+  }
+
+  try {
+    const getResponseResult = await getResponse({
+      url: originalUrl,
+      method: "GET",
+      headers: {
+        "User-Agent": config.userAgent,
+        Accept: "text/html, */*",
+      },
+      timeout: 10000,
+    });
+
+    const finalUrl = extractFinalUrl(originalUrl, getResponseResult);
+    cancelResponseBody(getResponseResult);
+
+    if (finalUrl && finalUrl !== originalUrl) {
+      return finalUrl;
+    }
+  } catch (error) {
+    logger.warn(`Failed to resolve short URL ${originalUrl}: ${error}`);
+  }
+
+  return null;
+}
+
+function isLikelyShortenerUrl(url: URL): boolean {
+  if (isKnownShortenerHostname(url.hostname)) {
+    return true;
+  }
+
+  const path = url.pathname.replace(/\/+$/, "");
+  if (!path || path === "/") {
+    return false;
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length > 2) {
+    return false;
+  }
+
+  const token = segments[segments.length - 1] ?? "";
+  if (token.length < 4 || token.length > 40) {
+    return false;
+  }
+
+  const loweredHost = url.hostname.toLowerCase();
+  if (
+    loweredHost.includes("amazon.") ||
+    loweredHost.includes("google.") ||
+    loweredHost.endsWith(".google.com") ||
+    loweredHost === "google.com"
+  ) {
+    return false;
+  }
+
+  return /^[a-z0-9_-]+$/i.test(token);
+}
+
+function isKnownShortenerHostname(hostname: string): boolean {
+  return [
+    /^amzn\.asia$/i,
+    /^maps\.app\.goo\.gl$/i,
+    /^t\.co$/i,
+    /^bit\.ly$/i,
+    /^tinyurl\.com$/i,
+    /^goo\.gl$/i,
+    /^is\.gd$/i,
+    /^ow\.ly$/i,
+    /^buff\.ly$/i,
+    /^ift\.tt$/i,
+    /^j\.mp$/i,
+    /^reut\.rs$/i,
+    /^trib\.al$/i,
+  ].some((pattern) => pattern.test(hostname));
 }
 
 function isAmazonShortenerHostname(hostname: string): boolean {

--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -41,6 +41,7 @@ async function translateDescriptionToJapaneseIfNeeded(
 }
 
 const logger = new Logger("url-preview");
+const AMAZON_SHORTENER_HOSTNAME_PATTERN = /^(?:www\.)?amzn\.asia$/i;
 
 export const urlPreviewHandler = async (ctx: Koa.Context) => {
   const url = ctx.query.url;
@@ -823,7 +824,7 @@ function isLikelyShortenerUrl(url: URL): boolean {
 
 function isKnownShortenerHostname(hostname: string): boolean {
   return [
-    /^amzn\.asia$/i,
+    AMAZON_SHORTENER_HOSTNAME_PATTERN,
     /^maps\.app\.goo\.gl$/i,
     /^t\.co$/i,
     /^bit\.ly$/i,
@@ -840,7 +841,7 @@ function isKnownShortenerHostname(hostname: string): boolean {
 }
 
 function isAmazonShortenerHostname(hostname: string): boolean {
-  return /^amzn\.asia$/i.test(hostname);
+  return AMAZON_SHORTENER_HOSTNAME_PATTERN.test(hostname);
 }
 
 type FetchResponse = ReturnType<typeof getResponse> extends Promise<infer T>


### PR DESCRIPTION
### Motivation
- 短縮URL（例: `maps.app.goo.gl`）を投稿した際に遷移先のOGを正しく取得できない問題に対応するため、URLプレビュー全体で短縮URLのリダイレクト先を事前に解決するようにしました。 
- 短縮っぽいURLを見つけたら先にリダイレクト先を取得し、その`effectiveUrl`でSteam/Amazon/VRC判定やOG取得を行うことで正しいプレビューを狙います。 
- 実装により短縮URLと判定された場合は追加の外部`HEAD`/`GET`リクエストが発生するため、遅延増や外部アクセスの負荷が発生する可能性があります。  

### Description
- `packages/backend/src/server/web/url-preview.ts` を修正し、短縮URL解決用の汎用関数 `resolveShortUrlIfNeeded` を追加しました。 
- 短縮URL判定のために `isLikelyShortenerUrl` と既知短縮ドメイン判定の `isKnownShortenerHostname` を追加し、ヒューリスティクスと既知ドメインで判定します。 
- ハンドラ内で先に `redirectedUrl = await resolveShortUrlIfNeeded(url)` を実行し、`effectiveUrl = redirectedUrl ?? url` を使ってSteam/Amazon/VRC判定やSummaly取得など既存フローへ反映するように変更しました（`maps.app.goo.gl`専用処理を全体対応へ拡張）。 
- 解決処理はまず `HEAD` を試行し、失敗または最終URLが取れない場合に `GET` をフォールバックで実行し、取得できた遷移先URLを返します。 

### Testing
- `pnpm --filter backend lint` を実行しましたが、`node_modules` 未展開のため `rome` バイナリが見つからず `spawn rome ENOENT` で失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bbff7b830832694e8a2ef3b746c5b)