### PR TITLE
Fix Google Maps short URL preview title handling

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -563,6 +563,11 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
       }
     }
 
+    const googleMapsPlaceTitle = extractGoogleMapsPlaceTitle(effectiveUrl);
+    if (googleMapsPlaceTitle && isGenericGoogleMapsTitle(summary.title)) {
+      summary.title = googleMapsPlaceTitle;
+    }
+
     summary.icon = wrap(summary.icon);
     summary.thumbnail = wrap(summary.thumbnail);
     // Cache 7days
@@ -580,6 +585,104 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
 function normalizeLang(lang?: string | null): string {
   if (!lang) return "en-US";
   return lang.replace("ja-KS", "ja-JP").replace("ja-KK", "ja-JP");
+}
+
+function isGenericGoogleMapsTitle(title: unknown): boolean {
+  if (typeof title !== "string") return false;
+  const normalizedTitle = title.trim().toLowerCase();
+  return normalizedTitle === "google maps" || normalizedTitle === "google マップ";
+}
+
+function extractGoogleMapsPlaceTitle(url: string): string | null {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (!isGoogleMapsHostname(parsedUrl.hostname)) {
+    return null;
+  }
+
+  const placeFromPath = extractGoogleMapsPlaceFromPath(parsedUrl.pathname);
+  if (placeFromPath) {
+    return placeFromPath;
+  }
+
+  const queryCandidates = ["q", "query", "destination", "daddr"];
+  for (const key of queryCandidates) {
+    const value = parsedUrl.searchParams.get(key);
+    const sanitized = sanitizeGoogleMapsPlaceCandidate(value);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+
+  return null;
+}
+
+function isGoogleMapsHostname(hostname: string): boolean {
+  const loweredHostname = hostname.toLowerCase();
+  return (
+    loweredHostname === "maps.google.com" ||
+    loweredHostname.endsWith(".google.com") ||
+    loweredHostname === "www.google.com" ||
+    loweredHostname === "google.com"
+  );
+}
+
+function extractGoogleMapsPlaceFromPath(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const placeIndex = segments.findIndex((segment) => segment.toLowerCase() === "place");
+  if (placeIndex !== -1 && segments.length > placeIndex + 1) {
+    const candidate = segments[placeIndex + 1];
+    return sanitizeGoogleMapsPlaceCandidate(candidate);
+  }
+
+  if (segments[0]?.toLowerCase() === "maps" && segments.length > 1) {
+    return sanitizeGoogleMapsPlaceCandidate(segments[1]);
+  }
+
+  return null;
+}
+
+function sanitizeGoogleMapsPlaceCandidate(candidate: string | null | undefined): string | null {
+  if (!candidate) return null;
+
+  const decoded = decodeURIComponentSafe(candidate)
+    .replace(/\+/g, " ")
+    .replace(/,/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!decoded) return null;
+
+  if (/^@[-\d.]+,[-\d.]+,/.test(decoded)) {
+    return null;
+  }
+
+  const loweredDecoded = decoded.toLowerCase();
+  if (
+    loweredDecoded === "maps" ||
+    loweredDecoded === "search" ||
+    loweredDecoded === "dir" ||
+    loweredDecoded === "place"
+  ) {
+    return null;
+  }
+
+  return decoded;
+}
+
+function decodeURIComponentSafe(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 // SteamのURLを判定し、App IDを取得する関数


### PR DESCRIPTION
### Motivation
- `maps.app.goo.gl` のような Google Maps 短縮URLを共有した際に URL プレビューのタイトルが汎用的な `Google Maps` / `Google マップ` になってしまい、店舗名など具体的な場所名が表示されない問題を解消するため。 

### Description
- `packages/backend/src/server/web/url-preview.ts` に Google Maps 固有のホスト判定・パス解析・クエリ解析・デコード用の補助関数（`isGoogleMapsHostname` / `extractGoogleMapsPlaceFromPath` / `sanitizeGoogleMapsPlaceCandidate` / `extractGoogleMapsPlaceTitle` 等）を追加して URL から場所名候補を抽出するようにしました。 
- プレビュー取得後に `effectiveUrl` から場所名を抽出し、取得された `summary.title` が汎用的な `Google Maps` / `Google マップ` の場合のみ抽出した場所名で上書きするロジックを追加しました。 
- 既存の挙動を壊さないように、抽出に失敗した場合や既に具体的なタイトルが取得できている場合は何も変更しないフォールバックを維持しています。 
- 変更は上記 1 ファイルに限定してコミット済み（コミットメッセージ: `Fix Google Maps short URL preview title handling`）。 

### Testing
- `pnpm -C packages/backend lint` を実行しましたが、依存関係が未インストールのため `rome` が見つからず実行に失敗しました（エラー: `spawn rome ENOENT`）。
- 他の自動テストやビルドはこの環境では実行していないため、CI 上で `pnpm install` 後に `pnpm -C packages/backend test` や `pnpm -C packages/backend build` を実行して総合的な検証を行うことを推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcce918988326bc9ea2ced9208759)