### PR TITLE
performance_incident マイグレーションで uuid-ossp を有効化して uuid_generate_v4 エラーを回避

### DIFF
--- a/packages/backend/migration/1738000000000-create-performance-incident.js
+++ b/packages/backend/migration/1738000000000-create-performance-incident.js
@@ -2,6 +2,7 @@ export class createPerformanceIncident1738000000000 {
 	name = "createPerformanceIncident1738000000000";
 
 	async up(queryRunner) {
+		await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
 		await queryRunner.query(
 			`CREATE TABLE "performance_incident" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "severity" character varying(16) NOT NULL, "metric" character varying(64) NOT NULL, "value" double precision NOT NULL, "stats" jsonb NOT NULL DEFAULT '{}'::jsonb, CONSTRAINT "PK_performance_incident_id" PRIMARY KEY ("id"))`,
 		);


### PR DESCRIPTION
### Motivation
- `function uuid_generate_v4() does not exist` エラーでマイグレーションが失敗する問題を防ぐため、`uuid_generate_v4()` を提供する拡張を事前に有効化します。

### Description
- `packages/backend/migration/1738000000000-create-performance-incident.js` の `up` 関数先頭に `await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);` を追加して、`performance_incident` テーブル作成前に `uuid-ossp` を有効化するようにしました。
- 副作用としてはデータベースユーザーに拡張作成権限が必要になる点があり、権限のない環境では `CREATE EXTENSION` 実行時にエラーになる可能性がありますが、`IF NOT EXISTS` を使っているため既存環境への再実行は安全です。

### Testing
- `node --check packages/backend/migration/1738000000000-create-performance-incident.js` を実行して構文チェックを行い成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf4f1c27c8326a488f939169a8a63)