### PR TITLE
fix: normalize Twitter/X status URLs only for local posts

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -305,25 +305,27 @@ export default async (
 			data.text += ` #${data.channel!.name}`;
 		}
 
-		// Twitterのstatusリンクの場合、?以降を取り除く
-		if (
-			data.text?.includes("https://twitter.com") ||
-			data.text?.includes("http://twitter.com")
-		) {
-			data.text = data.text.replaceAll(
-				/(https?:\/\/twitter.com\/\S*\/status\/\S*)(\?[^\s\)]*)/gi,
-				"$1",
-			);
-		}
+		// ローカル投稿のTwitter/X statusリンクのみ、?以降を取り除く
+		if (user.host == null) {
+			if (
+				data.text?.includes("https://twitter.com") ||
+				data.text?.includes("http://twitter.com")
+			) {
+				data.text = data.text.replaceAll(
+					/(https?:\/\/twitter.com\/\S*\/status\/\S*)(\?[^\s\)]*)/gi,
+					"$1",
+				);
+			}
 
-		if (
-			data.text?.includes("https://x.com") ||
-			data.text?.includes("http://x.com")
-		) {
-			data.text = data.text.replaceAll(
-				/(https?:\/\/x.com\/\S*\/status\/\S*)(\?[^\s\)]*)/gi,
-				"$1",
-			);
+			if (
+				data.text?.includes("https://x.com") ||
+				data.text?.includes("http://x.com")
+			) {
+				data.text = data.text.replaceAll(
+					/(https?:\/\/x.com\/\S*\/status\/\S*)(\?[^\s\)]*)/gi,
+					"$1",
+				);
+			}
 		}
 
 		//ローカルユーザーでこの投稿が1投稿目の場合

--- a/packages/backend/test/activitypub.ts
+++ b/packages/backend/test/activitypub.ts
@@ -66,6 +66,29 @@ describe("ActivityPub", () => {
 			assert.deepStrictEqual(note.visibility, "public");
 			assert.deepStrictEqual(note.text, post.content);
 		});
+
+		it("リモート投稿ではTwitter/Xのクエリを保持する", async () => {
+			const { MockResolver } = await import("./misc/mock-resolver.js");
+			const { createNote } = await import(
+				"../src/remote/activitypub/models/note.js"
+			);
+
+			const postWithQuery = {
+				...post,
+				id: `${host}/users/${rndstr("0-9a-z", 8)}`,
+				content:
+					"https://twitter.com/user/status/12345?ref_src=twsrc%5Etfw https://x.com/user/status/67890?s=20",
+			};
+
+			const resolver = new MockResolver();
+			resolver._register(actor.id, actor);
+			resolver._register(postWithQuery.id, postWithQuery);
+
+			const note = await createNote(postWithQuery.id, resolver, true);
+
+			assert.deepStrictEqual(note?.text, postWithQuery.content);
+		});
+
 	});
 
 	describe("Truncate long name", () => {

--- a/packages/backend/test/note.ts
+++ b/packages/backend/test/note.ts
@@ -192,6 +192,21 @@ describe("Note", () => {
 		assert.strictEqual(res.body.createdNote.renote.text, bobPost.text);
 	}));
 
+
+	it("ローカル投稿ではTwitter/Xのクエリが正規化される", async(async () => {
+		const post = {
+			text: "https://twitter.com/user/status/12345?ref_src=twsrc%5Etfw https://x.com/user/status/67890?s=20",
+		};
+
+		const res = await request("/notes/create", post, alice);
+
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(
+			res.body.createdNote.text,
+			"https://twitter.com/user/status/12345 https://x.com/user/status/67890",
+		);
+	}));
+
 	it("文字数ぎりぎりで怒られない", async(async () => {
 		const post = {
 			text: "!".repeat(3000),


### PR DESCRIPTION
### Motivation

- Twitter/X の status リンクから `?` 以下のクエリを常に削ってしまう処理を、ローカル投稿のみ適用することで、リモート（ActivityPub 経由）投稿では原文の `text` を保持する目的です。

### Description

- `packages/backend/src/services/note/create.ts` の Twitter/X URL 正規化（`replaceAll` による `?` 以降削除）処理を `if (user.host == null)` でガードし、ローカル投稿時のみ実行するように変更しました。 
- 既存のノート作成経路での検証用にテストケースを追記しました（ローカル投稿確認を `packages/backend/test/note.ts` に、ActivityPub 経路でのリモート投稿確認を `packages/backend/test/activitypub.ts` に追加）。
- 変更は既存の処理を狭めるものの、保存される `text` の内容がローカル/リモートで異なる挙動になる点に注意が必要です。

### Testing

- 追加したテストケースは `packages/backend/test/note.ts` の「ローカル投稿ではTwitter/Xのクエリが正規化される」と `packages/backend/test/activitypub.ts` の「リモート投稿ではTwitter/Xのクエリを保持する」です。 
- ローカルで `pnpm --filter backend test -- test/note.ts test/activitypub.ts` を実行して検証を試みましたが、依存が未インストールのため `cross-env: not found` エラーでテスト実行は失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dd557cd48326ba2520f40e6ed38c)