### PR TITLE
backend: リモート投稿で channel 整合調整をスキップ

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -214,45 +214,49 @@ export default async (
 
 		const firstVisibility = data.visibility ?? "public";
 
+		// リモートのノートはチャンネル扱いにしない
+		if (!Users.isLocalUser(user)) {
+			data.channel = null;
+		}
+
 		const dontFederateInitially =
 			(data.localOnly && data.channel) || data.visibility === "hidden";
 
-		// If you reply outside the channel, match the scope of the target.
-		// TODO (I think it's a process that could be done on the client side, but it's server side for now.)
-		if (
-			data.reply &&
-			data.channel &&
-			data.reply.channelId !== data.channel.id
-		) {
-			if (data.reply.channelId) {
+		if (Users.isLocalUser(user)) {
+			// If you reply outside the channel, match the scope of the target.
+			// TODO (I think it's a process that could be done on the client side, but it's server side for now.)
+			if (
+				data.reply &&
+				data.channel &&
+				data.reply.channelId !== data.channel.id
+			) {
+				if (data.reply.channelId) {
+					data.channel = await Channels.findOneBy({ id: data.reply.channelId });
+				} else {
+					data.channel = null;
+				}
+			}
+			if (
+				data.renote &&
+				data.channel &&
+				data.renote.channelId !== data.channel.id
+			) {
+				if (data.renote.channelId) {
+					data.channel = await Channels.findOneBy({ id: data.renote.channelId });
+				} else {
+					data.channel = null;
+				}
+			}
+
+			// When you reply in a channel, match the scope of the target
+			// TODO (I think it's a process that could be done on the client side, but it's server side for now.)
+			if (data.reply && data.channel == null && data.reply.channelId) {
 				data.channel = await Channels.findOneBy({ id: data.reply.channelId });
-			} else {
-				data.channel = null;
 			}
-		}
-		if (
-			data.renote &&
-			data.channel &&
-			data.renote.channelId !== data.channel.id
-		) {
-			if (data.renote.channelId) {
+			if (data.renote && data.channel == null && data.renote.channelId) {
 				data.channel = await Channels.findOneBy({ id: data.renote.channelId });
-			} else {
-				data.channel = null;
 			}
 		}
-
-		// When you reply in a channel, match the scope of the target
-		// TODO (I think it's a process that could be done on the client side, but it's server side for now.)
-		if (data.reply && data.channel == null && data.reply.channelId) {
-			data.channel = await Channels.findOneBy({ id: data.reply.channelId });
-		}
-		if (data.renote && data.channel == null && data.renote.channelId) {
-			data.channel = await Channels.findOneBy({ id: data.renote.channelId });
-		}
-
-		//リモートのノートはチャンネル扱いにしない
-		if (user.host && data.channel) data.channel = null;
 
 		//指定がなければpublicでlocalOnlyOFF
 		if (data.visibility == null) data.visibility = "public";


### PR DESCRIPTION
### Motivation
- `packages/backend/src/services/note/create.ts` の冒頭にある返信/リノート先の channel 整合調整処理がリモート投稿でも実行されており不要な DB 参照を発生させるため、リモート投稿は早期に channel を無効化して整合調整ロジック自体を通らないようにする。

### Description
- リモート投稿判定を `Users.isLocalUser(user)` に合わせて前倒しし、`if (!Users.isLocalUser(user)) { data.channel = null; }` を `data.createdAt` 確定の直後に適用しました。
- `data.reply`/`data.renote` と `data.channel` の整合調整（`Channels.findOneBy(...)` を呼ぶブロック）を `if (Users.isLocalUser(user)) { ... }` の内部に移動してローカル投稿時のみ実行されるようにしました。
- ローカル投稿に関する既存の「返信先/リノート先チャンネルへの追従」挙動は移動のみで維持しています。
- 変更対象は `packages/backend/src/services/note/create.ts` の該当ブロックで、他の処理の位置やシグネチャは変更していません。

### Testing
- `pnpm rome check packages/backend/src/services/note/create.ts` を実行しましたが環境で `rome` バイナリが見つからず `spawn rome ENOENT` により失敗しました。
- 変更ファイルは `git` によりコミット済みでワーキングツリーはクリーンであることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ddc99f208326a1595acb4f156cdd)