### PR TITLE
Allow overriding DB port via DB_PORT env var in TypeORM config

### DIFF
--- a/packages/backend/ormconfig.js
+++ b/packages/backend/ormconfig.js
@@ -5,7 +5,7 @@ import { entities } from "./built/db/postgre.js";
 export default new DataSource({
 	type: "postgres",
 	host: config.db.host,
-	port: config.db.port,
+	port: process.env.DB_PORT ? Number(process.env.DB_PORT) : config.db.port,
 	username: config.db.user,
 	password: config.db.pass,
 	database: config.db.db,


### PR DESCRIPTION
### Motivation
- Allow runtime override of the database port via an environment variable for containerized or dynamic deployments instead of relying solely on the built config.

### Description
- Update `packages/backend/ormconfig.js` to set `port` to `process.env.DB_PORT ? Number(process.env.DB_PORT) : config.db.port`, so the `DB_PORT` environment variable takes precedence and is properly cast to a number.

### Testing
- No automated tests were run for this trivial configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ef9aa84c832690e9df09bdecf734)