### PR TITLE
Add toggle for performance incident collection with UI, migration, and clear endpoint

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -714,6 +714,8 @@ database: "Database"
 performanceIncidents: "Performance Incidents"
 _performanceIncidents:
   severity: "Severity"
+  collect: "Collect"
+  changeCollectionStateConfirm: "Do you want to switch the state?"
   rawStatsSnapshot: "Raw stats snapshot"
   diagnosis: "Diagnosis"
   noProblemsDetected: "No problems detected"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -846,6 +846,8 @@ database: "データベース"
 performanceIncidents: "パフォーマンス障害ログ"
 _performanceIncidents:
   severity: "重大度"
+  collect: "収集する"
+  changeCollectionStateConfirm: "状態を切り替えますか？"
   rawStatsSnapshot: "Raw stats snapshot"
   diagnosis: "診断"
   noProblemsDetected: "問題は検出されていません"

--- a/packages/backend/migration/1740300000000-add-performance-incident-collection-setting.js
+++ b/packages/backend/migration/1740300000000-add-performance-incident-collection-setting.js
@@ -1,0 +1,15 @@
+export class AddPerformanceIncidentCollectionSetting1740300000000 {
+	name = "AddPerformanceIncidentCollectionSetting1740300000000";
+
+	async up(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "meta" ADD "enablePerformanceIncidentCollection" boolean NOT NULL DEFAULT true`,
+		);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(
+			`ALTER TABLE "meta" DROP COLUMN "enablePerformanceIncidentCollection"`,
+		);
+	}
+}

--- a/packages/backend/src/daemons/health-stats.ts
+++ b/packages/backend/src/daemons/health-stats.ts
@@ -2,6 +2,7 @@ import { monitorEventLoopDelay } from "perf_hooks";
 import Xev from "xev";
 import { db } from "@/db/postgre.js";
 import { redisClient } from "@/db/redis.js";
+import { fetchMeta } from "@/misc/fetch-meta.js";
 
 type ServerStats = {
 	cpu: number;
@@ -537,50 +538,60 @@ export default function () {
 			stats as unknown as StatsForDiagnosis,
 		);
 
-		if (shouldRecordIncident("cpuUsage", stats.cpuUsage, 90)) {
-			await recordIncident("critical", "cpuUsage", stats.cpuUsage, stats);
-		} else if (shouldRecordIncident("cpuUsageWarn", stats.cpuUsage, 75)) {
-			await recordIncident("warn", "cpuUsage", stats.cpuUsage, stats);
+		let enablePerformanceIncidentCollection = true;
+		try {
+			const instanceMeta = await fetchMeta();
+			enablePerformanceIncidentCollection = instanceMeta.enablePerformanceIncidentCollection;
+		} catch {
+			// ヘルススコア配信は継続し、DB記録判定のみデフォルト値を使う
 		}
 
-		if (shouldRecordIncident("queuePressure", stats.queuePressure, 8)) {
-			await recordIncident("critical", "queuePressure", stats.queuePressure, stats);
-		} else if (shouldRecordIncident("queuePressureWarn", stats.queuePressure, 4)) {
-			await recordIncident("warn", "queuePressure", stats.queuePressure, stats);
-		}
+		if (enablePerformanceIncidentCollection) {
+			if (shouldRecordIncident("cpuUsage", stats.cpuUsage, 90)) {
+				await recordIncident("critical", "cpuUsage", stats.cpuUsage, stats);
+			} else if (shouldRecordIncident("cpuUsageWarn", stats.cpuUsage, 75)) {
+				await recordIncident("warn", "cpuUsage", stats.cpuUsage, stats);
+			}
 
-		if (shouldRecordIncident("eventLoopLagMs", stats.eventLoopLagMs, 250)) {
-			await recordIncident("critical", "eventLoopLagMs", stats.eventLoopLagMs, stats);
-		} else if (shouldRecordIncident("eventLoopLagMsWarn", stats.eventLoopLagMs, 120)) {
-			await recordIncident("warn", "eventLoopLagMs", stats.eventLoopLagMs, stats);
-		}
+			if (shouldRecordIncident("queuePressure", stats.queuePressure, 8)) {
+				await recordIncident("critical", "queuePressure", stats.queuePressure, stats);
+			} else if (shouldRecordIncident("queuePressureWarn", stats.queuePressure, 4)) {
+				await recordIncident("warn", "queuePressure", stats.queuePressure, stats);
+			}
 
-		if (shouldRecordIncident("dbLatencyMs", stats.dbLatencyMs, 500)) {
-			await recordIncident("critical", "dbLatencyMs", stats.dbLatencyMs, stats);
-		} else if (shouldRecordIncident("dbLatencyMsWarn", stats.dbLatencyMs, 200)) {
-			await recordIncident("warn", "dbLatencyMs", stats.dbLatencyMs, stats);
-		}
+			if (shouldRecordIncident("eventLoopLagMs", stats.eventLoopLagMs, 250)) {
+				await recordIncident("critical", "eventLoopLagMs", stats.eventLoopLagMs, stats);
+			} else if (shouldRecordIncident("eventLoopLagMsWarn", stats.eventLoopLagMs, 120)) {
+				await recordIncident("warn", "eventLoopLagMs", stats.eventLoopLagMs, stats);
+			}
 
-		if (shouldRecordIncident("dbLongRunningQueryCount", stats.longRunningQueryCount, 3)) {
-			await recordIncident(
-				"critical",
-				"dbLongRunningQueryCount",
-				stats.longRunningQueryCount,
-				stats,
-			);
-		} else if (shouldRecordIncident("dbLongRunningQueryCountWarn", stats.longRunningQueryCount, 1)) {
-			await recordIncident(
-				"warn",
-				"dbLongRunningQueryCount",
-				stats.longRunningQueryCount,
-				stats,
-			);
-		}
+			if (shouldRecordIncident("dbLatencyMs", stats.dbLatencyMs, 500)) {
+				await recordIncident("critical", "dbLatencyMs", stats.dbLatencyMs, stats);
+			} else if (shouldRecordIncident("dbLatencyMsWarn", stats.dbLatencyMs, 200)) {
+				await recordIncident("warn", "dbLatencyMs", stats.dbLatencyMs, stats);
+			}
 
-		if (shouldRecordIncident("apiLatencyP95Ms", stats.apiLatencyP95Ms, 2000)) {
-			await recordIncident("critical", "apiLatencyP95Ms", stats.apiLatencyP95Ms, stats);
-		} else if (shouldRecordIncident("apiLatencyP95MsWarn", stats.apiLatencyP95Ms, 800)) {
-			await recordIncident("warn", "apiLatencyP95Ms", stats.apiLatencyP95Ms, stats);
+			if (shouldRecordIncident("dbLongRunningQueryCount", stats.longRunningQueryCount, 3)) {
+				await recordIncident(
+					"critical",
+					"dbLongRunningQueryCount",
+					stats.longRunningQueryCount,
+					stats,
+				);
+			} else if (shouldRecordIncident("dbLongRunningQueryCountWarn", stats.longRunningQueryCount, 1)) {
+				await recordIncident(
+					"warn",
+					"dbLongRunningQueryCount",
+					stats.longRunningQueryCount,
+					stats,
+				);
+			}
+
+			if (shouldRecordIncident("apiLatencyP95Ms", stats.apiLatencyP95Ms, 2000)) {
+				await recordIncident("critical", "apiLatencyP95Ms", stats.apiLatencyP95Ms, stats);
+			} else if (shouldRecordIncident("apiLatencyP95MsWarn", stats.apiLatencyP95Ms, 800)) {
+				await recordIncident("warn", "apiLatencyP95Ms", stats.apiLatencyP95Ms, stats);
+			}
 		}
 
 		ev.emit("healthStats", stats);

--- a/packages/backend/src/models/entities/meta.ts
+++ b/packages/backend/src/models/entities/meta.ts
@@ -437,6 +437,11 @@ export class Meta {
 	})
 	public libreTranslateApiKey: string | null;
 
+	@Column('boolean', {
+		default: true,
+	})
+	public enablePerformanceIncidentCollection: boolean;
+
 	/** OpenAI APIキー（パフォーマンスインシデントのAI分析用） */
 	@Column('varchar', {
 		length: 256,

--- a/packages/backend/src/server/api/endpoints.ts
+++ b/packages/backend/src/server/api/endpoints.ts
@@ -39,6 +39,7 @@ import * as ep___admin_federation_updateInstance from "./endpoints/admin/federat
 import * as ep___admin_getIndexStats from "./endpoints/admin/get-index-stats.js";
 import * as ep___admin_getTableStats from "./endpoints/admin/get-table-stats.js";
 import * as ep___admin_performanceIncidents from "./endpoints/admin/performance-incidents.js";
+import * as ep___admin_clearPerformanceIncidents from "./endpoints/admin/clear-performance-incidents.js";
 import * as ep___admin_analyzePerformanceIncident from "./endpoints/admin/analyze-performance-incident.js";
 import * as ep___admin_getPerformanceIncidentPrompt from "./endpoints/admin/get-performance-incident-prompt.js";
 import * as ep___admin_getUserIps from "./endpoints/admin/get-user-ips.js";
@@ -436,6 +437,7 @@ const eps = [
 	["admin/send-mod-mail", ep___admin_sendModMail],
 	["admin/server-info", ep___admin_serverInfo],
 	["admin/performance-incidents", ep___admin_performanceIncidents],
+	["admin/clear-performance-incidents", ep___admin_clearPerformanceIncidents],
 	["admin/analyze-performance-incident", ep___admin_analyzePerformanceIncident],
 	["admin/get-performance-incident-prompt", ep___admin_getPerformanceIncidentPrompt],
 	["admin/show-moderation-logs", ep___admin_showModerationLogs],

--- a/packages/backend/src/server/api/endpoints/admin/clear-performance-incidents.ts
+++ b/packages/backend/src/server/api/endpoints/admin/clear-performance-incidents.ts
@@ -1,0 +1,23 @@
+import { db } from "@/db/postgre.js";
+import define from "../../define.js";
+
+export const meta = {
+	tags: ["admin"],
+
+	requireCredential: true,
+	requireAdmin: true,
+} as const;
+
+export const paramDef = {
+	type: "object",
+	properties: {},
+	required: [],
+} as const;
+
+export default define(meta, paramDef, async () => {
+	await db.query(`DELETE FROM "performance_incident"`);
+
+	return {
+		deleted: true,
+	};
+});

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -485,6 +485,11 @@ export const meta = {
 				optional: true,
 				nullable: false,
 			},
+			enablePerformanceIncidentCollection: {
+				type: "boolean",
+				optional: true,
+				nullable: false,
+			},
 			enableIpLogging: {
 				type: "boolean",
 				optional: true,
@@ -617,6 +622,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		openaiApiKey: instance.openaiApiKey != null ? "***" : null,
 		openaiModel: instance.openaiModel,
 		openaiBaseUrl: instance.openaiBaseUrl,
+		enablePerformanceIncidentCollection: instance.enablePerformanceIncidentCollection,
 		enableIpLogging: instance.enableIpLogging,
 		enableActiveEmailValidation: instance.enableActiveEmailValidation,
 	};

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -137,6 +137,7 @@ export const paramDef = {
 		openaiApiKey: { type: "string", nullable: true },
 		openaiModel: { type: "string", nullable: true },
 		openaiBaseUrl: { type: "string", nullable: true },
+		enablePerformanceIncidentCollection: { type: "boolean", nullable: true },
 		enableTwitterIntegration: { type: "boolean" },
 		twitterConsumerKey: { type: "string", nullable: true },
 		twitterConsumerSecret: { type: "string", nullable: true },
@@ -607,6 +608,10 @@ export default define(meta, paramDef, async (ps, me) => {
 		} else {
 			set.openaiBaseUrl = ps.openaiBaseUrl;
 		}
+	}
+
+	if (ps.enablePerformanceIncidentCollection !== undefined) {
+		set.enablePerformanceIncidentCollection = ps.enablePerformanceIncidentCollection;
 	}
 
 	if (ps.enableIpLogging !== undefined) {

--- a/packages/client/src/pages/admin/performance.vue
+++ b/packages/client/src/pages/admin/performance.vue
@@ -8,6 +8,9 @@
 		/></template>
 		<MkSpacer :content-max="900" :margin-min="16" :margin-max="32">
 			<div class="controls">
+				<MkSwitch :model-value="enableCollection" @update:model-value="onToggleCollection">
+					{{ i18n.ts._performanceIncidents.collect }}
+				</MkSwitch>
 				<MkSelect v-model="severity">
 					<template #label>{{ i18n.ts._performanceIncidents.severity }}</template>
 					<option value="all">{{ i18n.ts.all }}</option>
@@ -27,7 +30,7 @@
 						<div class="head">
 							<span class="badge" :class="item.severity">{{ item.severity }}</span>
 							<strong>{{ metricLabel(item.metric) }}</strong>
-							<span>{{ item.value.toFixed(2) }}</span>
+							<span>{{ formatMetricValue(item.metric, item.value) }}</span>
 							<span class="date">{{ new Date(item.createdAt).toLocaleString() }}</span>
 						</div>
 
@@ -111,8 +114,8 @@
 										:key="`${item.id}-ep-${ei}`"
 									>
 										<td>{{ ep.endpoint }}</td>
-										<td>{{ ep.avgMs }}ms</td>
-										<td>{{ ep.p95Ms }}ms</td>
+										<td>{{ formatMs(ep.avgMs) }}ms</td>
+										<td>{{ formatMs(ep.p95Ms) }}ms</td>
 										<td>{{ ep.count }}</td>
 									</tr>
 								</tbody>
@@ -130,7 +133,7 @@
 								:key="`${item.id}-slow-${ci}`"
 								class="slowCallItem"
 							>
-								{{ c.endpoint }} {{ c.responseMs }}ms {{ formatAt(c.at) }}
+								{{ c.endpoint }} {{ formatMs(c.responseMs) }}ms {{ formatAt(c.at) }}
 							</div>
 						</div>
 
@@ -178,7 +181,7 @@
 								class="queryItem"
 							>
 								<div class="queryMeta">
-									PID {{ query.pid }} / {{ query.durationMs }}ms / {{ query.state }}
+									PID {{ query.pid }} / {{ formatMs(query.durationMs) }}ms / {{ query.state }}
 									<span v-if="query.waitEventType"> ({{ query.waitEventType }})</span>
 								</div>
 								<pre>{{ query.query }}</pre>
@@ -197,9 +200,10 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, onMounted, computed } from "vue";
+import { ref, watch, onMounted } from "vue";
 import MkButton from "@/components/MkButton.vue";
 import MkSelect from "@/components/form/select.vue";
+import MkSwitch from "@/components/form/switch.vue";
 import * as os from "@/os";
 import { i18n } from "@/i18n";
 import { definePageMetadata } from "@/scripts/page-metadata";
@@ -220,6 +224,7 @@ const severity = ref<"all" | "warn" | "critical">("all");
 const loading = ref(false);
 const analyzingId = ref<string | null>(null);
 const openaiApiKeySet = ref(false);
+const enableCollection = ref(true);
 
 const metricLabels: Record<string, string> = {
 	cpuUsage: "CPU使用率",
@@ -240,6 +245,20 @@ function formatAt(at: number): string {
 	return d.toLocaleTimeString();
 }
 
+function formatMetricValue(metric: string, value: unknown): string {
+	if (typeof value !== "number" || Number.isNaN(value)) return "-";
+	if (metric.toLowerCase().includes("ms")) return formatMs(value);
+	return value.toFixed(2);
+}
+
+function formatMs(value: unknown): string {
+	if (typeof value !== "number" || Number.isNaN(value)) return "-";
+	const abs = Math.abs(value);
+	if (abs < 10) return value.toFixed(2);
+	if (abs < 100) return value.toFixed(1);
+	return value.toFixed(0);
+}
+
 function deliverDelayedTotal(fs: { deliverDelayed?: { remote?: number; local?: number; unknown?: number } }): number {
 	const d = fs.deliverDelayed;
 	if (!d) return 0;
@@ -249,10 +268,17 @@ function deliverDelayedTotal(fs: { deliverDelayed?: { remote?: number; local?: n
 const fetchIncidents = async () => {
 	loading.value = true;
 	try {
-		incidents.value = await os.api("admin/performance-incidents", {
+		const response = await os.api("admin/performance-incidents", {
 			limit: 100,
 			severity: severity.value,
 		});
+
+		incidents.value = Array.isArray(response)
+			? response.map((item) => ({
+				...item,
+				stats: item?.stats ?? {},
+			}))
+			: [];
 	} finally {
 		loading.value = false;
 	}
@@ -261,6 +287,7 @@ const fetchIncidents = async () => {
 async function fetchMetaForOpenAi() {
 	const meta = await os.api("admin/meta");
 	openaiApiKeySet.value = meta.openaiApiKey != null && meta.openaiApiKey !== "";
+	enableCollection.value = meta.enablePerformanceIncidentCollection !== false;
 }
 
 const runAnalysis = async (incidentId: string) => {
@@ -299,6 +326,29 @@ const copyPrompt = async (incidentId: string) => {
 			text: e?.message ?? "プロンプトの取得に失敗しました。",
 		});
 	}
+};
+
+
+const onToggleCollection = async (nextValue: boolean) => {
+	if (nextValue === enableCollection.value) return;
+
+	const { canceled } = await os.confirm({
+		type: "warning",
+		text: i18n.ts._performanceIncidents.changeCollectionStateConfirm,
+	});
+
+	if (canceled) return;
+
+	await os.apiWithDialog("admin/update-meta", {
+		enablePerformanceIncidentCollection: nextValue,
+	});
+
+	if (!nextValue) {
+		await os.apiWithDialog("admin/clear-performance-incidents");
+	}
+
+	enableCollection.value = nextValue;
+	await fetchIncidents();
 };
 
 watch(severity, fetchIncidents);


### PR DESCRIPTION
### Motivation

- Provide a way to enable/disable automated recording of performance incidents so operators can opt out of storing incident records while keeping health metrics broadcasting.
- Expose the new toggle in the admin UI and allow clearing existing performance incident records when disabling collection.

### Description

- Add a new boolean field `enablePerformanceIncidentCollection` to the `Meta` entity and create migration `1740300000000-add-performance-incident-collection-setting.js` to persist the setting with a default of `true`.
- Update the health stats daemon (`packages/backend/src/daemons/health-stats.ts`) to fetch instance meta via `fetchMeta` and respect `enablePerformanceIncidentCollection` when deciding whether to record incidents to the DB.
- Extend admin APIs and server routes to support the new setting in `admin/meta` and `admin/update-meta`, add a new endpoint `admin/clear-performance-incidents` to delete all rows in `performance_incident`, and register it in the endpoints list.
- Update the admin performance UI (`packages/client/src/pages/admin/performance.vue`) to add a collection toggle (`MkSwitch`), confirmation dialog on state change, client-side clearing via the new endpoint, formatting helpers for metric values and milliseconds, and minor display improvements.
- Add localized strings for the new UI labels in `locales/en-US.yml` and `locales/ja-JP.yml`.

### Testing

- Ran the project test suite with `pnpm test` and the tests completed successfully with no failures.  
- Built client and server artifacts via the normal build commands (`pnpm build`) and verified the admin performance page compiles and runs in development.  
- Applied the new migration against a development database and confirmed the `meta` table now contains the `enablePerformanceIncidentCollection` column and the toggle is persisted and honored by the health stats daemon.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10cd7e9c08326af7245f1298d84f7)