### PR TITLE
ドライブ容量オーバーライドの反映遅延を修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/drive.ts
+++ b/packages/backend/src/server/api/endpoints/drive.ts
@@ -1,5 +1,5 @@
 import { fetchMeta } from "@/misc/fetch-meta.js";
-import { DriveFiles } from "@/models/index.js";
+import { DriveFiles, Users } from "@/models/index.js";
 import define from "../define.js";
 
 export const meta = {
@@ -36,6 +36,7 @@ export const paramDef = {
 
 export default define(meta, paramDef, async (ps, user) => {
 	const instance = await fetchMeta(true);
+	const latestUser = await Users.findOneByOrFail({ id: user.id });
 
 	// Calculate drive usage
 	const usage = await DriveFiles.calcDriveUsageOf(user.id);
@@ -44,7 +45,7 @@ export default define(meta, paramDef, async (ps, user) => {
 		capacity:
 			1024 *
 			1024 *
-			(user.driveCapacityOverrideMb || instance.localDriveCapacityMb),
+			(latestUser.driveCapacityOverrideMb ?? instance.localDriveCapacityMb),
 		usage: usage,
 	};
 });


### PR DESCRIPTION
### Motivation
- ドライブ設定画面で管理者が変更した `driveCapacityOverrideMb` がキャッシュや古いセッションコンテキストのために即時反映されない問題を解消するため、エンドポイントが最新のユーザーレコードを参照するようにします。

### Description
- `packages/backend/src/server/api/endpoints/drive.ts` を修正し、レスポンス生成前に `Users.findOneByOrFail({ id: user.id })` で最新のユーザーレコードを取得するようにしました。  
- 容量計算で `user.driveCapacityOverrideMb || instance.localDriveCapacityMb` を使っていた箇所を `latestUser.driveCapacityOverrideMb ?? instance.localDriveCapacityMb` に変更し、`0` や `null` の扱いを明確化しました。  
- 予想される副作用として、`drive` エンドポイント呼び出しごとに1回追加のDBクエリが発生します（整合性向上とのトレードオフ）。

### Testing
- 型チェック用に `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが、この環境では `@types/node` が見つからず失敗しました（ローカル開発環境では型定義を揃えて再実行してください）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11129e25c8326bf7470a854b6d9e1)