### PR TITLE
fix: include driveCapacityOverrideMb in auth user selection

### DIFF
--- a/packages/backend/src/server/api/authenticate.ts
+++ b/packages/backend/src/server/api/authenticate.ts
@@ -23,6 +23,7 @@ const AUTH_USER_SELECT = {
 	isSuspended: true,
 	isAdmin: true,
 	isModerator: true,
+	driveCapacityOverrideMb: true,
 	emojis: true,
 } as const;
 


### PR DESCRIPTION
### Motivation
- ドライブ設定画面でオーバーライド容量が反映されない問題は、認証ユーザーをキャッシュする際の選択フィールドに `driveCapacityOverrideMb` が含まれておらず古い値が返されるため発生しており、認証キャッシュにオーバーライド値を載せることで表示を即時反映させる目的です。 

### Description
- `AUTH_USER_SELECT` に `driveCapacityOverrideMb: true` を追加して、認証時にキャッシュされるユーザーオブジェクトにオーバーライド容量を含めるようにしました（`packages/backend/src/server/api/authenticate.ts` を変更）。
- これにより `drive` エンドポイント側で参照する `user.driveCapacityOverrideMb` が認証キャッシュ経由でも最新値を参照できるようになります。 
- 副作用として認証ユーザーキャッシュに数値フィールドが1つ増えるためキャッシュサイズがわずかに増加しますが、機能的な挙動は変わりません。 

### Testing
- `pnpm --filter backend run lint` を実行しましたが、ローカル環境で `node_modules` が未インストールだったため `rome` が見つからず `spawn rome ENOENT` により実行失敗しました（依存解決後に linter の検証が必要）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a112bd951083269eabb7a93ce5eb32)