### PR TITLE
Allow admins/moderators to edit channels and reassign channel owner

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1377,6 +1377,7 @@ _channel:
   edit: "Edit channel"
   setBanner: "Set banner"
   removeBanner: "Remove banner"
+  manager: "Channel admin"
   featured: "Trending"
   owned: "Owned"
   following: "Followed"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1600,6 +1600,7 @@ _channel:
   edit: "チャンネルを編集"
   setBanner: "バナーを設定"
   removeBanner: "バナーを削除"
+  manager: "チャンネル管理者"
   featured: "トレンド"
   owned: "管理中"
   following: "フォロー中"

--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -1,6 +1,6 @@
 import define from "../../define.js";
 import { ApiError } from "../../error.js";
-import { Channels, DriveFiles } from "@/models/index.js";
+import { Channels, DriveFiles, Users } from "@/models/index.js";
 
 export const meta = {
 	tags: ["channels"],
@@ -34,6 +34,12 @@ export const meta = {
 			code: "NO_SUCH_FILE",
 			id: "e86c14a4-0da2-4032-8df3-e737a04c7f3b",
 		},
+
+		noSuchUser: {
+			message: "そのユーザーは存在しません。",
+			code: "NO_SUCH_USER",
+			id: "958bc0ea-f4e0-4de4-aa02-d7ec2633f4e4",
+		},
 	},
 } as const;
 
@@ -49,6 +55,7 @@ export const paramDef = {
 			maxLength: 2048,
 		},
 		bannerId: { type: "string", format: "misskey:id", nullable: true },
+		userId: { type: "string", format: "misskey:id", nullable: true },
 	},
 	required: ["channelId"],
 } as const;
@@ -62,7 +69,9 @@ export default define(meta, paramDef, async (ps, me) => {
 		throw new ApiError(meta.errors.noSuchChannel);
 	}
 
-	if (channel.userId !== me.id) {
+	const canEditAsModerator = me.isAdmin || me.isModerator;
+
+	if (channel.userId !== me.id && !canEditAsModerator) {
 		throw new ApiError(meta.errors.accessDenied);
 	}
 
@@ -80,9 +89,20 @@ export default define(meta, paramDef, async (ps, me) => {
 		banner = null;
 	}
 
+	if (ps.userId !== undefined && ps.userId !== null) {
+		const user = await Users.findOneBy({
+			id: ps.userId,
+		});
+
+		if (user == null) {
+			throw new ApiError(meta.errors.noSuchUser);
+		}
+	}
+
 	await Channels.update(channel.id, {
 		...(ps.name !== undefined ? { name: ps.name } : {}),
 		...(ps.description !== undefined ? { description: ps.description } : {}),
+		...(ps.userId !== undefined ? { userId: ps.userId } : {}),
 		...(banner ? { bannerId: banner.id } : {}),
 	});
 

--- a/packages/client/src/pages/channel-editor.vue
+++ b/packages/client/src/pages/channel-editor.vue
@@ -26,6 +26,17 @@
 						>
 					</div>
 				</div>
+
+				<div v-if="$i?.isAdmin || $i?.isModerator" class="_formBlock">
+					<MkInput :model-value="managerLabel" readonly>
+						<template #label>{{ i18n.ts._channel.manager }}</template>
+					</MkInput>
+					<div style="display: flex; gap: 0.5rem; margin-top: 0.5rem">
+						<MkButton @click="selectManager()">{{ i18n.ts.selectUser }}</MkButton>
+						<MkButton @click="clearManager()">{{ i18n.ts.none }}</MkButton>
+					</div>
+				</div>
+
 				<div class="_formBlock">
 					<MkButton primary @click="save()"
 						><i class="ph-floppy-disk-back ph-bold ph-lg"></i>
@@ -40,7 +51,8 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, watch } from "vue";
+import { computed, watch } from "vue";
+import type * as misskey from "calckey-js";
 import MkTextarea from "@/components/form/textarea.vue";
 import MkButton from "@/components/MkButton.vue";
 import MkInput from "@/components/form/input.vue";
@@ -49,6 +61,7 @@ import * as os from "@/os";
 import { useRouter } from "@/router";
 import { definePageMetadata } from "@/scripts/page-metadata";
 import { i18n } from "@/i18n";
+import { $i } from "@/account";
 
 const router = useRouter();
 
@@ -61,6 +74,8 @@ let name = $ref(null);
 let description = $ref(null);
 let bannerUrl = $ref<string | null>(null);
 let bannerId = $ref<string | null>(null);
+let managerUserId = $ref<string | null>(null);
+let managerLabel = $ref(i18n.ts.none);
 
 watch(
 	() => bannerId,
@@ -77,6 +92,23 @@ watch(
 	}
 );
 
+function toUserLabel(user: misskey.entities.UserDetailed) {
+	return `@${user.username}${user.host ? `@${user.host}` : ""}`;
+}
+
+async function fetchManagerLabel() {
+	if (managerUserId == null) {
+		managerLabel = i18n.ts.none;
+		return;
+	}
+
+	const manager = await os.api("users/show", {
+		userId: managerUserId,
+	});
+
+	managerLabel = toUserLabel(manager);
+}
+
 async function fetchChannel() {
 	if (props.channelId == null) return;
 
@@ -88,6 +120,8 @@ async function fetchChannel() {
 	description = channel.description;
 	bannerId = channel.bannerId;
 	bannerUrl = channel.bannerUrl;
+	managerUserId = channel.userId;
+	await fetchManagerLabel();
 }
 
 fetchChannel();
@@ -101,6 +135,9 @@ function save() {
 
 	if (props.channelId) {
 		params.channelId = props.channelId;
+		if ($i?.isAdmin || $i?.isModerator) {
+			params.userId = managerUserId;
+		}
 		os.api("channels/update", params).then(() => {
 			os.success();
 		});
@@ -120,6 +157,17 @@ function setBannerImage(evt) {
 
 function removeBannerImage() {
 	bannerId = null;
+}
+
+async function selectManager() {
+	const user = await os.selectUser({ includeSelf: true });
+	managerUserId = user.id;
+	managerLabel = toUserLabel(user);
+}
+
+function clearManager() {
+	managerUserId = null;
+	managerLabel = i18n.ts.none;
 }
 
 const headerActions = $computed(() => []);

--- a/packages/client/src/pages/channel.vue
+++ b/packages/client/src/pages/channel.vue
@@ -155,7 +155,7 @@ const headerActions = $computed(() => [
 				},
 		  ]
 		: []),
-	...(channel && channel?.userId === $i?.id
+	...(channel && (channel?.userId === $i?.id || $i?.isAdmin || $i?.isModerator)
 		? [
 				{
 					icon: "ph-gear-six ph-bold ph-lg",


### PR DESCRIPTION
### Motivation
- チャンネル編集画面を管理者またはモデレーターでも利用できるようにし、必要に応じてチャンネルの管理者（owner / `userId`）を画面上で変更できるようにするための変更です。

### Description
- サーバー側で `channels/update` に `userId` パラメータを追加し、指定されたユーザーが存在しない場合は `NO_SUCH_USER` を返すようバリデーションを追加しました（`packages/backend/src/server/api/endpoints/channels/update.ts`）。
- 権限判定を拡張し、チャンネル所有者に加えて `me.isAdmin || me.isModerator` の場合も編集を許可するようにしました（同ファイル）。
- クライアント側でチャンネルページの編集ボタン表示条件を管理者/モデレーターにも拡張し、チャンネル編集画面に管理者/モデレーター向けの「チャンネル管理者（manager）」選択UIを追加して、ユーザー選択・クリアができるようにしました（`packages/client/src/pages/channel.vue` と `packages/client/src/pages/channel-editor.vue`）。
- 表示用ロケールに `_channel.manager` を追加しました（`locales/ja-JP.yml` / `locales/en-US.yml`）。
- 副作用として、管理者/モデレーターが他人のチャンネルを編集・所有者を差し替えられるため、監査（誰がいつ変更したか）や運用ルールの見直しが必要になる可能性があります。
- 管理者UIから `userId` を `null` にできるため、管理者不在のチャンネルを作れる点は仕様上の確認を推奨します。

### Testing
- バックエンドの型チェックを試行するために `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが、環境で `node` 型定義が見つからず失敗しました（環境依存）。
- フロントエンドの型チェックを試行するために `pnpm -C packages/client exec tsc -p tsconfig.json --noEmit` を実行しましたが、環境で `vite/client` 型定義が見つからず失敗しました（環境依存）。
- Playwright での画面キャプチャを試みましたが、ローカルのアプリサーバーが起動しておらず `ERR_EMPTY_RESPONSE` で取得できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a778a65bac8326aa333218981383dc)