### PR TITLE
fix: 本文なしチャンネル投稿でもハッシュタグを自動付与

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -227,12 +227,13 @@ async function applyLocalNoteRules(user: LocalRuleUser, data: Option): Promise<v
 		data.channel != null &&
 		data.localOnly === false &&
 		!data.reply &&
-		data.text?.trim() &&
-		!data.text.includes(`#${data.channel.name}`)
+		!(data.text ?? "").includes(`#${data.channel.name}`)
 	) {
-		//ローカル投稿でチャンネルで連合有りで返信でなくテキストがあり、
+		//ローカル投稿でチャンネルで連合有りで返信でなく、
 		//すでにタグが含まれていない場合はハッシュタグを自動で付ける
-		data.text += ` #${data.channel.name}`;
+		data.text = data.text?.trim()
+			? `${data.text} #${data.channel.name}`
+			: `#${data.channel.name}`;
 	}
 
 	// ローカル投稿のTwitter/X statusリンクのみ、?以降を取り除く


### PR DESCRIPTION
### Motivation
- チャンネルで公開投稿する際、本文が空の場合に自動でチャンネル名ハッシュタグが付与されずタグ検索や連合で見つかりにくい挙動になっていたため修正しました。\

### Description
- `packages/backend/src/services/note/create.ts` の `applyLocalNoteRules` における条件を `!(data.text ?? "").includes(`#${data.channel.name}`)` に変更し、本文が未定義/空でも判定できるようにしました。\
- 本文がある場合は末尾にスペース区切りで ` #<channelName>` を追加し、本文が空の場合は本文自体を `#<channelName>` に設定する分岐に変更しました。\
- 既存の重複防止（本文中に同一ハッシュタグがある場合は追加しない）は維持しています。\
- 想定される副作用として、画像のみなど本文が無い投稿にもハッシュタグが付与されるため、連合先やハッシュタグ検索での露出が増える可能性があります。\

### Testing
- `pnpm --filter backend run lint` を実行しましたが、`node_modules` 未セットアップにより `rome` が見つからず実行できませんでした（環境要因で失敗）。\
- 変更はローカルでの静的確認と差分確認により挙動を確認済みで、該当ロジックは `applyLocalNoteRules` のハッシュタグ付与部分（`packages/backend/src/services/note/create.ts`）のみを変更しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79d2ed1ec8326a7daf5ebee26e351)