### PR TITLE
Expose per-user renote counts and show them in users tooltip

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/renotes.ts
+++ b/packages/backend/src/server/api/endpoints/notes/renotes.ts
@@ -41,6 +41,7 @@ export const paramDef = {
 		limit: { type: "integer", minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: "string", format: "misskey:id" },
 		untilId: { type: "string", format: "misskey:id" },
+		withUserRenoteCount: { type: "boolean", default: false },
 	},
 	required: ["noteId"],
 } as const;
@@ -88,6 +89,41 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	if (found.length > ps.limit) {
 		found.length = ps.limit;
+	}
+
+	if (!ps.withUserRenoteCount || found.length === 0) {
+		return found;
+	}
+
+	const userIds = [...new Set(found.map((packedNote) => packedNote.userId))];
+
+	if (userIds.length === 0) {
+		return found;
+	}
+
+	const countQuery = Notes.createQueryBuilder("note")
+		.select("note.userId", "userId")
+		.addSelect("COUNT(note.id)", "count")
+		.where("note.renoteId = :renoteId", { renoteId: note.id })
+		.andWhere("note.userId IN (:...userIds)", { userIds })
+		.groupBy("note.userId");
+
+	generateVisibilityQuery(countQuery, user);
+	if (user) generateMutedUserQuery(countQuery, user);
+	if (user) generateBlockedUserQuery(countQuery, user);
+
+	const renoteCountRows = await countQuery.getRawMany<{
+		userId: string;
+		count: string;
+	}>();
+
+	const renoteCountsByUserId = new Map<string, number>(
+		renoteCountRows.map((row) => [row.userId, Number(row.count)])
+	);
+
+	for (const packedNote of found) {
+		(packedNote as Record<string, any>).userRenoteCount =
+			renoteCountsByUserId.get(packedNote.userId) ?? 1;
 	}
 
 	return found;

--- a/packages/client/src/components/MkRenoteButton.vue
+++ b/packages/client/src/components/MkRenoteButton.vue
@@ -46,9 +46,13 @@ useTooltip(buttonRef, async (showing) => {
 	const renotes = await os.api("notes/renotes", {
 		noteId: props.note.id,
 		limit: 11,
+		withUserRenoteCount: true,
 	});
 
 	const users = renotes.map((x) => x.user);
+	const userRenoteCounts = Object.fromEntries(
+		renotes.map((x) => [x.user.id, (x as Record<string, any>).userRenoteCount ?? 1])
+	);
 
 	if (users.length < 1) return;
 
@@ -58,6 +62,8 @@ useTooltip(buttonRef, async (showing) => {
 			showing,
 			users,
 			count: props.count,
+			showCount: true,
+			userRenoteCounts,
 			targetElement: buttonRef.value,
 		},
 		{},

--- a/packages/client/src/components/MkUsersTooltip.vue
+++ b/packages/client/src/components/MkUsersTooltip.vue
@@ -6,30 +6,60 @@
 		@closed="emit('closed')"
 	>
 		<div class="beaffaef">
-			<div v-for="u in users" :key="u.id" class="user">
-				<MkAvatar class="avatar" :user="u" disableLink />
-				<MkUserName class="name" :user="u" :nowrap="true" />
+			<div
+				v-for="(u, index) in displayedUsers"
+				:key="`${u.user.id}-${index}`"
+				class="user"
+			>
+				<MkAvatar class="avatar" :user="u.user" disableLink />
+				<MkUserName class="name" :user="u.user" :nowrap="true" />
+				<span v-if="u.count > 1" class="count">×{{ u.count }}</span>
 			</div>
-			<div v-if="users.length < count" class="omitted">
-				+{{ count - users.length }}
+			<div v-if="shownCount < count" class="omitted">
+				+{{ count - shownCount }}
 			</div>
 		</div>
 	</MkTooltip>
 </template>
 
 <script lang="ts" setup>
-import {} from "vue";
+import { computed } from "vue";
 import MkTooltip from "./MkTooltip.vue";
 
 const props = defineProps<{
 	users: any[]; // TODO
 	count: number;
 	targetElement: HTMLElement;
+	showCount?: boolean;
+	userRenoteCounts?: Record<string, number>;
 }>();
 
 const emit = defineEmits<{
 	(ev: "closed"): void;
 }>();
+
+const displayedUsers = computed(() => {
+	if (!props.showCount) {
+		return props.users.map((user) => ({ user, count: 1 }));
+	}
+
+	const usersById = new Map<string, { user: any; count: number }>();
+
+	for (const user of props.users) {
+		if (usersById.has(user.id)) continue;
+
+		usersById.set(user.id, {
+			user,
+			count: props.userRenoteCounts?.[user.id] ?? 1,
+		});
+	}
+
+	return Array.from(usersById.values());
+});
+
+const shownCount = computed(() =>
+	displayedUsers.value.reduce((sum, user) => sum + user.count, 0)
+);
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
### Motivation

- Provide aggregated per-user renote counts for a note so the UI can indicate when a user renoted the same note multiple times and correctly compute the omitted count. 

### Description

- Add a `withUserRenoteCount` boolean parameter to the `notes/renotes` endpoint and, when enabled, run a grouped count query by `note.userId` and attach `userRenoteCount` to each returned packed note (defaults to `1`).
- Update `MkRenoteButton.vue` to request `withUserRenoteCount: true` for the tooltip and pass `userRenoteCounts` and `showCount` into the popup.
- Update `MkUsersTooltip.vue` to accept `showCount` and `userRenoteCounts`, compute `displayedUsers` with per-user counts, render a `×N` badge when `count > 1`, and use the summed `shownCount` to compute the omitted indicator.

### Testing

- Ran TypeScript typecheck (`tsc --noEmit`) which succeeded.
- Built the project (frontend and backend) which completed successfully.
- Executed the automated test suite (`pnpm -w test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84cd5a2808326b41a17612f10fddf)