### PR TITLE
renote tooltip: 省略時はRT回数優先で並び替え（同数は初RT順）

### DIFF
--- a/packages/client/src/components/MkUsersTooltip.vue
+++ b/packages/client/src/components/MkUsersTooltip.vue
@@ -43,18 +43,33 @@ const displayedUsers = computed(() => {
 		return props.users.map((user) => ({ user, count: 1 }));
 	}
 
-	const usersById = new Map<string, { user: any; count: number }>();
+	const usersById = new Map<string, { user: any; count: number; order: number }>();
 
-	for (const user of props.users) {
+	for (const [order, user] of props.users.entries()) {
 		if (usersById.has(user.id)) continue;
 
 		usersById.set(user.id, {
 			user,
 			count: props.userRenoteCounts?.[user.id] ?? 1,
+			order,
 		});
 	}
 
-	return Array.from(usersById.values());
+	const dedupedUsers = Array.from(usersById.values());
+	const hasOmittedUsers = props.count > 10 &&
+		dedupedUsers.reduce((sum, user) => sum + user.count, 0) < props.count;
+
+	if (!hasOmittedUsers) {
+		return dedupedUsers;
+	}
+
+	return [...dedupedUsers].sort((a, b) => {
+		if (a.count !== b.count) {
+			return b.count - a.count;
+		}
+
+		return a.order - b.order;
+	});
 });
 
 const shownCount = computed(() =>


### PR DESCRIPTION
### Motivation
- renoteツールチップで表示を省略する場合（11人以上）に、現在の「初RT順」だけでは重要なRT者が埋もれるため、省略発生時のみ`RT回数降順`→`同数時は初RT順`で表示したい。 

### Description
- `packages/client/src/components/MkUsersTooltip.vue`を修正し、重複除去時に要素の初出順を保持する`order`を追加しました。 
- `props.count > 10`かつ表示中のRT合計が全RT数より小さい場合に「省略発生」と判定し、そのときのみ`userRenoteCounts`で`count`を比較して降順ソートし、同数時は`order`で初RT順を採用します。 
- `showCount`が無効な場合の既存挙動（ユーザーをそのまま列挙）は変更していません。 
- 想定される副作用として、省略時のみ並びが変わるため、これまでの“初RT順”の見え方が変わるケースがありますが、10人以内（省略なし）は既存順を維持します。 

### Testing
- `pnpm --filter client run lint`を実行しましたが、`node_modules`未インストールの環境で`rome`コマンドが見つからず実行できませんでした（失敗）。
- Playwrightでのページスクリーンショット取得を試みましたが、ローカルサーバが起動しておらず`ERR_EMPTY_RESPONSE`で失敗しました。
- 変更は小規模なUIロジックの変更のみで、自動テスト実行環境が整い次第`pnpm install`後に`pnpm --filter client run lint`と実際のブラウザ確認（ツールチップ表示の省略/非省略ケース）を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8512e252c8326a8f6496b345d17ed)