### PR TITLE
Track and clean up queue for upload-from-url (drive)

### DIFF
--- a/packages/client/src/components/MkDrive.vue
+++ b/packages/client/src/components/MkDrive.vue
@@ -663,12 +663,30 @@ function urlUpload() {
                 placeholder: i18n.ts.uploadFromUrlDescription,
         }).then(({ canceled, result: url }) => {
                 if (canceled || !url) return;
+                const marker = Math.random().toString(); // TODO: UUIDとか使う
+                const queueData = os.addQueue({
+                        endpoint: "drive/files/upload-from-url",
+                        comment: i18n.ts.uploadFromUrl,
+                });
+
+                const mainConnection = stream.useChannel("main");
+                mainConnection.on("urlUploadFinished", (urlResponse) => {
+                        if (urlResponse.marker === marker) {
+                                os.removeQueue(queueData.id);
+                                mainConnection.dispose();
+                        }
+                });
+
                 os.api("drive/files/upload-from-url", {
                         url: url,
                         folderId:
                                 !isVirtualDriveFolder(folder.value) && folder.value
                                         ? folder.value.id
                                         : undefined,
+                        marker,
+                }).catch(() => {
+                        os.removeQueue(queueData.id);
+                        mainConnection.dispose();
                 });
 
                 os.alert({

--- a/packages/client/src/scripts/select-file.ts
+++ b/packages/client/src/scripts/select-file.ts
@@ -90,10 +90,15 @@ function select(
 				if (canceled) return;
 
 				const marker = Math.random().toString(); // TODO: UUIDとか使う
+				const queueData = os.addQueue({
+					endpoint: "drive/files/upload-from-url",
+					comment: i18n.ts.uploadFromUrl,
+				});
 
 				const connection = stream.useChannel("main");
 				connection.on("urlUploadFinished", (urlResponse) => {
 					if (urlResponse.marker === marker) {
+						os.removeQueue(queueData.id);
 						res(multiple ? [urlResponse.file] : urlResponse.file);
 						connection.dispose();
 					}
@@ -104,6 +109,8 @@ function select(
 					folderId,
 					marker,
 				}).catch((err) => {
+					os.removeQueue(queueData.id);
+					connection.dispose();
 					rej(err); // エラー発生時にリジェクト
 				});
 


### PR DESCRIPTION
### Motivation

- Ensure uploads initiated via URL show a queue entry and are properly cleaned up when finished or on error to avoid stuck UI state and lingering stream listeners.

### Description

- Add a `marker` and call `os.addQueue` when starting `drive/files/upload-from-url` in `MkDrive.vue` and `select-file.ts` to display an upload queue entry.  
- Listen on the `main` stream channel for `urlUploadFinished` and match by `marker`, then call `os.removeQueue(queueData.id)` and `connection.dispose()`/`mainConnection.dispose()` when the upload finishes.  
- Remove the queue entry and dispose the stream connection in the API `.catch()` handlers to guarantee cleanup on errors.  
- Propagate the uploaded file back to the caller in `select-file.ts` and resolve/reject promises appropriately.

### Testing

- Built the client TypeScript bundle with `pnpm -w -s build` and checked for compilation errors; the build succeeded.  
- Ran the test suite with `pnpm -w test` and unit tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace7151a68832680d73b568cd0826e)