### PR TITLE
Normalize webhook user references and publish emojiAdded on emoji approval

### DIFF
--- a/packages/backend/src/queue/processors/webhook-deliver.ts
+++ b/packages/backend/src/queue/processors/webhook-deliver.ts
@@ -390,6 +390,34 @@ function getUsername(user?: any): string | undefined {
 		: undefined;
 }
 
+async function resolveUserForWebhook(user?: any): Promise<any | undefined> {
+	if (!user) {
+		return undefined;
+	}
+
+	if (typeof user === "object" && typeof user.username === "string") {
+		return user;
+	}
+
+	const userId = typeof user === "string" ? user : user.id;
+	if (typeof userId !== "string") {
+		return user;
+	}
+
+	const resolved = await Users.findOneBy({ id: userId });
+	if (!resolved) {
+		return user;
+	}
+
+	return {
+		id: resolved.id,
+		name: resolved.name,
+		username: resolved.username,
+		host: resolved.host,
+		avatarUrl: Users.getAvatarUrlSync(resolved),
+	};
+}
+
 function getNoteContentSummary(
 	note: any,
 	userId: string,
@@ -425,14 +453,16 @@ async function typeToBody(jobData: any): Promise<any> {
 		: body.message
 		? body.message.user
 		: undefined;
-	const username = user ? getUsername(user) : undefined;
-	const fullUsername = user
-		? user.name
-			? `${user.name} (${user.username}@${user.host ?? config.host})`
-			: `${user.username}@${user.host ?? config.host}`
+	const normalizedUser = await resolveUserForWebhook(user);
+	const normalizedNoteUser = await resolveUserForWebhook(body.note?.user);
+	const username = normalizedUser ? getUsername(normalizedUser) : undefined;
+	const fullUsername = normalizedUser
+		? normalizedUser.name
+			? `${normalizedUser.name} (${normalizedUser.username}@${normalizedUser.host ?? config.host})`
+			: `${normalizedUser.username}@${normalizedUser.host ?? config.host}`
 		: undefined;
-	const avatar_url = user
-		? user.avatarUrl ?? (await Users.getAvatarUrl(user))
+	const avatar_url = normalizedUser
+		? normalizedUser.avatarUrl ?? (await Users.getAvatarUrl(normalizedUser))
 		: undefined;
 
 	const content =
@@ -533,8 +563,8 @@ async function typeToBody(jobData: any): Promise<any> {
 				username,
 				avatar_url,
 				content: `${body.antenna?.name}📡新着 : ${username}${
-					user.id !== body.note?.user?.id
-						? ` : RT ${getUsername(body.note?.user)}`
+					normalizedUser?.id !== normalizedNoteUser?.id
+						? ` : RT ${getUsername(normalizedNoteUser)}`
 						: ""
 				}${content}`,
 			};

--- a/packages/backend/src/server/api/endpoints/emoji-import-request/approve.ts
+++ b/packages/backend/src/server/api/endpoints/emoji-import-request/approve.ts
@@ -20,6 +20,7 @@ import { createNotification } from "@/services/create-notification.js";
 import { insertModerationLog } from "@/services/insert-moderation-log.js";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import config from "@/config/index.js";
+import { publishBroadcastStream } from "@/services/stream.js";
 
 export const meta = {
 	tags: ["emoji-import-request", "admin"],
@@ -189,6 +190,9 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	await db.queryResultCache!.remove(["meta_emojis"]);
 	await bumpReactionNormalizeCacheVersion();
+	publishBroadcastStream("emojiAdded", {
+		emoji: await Emojis.pack(copied.id),
+	});
 
 	await EmojiImportRequests.update(request.id, {
 		status: "approved",


### PR DESCRIPTION
### Motivation

- Ensure webhook delivery builds consistent user data when `user` can be an id string or partial object so notification payloads (username/avatar/RT detection) are correct.
- Notify real-time clients when an imported emoji is approved so frontends can immediately update their emoji lists.

### Description

- Added `resolveUserForWebhook` to normalize a `user` value that may be an id string, full object, or partial into a consistent object including `avatarUrl` via `Users.getAvatarUrlSync` or `Users.getAvatarUrl` when needed.
- Updated webhook body generation in `typeToBody` to use the normalized user (`normalizedUser`) and normalized note author (`normalizedNoteUser`) for username, `avatar_url`, and RT/renote checks.
- Imported and invoked `publishBroadcastStream` in the emoji import approval endpoint to broadcast an `emojiAdded` event with `emoji: await Emojis.pack(copied.id)` after creating the emoji.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae42c0210c83269d71cf3d89a87e7b)