### PR TITLE
webhookのアンテナ通知でユーザーIDが表示される問題を修正

### DIFF
--- a/packages/backend/src/queue/processors/webhook-deliver.ts
+++ b/packages/backend/src/queue/processors/webhook-deliver.ts
@@ -45,15 +45,18 @@ async function toDiscordEmbeds(
 ): Promise<(DiscordEmbeds | undefined)[] | undefined> {
 	const meta = await fetchMeta();
 	const defaultReaction = meta.defaultReaction;
+	const normalizedNoteUser = await resolveUserForWebhook(body.note?.user);
+	const normalizedMessageUser = await resolveUserForWebhook(body.message?.user);
 	return [
 		body.note
 			? {
 					author: {
-						name: getUsername(body.note.user) ?? "",
-						url: `${config.url}/@${body.note.user?.username}${
-							body.note.user?.host ? `@${body.note.user?.host}` : ""
+						name: getUsername(normalizedNoteUser) ?? "",
+						url: `${config.url}/@${normalizedNoteUser?.username}${
+							normalizedNoteUser?.host ? `@${normalizedNoteUser?.host}` : ""
 						}`,
-						icon_url: body.note.user?.avatarUrl,
+						icon_url:
+							normalizedNoteUser?.avatarUrl ?? body.note.user?.avatarUrl,
 					},
 					title: `投稿${
 						body.note.visibility === "home"
@@ -109,7 +112,7 @@ async function toDiscordEmbeds(
 							? body.note.files[1].thumbnailUrl
 								: body.reaction?.emojiName === defaultReaction || body.reaction?.emojiName.startsWith(`${defaultReaction} (+`) // デフォルトリアクション判定
 									? undefined
-							: body.note.user?.avatarUrl,
+							: normalizedNoteUser?.avatarUrl ?? body.note.user?.avatarUrl,
 					},
 					color: 16757683,
 			  }
@@ -161,11 +164,14 @@ async function toDiscordEmbeds(
 		body.message
 			? {
 					author: {
-						name: getUsername(body.message.user) ?? "",
-						url: `${config.url}/@${body.message.user?.username}${
-							body.message.user?.host ? `@${body.message.user?.host}` : ""
+						name: getUsername(normalizedMessageUser) ?? "",
+						url: `${config.url}/@${normalizedMessageUser?.username}${
+							normalizedMessageUser?.host
+								? `@${normalizedMessageUser?.host}`
+								: ""
 						}`,
-						icon_url: body.message.user?.avatarUrl,
+						icon_url:
+							normalizedMessageUser?.avatarUrl ?? body.message.user?.avatarUrl,
 					},
 					title: `${
 						body.message.group ? `${body.message.group.name} の` : "個人宛の"
@@ -173,8 +179,10 @@ async function toDiscordEmbeds(
 					url: body.message.groupId
 						? `${config.url}/my/messaging/group/${body.message.groupId}`
 						: `${config.url}/my/messaging/${
-								body.message.user?.username +
-								(body.message.user?.host ? `@${body.message.user?.host}` : "")
+								normalizedMessageUser?.username +
+								(normalizedMessageUser?.host
+									? `@${normalizedMessageUser?.host}`
+									: "")
 						  }`,
 					description:
 						((excludeNotPlain(body.message.text)?.length ?? 0) > 100
@@ -210,7 +218,7 @@ async function toDiscordEmbeds(
 							  !body.message.file.isSensitive &&
 							  body.message.file.type?.toLowerCase().startsWith("video")
 							? body.message.file.thumbnailUrl
-							: body.message.user?.avatarUrl,
+							: normalizedMessageUser?.avatarUrl ?? body.message.user?.avatarUrl,
 					},
 					color: 16757683,
 			  }
@@ -222,14 +230,17 @@ async function toSlackEmbeds(data: any): Promise<any[]> {
 	const meta = await fetchMeta();
 	const content = await typeToBody(data);
 	const body = data.content;
+	const normalizedNoteUser = await resolveUserForWebhook(body.note?.user);
+	const normalizedMessageUser = await resolveUserForWebhook(body.message?.user);
 	return [
 		body.note
 			? {
-					author_name: getUsername(body.note.user),
-					author_link: `${config.url}/@${body.note.user?.username}${
-						body.note.user?.host ? `@${body.note.user?.host}` : ""
+					author_name: getUsername(normalizedNoteUser),
+					author_link: `${config.url}/@${normalizedNoteUser?.username}${
+						normalizedNoteUser?.host ? `@${normalizedNoteUser?.host}` : ""
 					}`,
-					author_icon: body.note.user?.avatarUrl,
+					author_icon:
+						normalizedNoteUser?.avatarUrl ?? body.note.user?.avatarUrl,
 					icon_url: content.avatar_url,
 					username: content.username,
 					fallback: emojiEscape(content.content),
@@ -271,7 +282,7 @@ async function toSlackEmbeds(data: any): Promise<any[]> {
 						  !body.note.files[1].isSensitive &&
 						  body.note.files[1].type?.startsWith("image")
 						? body.note.files[1].thumbnailUrl
-						: body.note.user?.avatarUrl,
+						: normalizedNoteUser?.avatarUrl ?? body.note.user?.avatarUrl,
 					footer: meta.name || "Calckey",
 					footer_icon: meta.iconUrl || undefined,
 			  }
@@ -320,11 +331,14 @@ async function toSlackEmbeds(data: any): Promise<any[]> {
 			: undefined,
 		body.message
 			? {
-					author_name: getUsername(body.message.user),
-					author_link: `${config.url}/@${body.message.user?.username}${
-						body.message.user?.host ? `@${body.message.user?.host}` : ""
+					author_name: getUsername(normalizedMessageUser),
+					author_link: `${config.url}/@${normalizedMessageUser?.username}${
+						normalizedMessageUser?.host
+							? `@${normalizedMessageUser?.host}`
+							: ""
 					}`,
-					author_icon: body.message.user?.avatarUrl,
+					author_icon:
+						normalizedMessageUser?.avatarUrl ?? body.message.user?.avatarUrl,
 					icon_url: content.avatar_url,
 					username: content.username,
 					fallback: emojiEscape(content.content),
@@ -335,8 +349,10 @@ async function toSlackEmbeds(data: any): Promise<any[]> {
 					title_link: body.message.groupId
 						? `${config.url}/my/messaging/group/${body.message.groupId}`
 						: `${config.url}/my/messaging/${
-								body.message.user?.username +
-								(body.message.user?.host ? `@${body.message.user?.host}` : "")
+								normalizedMessageUser?.username +
+								(normalizedMessageUser?.host
+									? `@${normalizedMessageUser?.host}`
+									: "")
 						  }`,
 					text: emojiEscape(
 						((excludeNotPlain(body.message.text)?.length ?? 0) > 100
@@ -357,7 +373,7 @@ async function toSlackEmbeds(data: any): Promise<any[]> {
 						  !body.message.file.isSensitive &&
 						  body.message.file.type?.toLowerCase().startsWith("video")
 						? body.message.file.thumbnailUrl
-						: body.message.user?.avatarUrl,
+						: normalizedMessageUser?.avatarUrl ?? body.message.user?.avatarUrl,
 					color: meta.themeColor || "#f8bcba",
 					footer: meta.name || "Calckey",
 					footer_icon: meta.iconUrl || undefined,


### PR DESCRIPTION
### Motivation
- webhook（Discord/Slack埋め込み）で `note.user` / `message.user` が ID 文字列のみのケースにおいてユーザー名ではなく ID が表示されてしまう問題を修正するため。 
- 通知の投稿者表示を解決済みユーザー情報優先にして、埋め込みの表示を一貫させることが目的。 

### Description
- `packages/backend/src/queue/processors/webhook-deliver.ts` の `toDiscordEmbeds` / `toSlackEmbeds` において、`body.note?.user` と `body.message?.user` を `resolveUserForWebhook` で正規化する処理を追加しました。 
- 埋め込み生成時は `author.name` / `author.url` / `icon_url` / `thumbnail`（Discord）および `author_name` / `author_link` / `author_icon` / `thumb_url`（Slack）を、正規化済みユーザー情報（存在すれば）を優先して使用するようにしました。 
- 正規化に失敗した場合は従来の `body.*.user` 情報をフォールバックとして保持します。 
- 変更ファイル: `packages/backend/src/queue/processors/webhook-deliver.ts`。副作用として、ID文字列のみの `user` を解決する際に `Users.findOneBy` による追加の DB クエリが発生する可能性があります。 

### Testing
- 静的チェックとして `pnpm -C packages/backend exec eslint src/queue/processors/webhook-deliver.ts` を試行しましたが、ローカル ESLint 設定（`eslint.config.*`）の違いにより実行できませんでした（エラー発生）。 
- リポジトリ内の `pnpm -C packages/backend run lint` を実行しましたが、`rome` が見つからず実行不可（`node_modules` が未配置のため）。 
- 自動テストは環境制約により実行できませんでしたが、該当ファイルの変更はコミット済みです（変更点は上記ファイルに限定）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae86512b9c832680c8de4ad6aa239c)