### PR TITLE
Add search lookup flow, require auth for searches, and remote emoji fetch

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -5,6 +5,7 @@ introMisskey: "Welcome! Calckey is an open source, decentralized social media pl
   \ that's free forever! \U0001F680"
 monthAndDay: "{month}/{day}"
 search: "Search"
+searchLookupConfirm: "This query can be looked up. Do you want to look it up?"
 notifications: "Notifications"
 username: "Username"
 password: "Password"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -5,6 +5,7 @@ introMisskey: "ようこそ！Calckeyは、オープンソースの非中央集�
 monthAndDay: "{month}月 {day}日"
 mkkey: "もこきー"
 search: "検索・照会"
+searchLookupConfirm: "照会可能なワードです。照会しますか？"
 userSearch: "ユーザ内検索"
 channelSearch: "チャンネル内検索"
 notifications: "通知"

--- a/packages/backend/src/server/api/endpoints/emoji.ts
+++ b/packages/backend/src/server/api/endpoints/emoji.ts
@@ -1,6 +1,11 @@
 import { IsNull } from "typeorm";
 import { Emojis } from "@/models/index.js";
 import define from "../define.js";
+import { ApiError } from "../error.js";
+import { toPuny } from "@/misc/convert-host.js";
+import { getJson } from "@/misc/fetch.js";
+import { genId } from "@/misc/gen-id.js";
+import { toStoredCopyPermission } from "@/misc/copy-permission.js";
 
 export const meta = {
 	tags: ["meta"],
@@ -8,6 +13,14 @@ export const meta = {
 	requireCredential: false,
 	allowGet: true,
 	cacheSec: 3600,
+
+	errors: {
+		noSuchEmoji: {
+			message: "No such emoji.",
+			code: "NO_SUCH_EMOJI",
+			id: "6023366f-c5a9-4f6d-a7f8-bff2cc53f963",
+		},
+	},
 
 	res: {
 		type: "object",
@@ -30,13 +43,97 @@ export const paramDef = {
 	required: ["name"],
 } as const;
 
+type RemoteEmojiPayload = {
+	name?: string;
+	aliases?: unknown;
+	category?: string | null;
+	url?: string;
+	uri?: string | null;
+	copyPermission?: string | null;
+	licenseName?: string | null;
+	usageInfo?: string | null;
+	creator?: string | null;
+	description?: string | null;
+	isBasedOnUrl?: string | null;
+	license?: string | null;
+	sensitive?: boolean;
+};
+
+async function fetchRemoteEmoji(name: string, host: string) {
+	const normalizedHost = toPuny(host);
+	const apiurl = `https://${normalizedHost}/api/emoji?name=${encodeURIComponent(name)}`;
+	const remote = (await getJson(
+		apiurl,
+		"application/json, */*",
+		5000,
+	)) as RemoteEmojiPayload;
+
+	if (!remote?.url) {
+		return null;
+	}
+
+	const now = new Date();
+	const normalizedName = remote.name ?? name;
+	const exists = await Emojis.findOneBy({
+		name: normalizedName,
+		host: normalizedHost,
+	});
+
+	const updateData = {
+		updatedAt: now,
+		name: normalizedName,
+		host: normalizedHost,
+		category: remote.category ?? null,
+		originalUrl: remote.url,
+		publicUrl: remote.url,
+		uri: remote.uri ?? null,
+		aliases: Array.isArray(remote.aliases)
+			? remote.aliases.filter((x): x is string => typeof x === "string")
+			: [],
+		copyPermission: toStoredCopyPermission(remote.copyPermission ?? null),
+		licenseName: remote.licenseName ?? null,
+		usageInfo: remote.usageInfo ?? null,
+		creator: remote.creator ?? null,
+		description: remote.description ?? null,
+		isBasedOnUrl: remote.isBasedOnUrl ?? null,
+		license: remote.license ?? null,
+		sensitive: remote.sensitive ?? false,
+	};
+
+	if (exists) {
+		await Emojis.update({ id: exists.id }, updateData);
+		return await Emojis.findOneBy({ id: exists.id });
+	}
+
+	const inserted = await Emojis.insert({
+		id: genId(),
+		createdAt: now,
+		usageVisibility: "public",
+		...updateData,
+	});
+
+	return await Emojis.findOneBy(inserted.identifiers[0]);
+}
+
 export default define(meta, paramDef, async (ps, me) => {
-	const emoji = await Emojis.findOneOrFail({
+	const isLocalHost = ps.host == null || ps.host === "" || ps.host === ".";
+	const whereHost = isLocalHost ? IsNull() : toPuny(ps.host);
+
+	let emoji = await Emojis.findOne({
 		where: {
 			name: ps.name,
-			host: ps.host || IsNull(),
+			host: whereHost,
 		},
 	});
+
+	// 未知リモート絵文字の照会は認証済みユーザー時のみ行う
+	if (!emoji && !isLocalHost && me) {
+		emoji = await fetchRemoteEmoji(ps.name, ps.host);
+	}
+
+	if (!emoji) {
+		throw new ApiError(meta.errors.noSuchEmoji);
+	}
 
 	return Emojis.pack(emoji);
 });

--- a/packages/backend/src/server/api/endpoints/hashtags/search.ts
+++ b/packages/backend/src/server/api/endpoints/hashtags/search.ts
@@ -4,7 +4,7 @@ import { Hashtags } from "@/models/index.js";
 export const meta = {
 	tags: ["hashtags"],
 
-	requireCredential: false,
+	requireCredential: true,
 	requireCredentialPrivateMode: true,
 
 	res: {

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -15,7 +15,7 @@ import { createFollowingExistsCondition } from "../../common/following-exists-co
 export const meta = {
 	tags: ["notes"],
 
-	requireCredential: false,
+	requireCredential: true,
 	requireCredentialPrivateMode: true,
 
 	res: {

--- a/packages/backend/src/server/api/endpoints/users/search.ts
+++ b/packages/backend/src/server/api/endpoints/users/search.ts
@@ -6,7 +6,7 @@ import define from "../../define.js";
 export const meta = {
 	tags: ["users"],
 
-	requireCredential: false,
+	requireCredential: true,
 	requireCredentialPrivateMode: true,
 
 	description: "Search for users.",

--- a/packages/client/src/scripts/search.ts
+++ b/packages/client/src/scripts/search.ts
@@ -1,8 +1,101 @@
 import * as os from "@/os";
 import { i18n } from "@/i18n";
 import { mainRouter } from "@/router";
+import { $i } from "@/account";
+import { pleaseLogin } from "@/scripts/please-login";
+
+type LookupTarget =
+	| { type: "user"; path: string }
+	| { type: "tag"; path: string }
+	| { type: "emoji"; path: string; name: string; host?: string }
+	| { type: "uri"; uri: string };
+
+function getLookupTarget(q: string): LookupTarget | null {
+	if (q.startsWith("@") && !q.includes(" ")) {
+		return {
+			type: "user",
+			path: `/${q}`,
+		};
+	}
+
+	if (q.startsWith("#")) {
+		return {
+			type: "tag",
+			path: `/tags/${encodeURIComponent(q.slice(1))}`,
+		};
+	}
+
+	const emojiMatch = q.match(/^:([^\s:@]+)@([^\s:@]+):$/);
+	if (emojiMatch) {
+		const emojiName = emojiMatch[1];
+		const emojiHost = emojiMatch[2];
+		const emojiCode = `:${emojiName}${emojiHost ? `@${emojiHost}` : ""}:`;
+
+		return {
+			type: "emoji",
+			name: emojiName,
+			host: emojiHost,
+			path: `/emoji/${encodeURIComponent(emojiCode)}`,
+		};
+	}
+
+	if (q.startsWith("https://")) {
+		return {
+			type: "uri",
+			uri: q,
+		};
+	}
+
+	return null;
+}
+
+async function execLookup(lookupTarget: LookupTarget): Promise<boolean> {
+	if (lookupTarget.type === "uri") {
+		const promise = os.api("ap/show", {
+			uri: lookupTarget.uri,
+		});
+
+		os.promiseDialog(promise, null, null, i18n.ts.fetchingAsApObject);
+
+		const res = await promise;
+
+		if (res.type === "User") {
+			mainRouter.push(`/@${res.object.username}@${res.object.host}`);
+			return true;
+		}
+
+		if (res.type === "Note") {
+			mainRouter.push(`/notes/${res.object.id}`);
+			return true;
+		}
+
+		return false;
+	}
+
+	if (lookupTarget.type === "emoji") {
+		try {
+			await os.apiGet("emoji", {
+				name: lookupTarget.name,
+				...(lookupTarget.host ? { host: lookupTarget.host } : {}),
+			});
+		} catch {
+			return false;
+		}
+
+		mainRouter.push(lookupTarget.path);
+		return true;
+	}
+
+	mainRouter.push(lookupTarget.path);
+	return true;
+}
 
 export async function search(channel?: string, user?: string) {
+	if (!$i) {
+		pleaseLogin(window.location.href);
+		return;
+	}
+
 	const { canceled, result: query } = await os.inputText({
 		title: channel
 			? i18n.ts.channelSearch
@@ -18,14 +111,23 @@ export async function search(channel?: string, user?: string) {
 
 	const q = query.trim();
 
-	if (!(channel || user) && q.startsWith("@") && !q.includes(" ")) {
-		mainRouter.push(`/${q}`);
-		return;
-	}
+	if (!(channel || user)) {
+		const lookupTarget = getLookupTarget(q);
 
-	if (!(channel || user) && q.startsWith("#")) {
-		mainRouter.push(`/tags/${encodeURIComponent(q.substr(1))}`);
-		return;
+		if (lookupTarget) {
+			const { canceled: lookupCanceled } = await os.confirm({
+				title: i18n.ts.lookup,
+				text: i18n.ts.searchLookupConfirm,
+				okText: i18n.ts.yes,
+				cancelText: i18n.ts.no,
+			});
+
+			if (!lookupCanceled) {
+				if (await execLookup(lookupTarget)) {
+					return;
+				}
+			}
+		}
 	}
 
 	// like 2018/03/12
@@ -47,24 +149,6 @@ export async function search(channel?: string, user?: string) {
 			iconOnly: true,
 			autoClose: true,
 		});
-		return;
-	}
-
-	if (!(channel || user) && q.startsWith("https://")) {
-		const promise = os.api("ap/show", {
-			uri: q,
-		});
-
-		os.promiseDialog(promise, null, null, i18n.ts.fetchingAsApObject);
-
-		const res = await promise;
-
-		if (res.type === "User") {
-			mainRouter.push(`/@${res.object.username}@${res.object.host}`);
-		} else if (res.type === "Note") {
-			mainRouter.push(`/notes/${res.object.id}`);
-		}
-
 		return;
 	}
 


### PR DESCRIPTION
### Motivation

- Provide an inline "lookup" behavior in the search UI so queries like user handles, tags, emoji codes, and Fediverse URIs can be directly resolved and navigated. 
- Restrict certain indexing/search endpoints to authenticated clients to respect private-mode and access control. 
- Support resolving remote emoji by querying a host's `/api/emoji` and caching/storing the result in the local emoji store.

### Description

- Added localized confirmation strings `searchLookupConfirm` to `locales/en-US.yml` and `locales/ja-JP.yml`.
- Rewrote client search logic in `packages/client/src/scripts/search.ts` to detect lookup targets (`user`, `tag`, `emoji`, `uri`), show a confirmation dialog with `i18n.ts.searchLookupConfirm`, require login via `$i`/`pleaseLogin`, and execute lookups via `ap/show` (for URIs) or `emoji` API calls; successful lookups navigate with `mainRouter.push`.
- Added helper types and functions `getLookupTarget` and `execLookup` to encapsulate detection and resolution of special queries.
- Changed search endpoints to require credentials by setting `requireCredential: true` in `hashtags/search.ts`, `notes/search.ts`, and `users/search.ts` to enforce authenticated access and `requireCredentialPrivateMode: true` remains in place.
- Extended the emoji endpoint (`packages/backend/.../emoji.ts`) to support fetching a remote emoji from `https://<host>/api/emoji?name=...` using `toPuny`, `getJson`, `genId`, and `toStoredCopyPermission`; it now inserts or updates stored emoji records and returns them.
- Added structured error handling to the emoji endpoint using `ApiError` with an explicit `noSuchEmoji` error when an emoji cannot be found locally or remotely, and limited remote emoji lookup to authenticated users only.

### Testing

- Ran the TypeScript build and lint checks for the repo and they completed successfully.
- Executed the existing backend and client unit test suites and the integration smoke tests; all tests passed. 
- Manually exercised the new client lookup flows against local backend and a remote instance during development and observed expected navigation and emoji resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af98c8753c83268b57352ae73640d4)