### PR TITLE
Fix: 管理APIでライセンス名がクリアされない問題を修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/emoji/set-license-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/set-license-bulk.ts
@@ -134,7 +134,7 @@ export default define(meta, paramDef, async (ps) => {
 			update.creator = null;
 		} else {
 			update.copyPermission = toStoredCopyPermission(ps.copyPermission ?? emoji.copyPermission);
-			update.licenseName = ps.licenseName ?? emoji.licenseName;
+			update.licenseName = ps.licenseName !== undefined ? ps.licenseName : emoji.licenseName;
 			update.creator = ps.creator ?? emoji.creator;
 		}
 		if (ps.usageVisibility !== undefined) update.usageVisibility = ps.usageVisibility;

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -146,7 +146,7 @@ export default define(meta, paramDef, async (ps) => {
 		update.creator = null;
 	} else {
 		update.copyPermission = toStoredCopyPermission(ps.copyPermission ?? emoji.copyPermission);
-		update.licenseName = ps.licenseName ?? emoji.licenseName;
+		update.licenseName = ps.licenseName !== undefined ? ps.licenseName : emoji.licenseName;
 		update.creator = ps.creator ?? emoji.creator;
 	}
 


### PR DESCRIPTION
### Motivation
- 管理画面から絵文字の `ライセンス名` を「設定しない（クリア）」した際に、既存の `licenseName` が残ってしまう不具合を修正するため。

### Description
- `admin/emoji/update` にて `licenseName` の代入判定を `ps.licenseName ?? emoji.licenseName` から `ps.licenseName !== undefined ? ps.licenseName : emoji.licenseName` に変更して、`null` を明示的に渡した場合に DB に `null` が反映されるようにした。 
- 同様の修正を `admin/emoji/set-license-bulk` に適用して、一括更新でも同じ挙動に統一した。 
- `isTextOnly` の絵文字に対する既存の固定挙動（`licenseName = "CC0 1.0 Universal"` 等）は変更していない。

### Testing
- `git diff --check` を実行し問題ないことを確認済み（成功）。
- 型チェックとして `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行したが、環境依存で `@types/node` が不足しているため型チェックは失敗した（環境依存のエラー）。
- 変更ファイル：`packages/backend/src/server/api/endpoints/admin/emoji/update.ts` と `packages/backend/src/server/api/endpoints/admin/emoji/set-license-bulk.ts`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd601861083269d6220d34632c595)