### PR TITLE
Add client-side acct→user resolver with caching and optimize server user lookup

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/show.ts
+++ b/packages/backend/src/server/api/endpoints/users/show.ts
@@ -120,20 +120,28 @@ export default define(meta, paramDef, async (ps, me) => {
 			detail: true,
 		});
 	}
-		// Lookup user
-		if (typeof ps.host === "string" && typeof ps.username === "string") {
-			user = await resolveUser(ps.username, ps.host).catch((e) => {
-				apiLogger.warn(`failed to resolve remote user: ${e}`);
-				throw new ApiError(meta.errors.failedToResolveRemoteUser);
-			});
-		} else {
-			const q: FindOptionsWhere<User> =
-				ps.userId != null
-					? { id: ps.userId }
-					: { usernameLower: ps.username?.toLowerCase(), host: IsNull() };
+	// Lookup user
+	if (typeof ps.username === "string") {
+		if (typeof ps.host === "string") {
+			const usernameLower = ps.username.toLowerCase();
+			user = await Users.findOneBy({ usernameLower, host: ps.host });
 
-			user = await Users.findOneBy(q);
+			if (user == null) {
+				user = await resolveUser(ps.username, ps.host).catch((e) => {
+					apiLogger.warn(`failed to resolve remote user: ${e}`);
+					throw new ApiError(meta.errors.failedToResolveRemoteUser);
+				});
+			}
+		} else {
+			user = await Users.findOneBy({
+				usernameLower: ps.username.toLowerCase(),
+				host: IsNull(),
+			});
 		}
+	} else {
+		const q: FindOptionsWhere<User> = { id: ps.userId };
+		user = await Users.findOneBy(q);
+	}
 
 		if (
 			user == null ||

--- a/packages/client/src/pages/follow.vue
+++ b/packages/client/src/pages/follow.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts" setup>
 import {} from "vue";
-import * as Acct from "calckey-js/built/acct";
 import * as os from "@/os";
 import { mainRouter } from "@/router";
 import { i18n } from "@/i18n";
+import { resolveUserFromAcct } from "@/scripts/resolve-user-from-acct";
 
 async function follow(user): Promise<void> {
 	const { canceled } = await os.confirm({
@@ -51,7 +51,7 @@ if (acct.startsWith("https://")) {
 		}
 	});
 } else {
-	promise = os.api("users/show", Acct.parse(acct));
+	promise = resolveUserFromAcct(acct);
 	promise.then((user) => {
 		follow(user);
 	});

--- a/packages/client/src/pages/user/followers.vue
+++ b/packages/client/src/pages/user/followers.vue
@@ -24,10 +24,9 @@ import {
 	onUnmounted,
 	watch,
 } from "vue";
-import * as Acct from "calckey-js/built/acct";
 import * as misskey from "calckey-js";
 import XFollowList from "./follow-list.vue";
-import * as os from "@/os";
+import { resolveUserFromAcct } from "@/scripts/resolve-user-from-acct";
 import { definePageMetadata } from "@/scripts/page-metadata";
 import { i18n } from "@/i18n";
 
@@ -44,7 +43,7 @@ let error = $ref(null);
 function fetchUser(): void {
 	if (props.acct == null) return;
 	user = null;
-	os.api("users/show", Acct.parse(props.acct))
+	resolveUserFromAcct(props.acct)
 		.then((u) => {
 			user = u;
 		})

--- a/packages/client/src/pages/user/following.vue
+++ b/packages/client/src/pages/user/following.vue
@@ -24,10 +24,9 @@ import {
 	onUnmounted,
 	watch,
 } from "vue";
-import * as Acct from "calckey-js/built/acct";
 import * as misskey from "calckey-js";
 import XFollowList from "./follow-list.vue";
-import * as os from "@/os";
+import { resolveUserFromAcct } from "@/scripts/resolve-user-from-acct";
 import { definePageMetadata } from "@/scripts/page-metadata";
 import { i18n } from "@/i18n";
 
@@ -44,7 +43,7 @@ let error = $ref(null);
 function fetchUser(): void {
 	if (props.acct == null) return;
 	user = null;
-	os.api("users/show", Acct.parse(props.acct))
+	resolveUserFromAcct(props.acct)
 		.then((u) => {
 			user = u;
 		})

--- a/packages/client/src/pages/user/index.vue
+++ b/packages/client/src/pages/user/index.vue
@@ -33,12 +33,11 @@
 <script lang="ts" setup>
 import { defineAsyncComponent, computed, watch } from "vue";
 import calcAge from "s-age";
-import * as Acct from "calckey-js/built/acct";
 import type * as misskey from "calckey-js";
 import { getScrollPosition } from "@/scripts/scroll";
 import number from "@/filters/number";
 import { userPage, acct as getAcct } from "@/filters/user";
-import * as os from "@/os";
+import { resolveUserFromAcct } from "@/scripts/resolve-user-from-acct";
 import { useRouter } from "@/router";
 import { definePageMetadata } from "@/scripts/page-metadata";
 import { i18n } from "@/i18n";
@@ -76,7 +75,7 @@ function userSearch() {
 function fetchUser(): void {
 	if (props.acct == null) return;
 	user = null;
-	os.api("users/show", Acct.parse(props.acct))
+	resolveUserFromAcct(props.acct)
 		.then((u) => {
 			user = u;
 		})

--- a/packages/client/src/scripts/resolve-user-from-acct.ts
+++ b/packages/client/src/scripts/resolve-user-from-acct.ts
@@ -1,0 +1,45 @@
+import * as Acct from "calckey-js/built/acct";
+import type * as misskey from "calckey-js";
+import * as os from "@/os";
+
+const CACHE_TTL_MS = 1000 * 60 * 30;
+
+type UserIdCacheEntry = {
+	userId: string;
+	cachedAt: number;
+};
+
+const userIdCache = new Map<string, UserIdCacheEntry>();
+
+function normalizeAcct(acct: string): string {
+	return acct.trim().toLowerCase();
+}
+
+export async function resolveUserFromAcct(
+	acct: string,
+): Promise<misskey.entities.UserDetailed> {
+	const normalizedAcct = normalizeAcct(acct);
+	const cached = userIdCache.get(normalizedAcct);
+	if (cached != null && Date.now() - cached.cachedAt <= CACHE_TTL_MS) {
+		return await os.api("users/show", { userId: cached.userId }).catch(async () => {
+			userIdCache.delete(normalizedAcct);
+			const user = await os.api("users/show", Acct.parse(acct));
+			userIdCache.set(normalizedAcct, {
+				userId: user.id,
+				cachedAt: Date.now(),
+			});
+			return user;
+		});
+	}
+
+	if (cached != null) {
+		userIdCache.delete(normalizedAcct);
+	}
+
+	const user = await os.api("users/show", Acct.parse(acct));
+	userIdCache.set(normalizedAcct, {
+		userId: user.id,
+		cachedAt: Date.now(),
+	});
+	return user;
+}


### PR DESCRIPTION
### Motivation
- Reduce unnecessary remote user resolution from the client by centralizing acct parsing and caching resolved user IDs.  
- Avoid remote resolution on the server when a local user record already exists for a given `username`+`host`.  

### Description
- Add `src/scripts/resolve-user-from-acct.ts` which exposes `resolveUserFromAcct(acct)` and implements a 30-minute (`1000 * 60 * 30`) in-memory cache keyed by normalized (trimmed, lowercased) `acct` strings.  
- Update several client pages (`follow.vue`, `user/index.vue`, `user/followers.vue`, `user/following.vue`) to use `resolveUserFromAcct` instead of calling `os.api("users/show", Acct.parse(acct))` directly and remove the now-unused `Acct` imports.  
- Cache behavior: on hit it calls `users/show` by `userId`, and on failure deletes the cache entry and re-resolves from the `acct` string; on miss it resolves via `Acct.parse` and stores `{ userId, cachedAt }`.  
- Backend `users/show` endpoint was adjusted to first try finding a local user by `{ usernameLower, host }` when both `ps.username` and `ps.host` are provided, falling back to `resolveUser` only if no local user is found; also restructured lookup branches to handle the `username` vs `userId` cases more clearly.  

### Testing
- Ran TypeScript type checks and client build locally; both completed successfully.  
- Ran automated unit tests (frontend + backend test suites); all tests passed.  
- Performed a quick manual verification of following/profile pages to confirm `resolveUserFromAcct` is used and cached lookups return expected `UserDetailed` objects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b077eb93d08326a87f4bed51dbe9a1)