### PR TITLE
users/notes系のpack処理でdrive_file参照を事前バッチ化

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -7,6 +7,7 @@
 import { In, IsNull } from "typeorm";
 import * as mfm from "mfm-js";
 import { Note } from "@/models/entities/note.js";
+import type { DriveFile } from "@/models/entities/drive-file.js";
 import type { User } from "@/models/entities/user.js";
 import type { Channel } from "@/models/entities/channel.js";
 import {
@@ -114,6 +115,8 @@ type NotePackHint = {
 	channelMap?: Map<string, Channel>;
 	/** packMany 用: reply/renote 用ノートを一括取得した Map */
 	noteMap?: Map<Note["id"], Note>;
+	/** packMany 用: ノート添付ファイルを一括 pack した Map */
+	packedFileMap?: Map<DriveFile["id"], Packed<"DriveFile">>;
 };
 
 const NOTE_PACK_CACHE_TTL_MS = 30 * 1000;
@@ -663,7 +666,11 @@ export const NoteRepository = db.getRepository(Note).extend({
 			fileIds: isVisible ? note.fileIds : [],
 			files:
 				isVisible && note.fileIds.length > 0
-					? DriveFiles.packMany(note.fileIds)
+					? hint.packedFileMap
+						? note.fileIds
+								.map((fileId) => hint.packedFileMap?.get(fileId))
+								.filter((file): file is Packed<"DriveFile"> => file != null)
+						: DriveFiles.packMany(note.fileIds)
 					: [],
 			replyId: note.replyId,
 			renoteId: note.renoteId,
@@ -935,6 +942,52 @@ export const NoteRepository = db.getRepository(Note).extend({
                                         : [],
                         ]);
 
+		const noteFilesToPackIds = new Set<DriveFile["id"]>();
+		for (const note of notes) {
+			for (const fileId of note.fileIds) {
+				noteFilesToPackIds.add(fileId);
+			}
+		}
+		for (const note of notesForReplyRenote) {
+			for (const fileId of note.fileIds) {
+				noteFilesToPackIds.add(fileId);
+			}
+		}
+
+		const allUsersForImageResolve = [
+			...usersForNotes,
+			...notesForReplyRenote
+				.map((note) => note.user)
+				.filter((user): user is User => user != null),
+		];
+		const userImageIds = new Set<DriveFile["id"]>();
+		for (const user of allUsersForImageResolve) {
+			if (user.avatarId != null) userImageIds.add(user.avatarId);
+			if (user.bannerId != null) userImageIds.add(user.bannerId);
+		}
+
+		const allDriveFileIds = [...new Set([...noteFilesToPackIds, ...userImageIds])];
+		const driveFiles =
+			allDriveFileIds.length > 0
+				? await DriveFiles.findBy({ id: In(allDriveFileIds) })
+				: [];
+		const driveFileMap = new Map(driveFiles.map((file) => [file.id, file]));
+
+		for (const user of allUsersForImageResolve) {
+			if (user.avatar === undefined && user.avatarId) {
+				user.avatar = driveFileMap.get(user.avatarId) ?? null;
+			}
+			if (user.banner === undefined && user.bannerId) {
+				user.banner = driveFileMap.get(user.bannerId) ?? null;
+			}
+		}
+
+		const noteFilesToPack = [...noteFilesToPackIds]
+			.map((fileId) => driveFileMap.get(fileId))
+			.filter((file): file is NonNullable<typeof file> => file != null);
+		const packedFiles = await DriveFiles.packMany(noteFilesToPack);
+		const packedFileMap = new Map(packedFiles.map((file) => [file.id, file]));
+
                 const userMap = new Map(usersForNotes.map((u) => [u.id, u]));
                 const channelMap = new Map(channelsForNotes.map((c) => [c.id, c]));
                 const noteMap = new Map(notesForReplyRenote.map((n) => [n.id, n]));
@@ -947,6 +1000,7 @@ export const NoteRepository = db.getRepository(Note).extend({
                         userMap,
                         channelMap,
                         noteMap,
+			packedFileMap,
                 };
 
                 const promises = await Promise.allSettled(


### PR DESCRIPTION
### Motivation
- 同一リクエスト内で同一の `drive_file` SELECT が大量に発生して応答遅延を招いているため、`pack`/`packMany` 内の `DriveFiles` 参照をまとめて読み出すことで N+1 問題を緩和する。

### Description
- `NotePackHint` に `packedFileMap` を追加し、`NoteRepository.packMany` が収集した添付ファイルの `Packed<"DriveFile">` を `pack` 側で再利用する仕組みを導入しました。  
- `packMany` 内でノート本体と reply/renote の `fileIds`、および関連ユーザの `avatarId`/`bannerId` を先に集めて `DriveFiles.findBy({ id: In(...) })` を一度だけ実行し、まとめて `DriveFiles.packMany` を呼んで `packedFileMap` を構築するようにしました。  
- 取得した `drive_file` エンティティで関連ユーザの `avatar`/`banner` を事前補完することで、`Users.pack` 側での個別 `DriveFiles.findOneBy` の発生も抑制します。  
- `pack` 実行時は `hint.packedFileMap` を参照して個別 `DriveFiles.packMany(note.fileIds)` を回避し、既に packed されたオブジェクトを再利用します。

### Testing
- 型チェックとして `pnpm -C packages/backend exec tsc -p tsconfig.json --noEmit` を実行しましたが `Cannot find type definition file for 'node'` により失敗しました。  
- 依存導入のために `pnpm install --frozen-lockfile` を試みましたが、`pnpm-lock.yaml` の破損により失敗しました（ロックファイルの修復が必要です）。  
- 上記の理由により自動ビルド/型検査は未完了で、追加の CI 環境での検証を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07c53f5f08326953ff03dc7019a75)