### PR TITLE
URLサマリーでTwitter playerカード時に大きいサムネイルを優先

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -115,7 +115,7 @@ function isSensitiveFromHeadersAndHtml(
 
 /**
  * HTMLから「大きくサムネイルを表示してよさそう」かどうかを判定する。
- * twitter:card summary_large_image または robots に max-image-preview:large があれば true。
+ * twitter:card summary_large_image/player または robots に max-image-preview:large があれば true。
  * @internal
  */
 function preferLargeThumbnailFromHtml(html: string | null): boolean {
@@ -124,7 +124,7 @@ function preferLargeThumbnailFromHtml(html: string | null): boolean {
 	const twitterCard =
 		$('meta[name="twitter:card"]').attr("content")?.trim() ??
 		$('meta[property="twitter:card"]').attr("content")?.trim();
-	if (twitterCard === "summary_large_image") return true;
+	if (twitterCard === "summary_large_image" || twitterCard === "player") return true;
 	const robots = $('meta[name="robots"]').attr("content") ?? "";
 	if (/max-image-preview:\s*large/i.test(robots)) return true;
 	return false;
@@ -752,6 +752,10 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
     }
     // Google Maps 専用処理でサムネイルを付与した場合のみ大きい表示を希望
     if (googleMapsThumbnailAssigned) {
+      summaryPreferLargeThumbnail = true;
+    }
+    // player 情報がある場合も大きい表示を希望
+    if (summary.player?.url) {
       summaryPreferLargeThumbnail = true;
     }
 


### PR DESCRIPTION
### Motivation
- Twitter の `player` カードやページから返される `player` 情報がある場合にも、大きなサムネイル表示（`preferLargeThumbnail`）を有効化したいための対応。これにより動画埋め込みなどで視認性の高いプレビューを出せるようにします。
- 実装によりリンクカードの表示サイズが増えるため、UIの一覧密度やレイアウトに影響が出る可能性があります。

### Description
- `packages/backend/src/server/web/url-preview.ts` の `preferLargeThumbnailFromHtml` を拡張し、`twitter:card` が `summary_large_image` に加えて `player` の場合も `true` を返すように変更しました（コメントも更新）。
- URLプレビュー生成の最終段で、`summary.player?.url` が存在する場合に `summary.preferLargeThumbnail` を強制的に `true` にする処理を追加しました（`summary.player` があるが meta が欠けている場合も拾うため）。
- 変更ファイルは `packages/backend/src/server/web/url-preview.ts` です。副作用として `player` 情報を持つ全てのプレビューで大きいサムネイルが有効になり、従来より大きなカードが増える点に注意してください。

### Testing
- `pnpm --filter backend run lint` を実行しましたが、`rome` がローカルに見つからず失敗しました（`node_modules` 未構築のため実行不可）。
- 変更はローカルでソースに適用・コミット済み（`git` による差分確認で `packages/backend/src/server/web/url-preview.ts` の該当箇所が更新されたことを確認）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b352be18508326a3a02027e889744d)