### PR TITLE
URLプレビュー: Xのメディア時のみサムネイル拡大フラグを有効化

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -141,6 +141,56 @@ function preferLargeThumbnailFromHtml(html: string | null): boolean {
 	return false;
 }
 
+function isXLikeHostname(hostname: string): boolean {
+	const normalized = hostname.toLowerCase();
+	return [
+		"x.com",
+		"www.x.com",
+		"mobile.x.com",
+		"twitter.com",
+		"www.twitter.com",
+		"mobile.twitter.com",
+	].includes(normalized);
+}
+
+/**
+ * X(Twitter) のサムネイルURLがメディア由来かどうかを判定する。
+ * アイコン・汎用画像と見なせるものは false を返す。
+ */
+function hasXMediaThumbnail(thumbnail: string | null | undefined): boolean {
+	if (!thumbnail) return false;
+
+	try {
+		const thumbnailUrl = new URL(thumbnail);
+		const host = thumbnailUrl.hostname.toLowerCase();
+		const path = thumbnailUrl.pathname.toLowerCase();
+
+		if (host === "pbs.twimg.com") {
+			return (
+				path.startsWith("/media/") ||
+				path.startsWith("/ext_tw_video_thumb/") ||
+				path.startsWith("/amplify_video_thumb/") ||
+				path.startsWith("/tweet_video_thumb/")
+			);
+		}
+
+		if (host.endsWith("twimg.com")) {
+			return false;
+		}
+
+		if (
+			isXLikeHostname(host) &&
+			(path === "/favicon.ico" || path.startsWith("/icons/"))
+		) {
+			return false;
+		}
+	} catch {
+		return false;
+	}
+
+	return false;
+}
+
 /**
  * HTML から og:image / twitter:image を用いてサムネイルを補完する。
  * すでに summary.thumbnail が存在する場合は何もしない。
@@ -191,6 +241,13 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
 
   const redirectedUrl = await resolveShortUrlIfNeeded(url);
   const effectiveUrl = redirectedUrl ?? url;
+  const isXPreviewUrl = (() => {
+		try {
+			return isXLikeHostname(new URL(effectiveUrl).hostname);
+		} catch {
+			return false;
+		}
+	})();
 
   // SteamのApp IDを取得
   const steamAppId = isSteamUrl(effectiveUrl);
@@ -769,6 +826,11 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
     if (summary.player?.url) {
       summaryPreferLargeThumbnail = true;
     }
+
+		if (isXPreviewUrl) {
+			summaryPreferLargeThumbnail =
+				!!summary.player?.url || hasXMediaThumbnail(summary.thumbnail);
+		}
 
     summary.isSensitive = summaryIsSensitive;
     summary.preferLargeThumbnail = summaryPreferLargeThumbnail;


### PR DESCRIPTION
## 概要
- URLプレビュー生成処理で、X(Twitter) URLの場合の `preferLargeThumbnail` 判定を調整しました。
- `preferLargeThumbnail` は、X投稿にメディア由来のサムネイルがある場合のみ `true` になるようにしました。
- アイコンや汎用サムネイルと判定されるケースでは `false` のままにしています。

## 変更内容
- `packages/backend/src/server/web/url-preview.ts`
  - X/Twitter のホスト判定ヘルパーを追加
  - Xサムネイルがメディア由来かを判定するヘルパーを追加
    - `pbs.twimg.com/media/` などのメディア系パスのみ `true`
    - `twimg.com` 系の汎用/アイコン系は `false`
  - 通常の `preferLargeThumbnail` 算出後、X URL の場合のみ専用ロジックで上書き
    - `player.url` がある場合は `true`
    - それ以外は「メディア由来サムネイル」のときのみ `true`

## 期待される効果
- X投稿のURLプレビューで、メディアがある投稿は大きいサムネイル表示になりやすくなります。
- アイコンや汎用画像しかない場合に不必要に大きいサムネイル表示になることを防ぎます。

## 副作用・注意点
- X側のサムネイルURL構造が将来変更された場合、メディア判定が外れて `preferLargeThumbnail` が `false` になる可能性があります。
- `pbs.twimg.com` のメディア系既知パスに依存しているため、新しいパス形式が増えた場合は判定条件の追加が必要です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60d0542ec83268c91e31201618210)