### PR TITLE
壁紙同期一覧の復元不具合修正

### DIFF
--- a/packages/client/src/scripts/wallpaper-sync.ts
+++ b/packages/client/src/scripts/wallpaper-sync.ts
@@ -50,12 +50,18 @@ function writeLocalWallpapers(wallpapers: string[]): void {
 }
 
 export function readLocalWallpaperEntries(): WallpaperEntry[] {
+	const wallpapers = readLocalWallpapers();
 	const savedEntries = localStorage.getItem(wallpaperEntriesStorageKey);
 	if (savedEntries != null) {
-		return normalizeEntries(JSON.parse(savedEntries) as WallpaperEntry[]);
+		return normalizeEntries([
+			...(JSON.parse(savedEntries) as WallpaperEntry[]),
+			...wallpapers.map((url) => ({
+				url,
+				synced: false,
+			})),
+		]);
 	}
 
-	const wallpapers = readLocalWallpapers();
 	const migrated = wallpapers.map((url) => ({
 		url,
 		synced: false,
@@ -146,11 +152,13 @@ export async function setWallpaperEntrySyncState(
 	uaClass: WallpaperSyncUaClass = getWallpaperSyncUaClass(),
 ): Promise<WallpaperEntry[]> {
 	const localEntries = readLocalWallpaperEntries();
-	const nextEntries = normalizeEntries(
-		localEntries.map((entry) =>
+	const hasTargetEntry = localEntries.some((entry) => entry.url === url);
+	const nextEntries = normalizeEntries([
+		...localEntries.map((entry) =>
 			entry.url === url ? { ...entry, synced } : entry,
 		),
-	);
+		...(hasTargetEntry ? [] : [{ url, synced }]),
+	]);
 	const syncedWallpapers = nextEntries
 		.filter((entry) => entry.synced)
 		.map((entry) => entry.url);


### PR DESCRIPTION
### Motivation
- 設定画面で「同期する」がONになっている壁紙が一覧に表示されない、かつリロードで同期中の壁紙が消える問題を修正するため。

### Description
- `packages/client/src/scripts/wallpaper-sync.ts` の `readLocalWallpaperEntries()` を変更し、既存の `wallpaperEntries` に加えて `wallpapers` 側の URL も必ず取り込むようにして一覧の復元を行うようにした。 
- 同期トグル処理の `setWallpaperEntrySyncState()` を強化し、対象 URL が `wallpaperEntries` に存在しない場合はエントリを補ってから保存するようにした。 
- 上記によりローカルメタと同期ストアの不整合が原因で同期中の壁紙が一覧から消える場合を補正する。 
- 変更対象は `packages/client/src/scripts/wallpaper-sync.ts`（一覧マージと同期フローの耐性向上）。
- 想定される副作用として、過去に `wallpapers` にだけ残っていた URL が設定画面の一覧に復活する可能性がある点を明記する。同期状態自体はレジストリ取得結果で決まるため `synced` フラグの永続的な誤固定は起きにくい設計にしている。

### Testing
- `git diff --check` を実行し問題なし（成功）。
- `pnpm exec prettier --check packages/client/src/scripts/wallpaper-sync.ts` を実行したが、この環境では `vue` のパッケージ解決ができず失敗（環境依存のためローカルでのフォーマット確認を推奨）。
- `pnpm exec tsc -p packages/client/tsconfig.json --noEmit` を実行したが、`vite/client` の型定義が見つからず型チェックは失敗（環境依存のため CI/開発環境での型チェック実行を推奨）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc6c124348326a07e23422b0f87b6)