### PR TITLE
fix(client): persist wallpaper sync toggle off state

### DIFF
--- a/packages/client/src/scripts/wallpaper-sync.ts
+++ b/packages/client/src/scripts/wallpaper-sync.ts
@@ -115,9 +115,19 @@ async function persistSyncedWallpapers(
 ): Promise<void> {
 	if ($i == null) return;
 
+	const key = getRegistryKey(uaClass);
+
+	if (syncedWallpapers.length === 0) {
+		await api("i/registry/remove", {
+			scope,
+			key,
+		});
+		return;
+	}
+
 	await api("i/registry/set", {
 		scope,
-		key: getRegistryKey(uaClass),
+		key,
 		value: syncedWallpapers,
 	});
 }
@@ -194,14 +204,16 @@ export async function initializeWallpaperSync(): Promise<void> {
 			updatedScope.length !== 2 ||
 			updatedScope[0] !== scope[0] ||
 			updatedScope[1] !== scope[1] ||
-			key !== getRegistryKey(uaClass) ||
-			!Array.isArray(value)
+			key !== getRegistryKey(uaClass)
 		) {
 			return;
 		}
 
 		writeLocalWallpaperEntries(
-			mergeWallpaperEntries(readLocalWallpaperEntries(), value as string[]),
+			mergeWallpaperEntries(
+				readLocalWallpaperEntries(),
+				Array.isArray(value) ? (value as string[]) : [],
+			),
 		);
 	});
 }


### PR DESCRIPTION
### Motivation
- 壁紙の「同期する」トグルをOFFにしても、レジストリキーが削除されずリロードで再びON扱いになる不具合を修正するため、OFF時はレジストリから該当キーを削除し端末のローカルストレージは保持する挙動にする。\n
### Description
- `packages/client/src/scripts/wallpaper-sync.ts` の `persistSyncedWallpapers` を変更し、`syncedWallpapers.length === 0` の場合は `i/registry/set` ではなく `i/registry/remove` を呼ぶようにした。\n
- レジストリ変更イベントの処理を修正し、`registryUpdated` の `value` が配列でない（キー削除など）の場合は空の配列として扱い、ローカルキャッシュが再び同期ON側に戻らないようにした。\n
- ローカル側の `wallpaperEntries` / `wallpapers` はOFFにしても端末のローカルストレージに残す（つまり同期解除はレジストリ削除のみでローカルデータを消さない）。\n
- 変更箇所: `packages/client/src/scripts/wallpaper-sync.ts`（コミット済み: `a21c83f`）。\n
- 想定される副作用: レジストリに空配列が明示的に保存されることを前提とする他の実装がある場合、キーが完全に削除されることで挙動差が発生する可能性があるが、本ファイル内および既存の読み取り処理はキー未存在を `[]` とみなすため互換性は保たれている。\n
### Testing
- `pnpm --filter client run lint` を実行しようとしたが、`rome` がこの環境に存在せず `node_modules` 未配置のため実行できず失敗した。\n
- 変更内容はローカルでコミット済みで、`git status` / `git show --stat` により差分を確認済み（コミット: `a21c83f`）。\n
- 自動テストはこの環境では未実行のため、CI上で `pnpm install` 後に `pnpm --filter client run lint` とビルド・回帰テストを実行することを推奨する。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc87bbf288326af077f00bbbcb1e4)