### PR TITLE
リロードで壁紙の同期状態が消える不具合を修正

### DIFF
--- a/packages/client/src/scripts/wallpaper-sync.ts
+++ b/packages/client/src/scripts/wallpaper-sync.ts
@@ -278,19 +278,32 @@ function removeWallpaperFromLocalStorage(
  * @returns レジストリに保存されている壁紙URL一覧
  * @internal
  */
+type SyncedWallpapersFetchResult = {
+	exists: boolean;
+	wallpapers: string[];
+};
+
 async function fetchSyncedWallpapers(
 	uaClass: WallpaperSyncUaClass = getWallpaperSyncUaClass(),
-): Promise<string[]> {
-	if ($i == null) return [];
+): Promise<SyncedWallpapersFetchResult> {
+	if ($i == null) {
+		return {
+			exists: false,
+			wallpapers: [],
+		};
+	}
 
 	const values = ((await api("i/registry/get-all", { scope })) || {}) as Record<
 		string,
 		unknown
 	>;
 	const registryKey = getRegistryKey(uaClass);
-	return Array.isArray(values[registryKey])
-		? (values[registryKey] as string[])
-		: [];
+	const registryValue = values[registryKey];
+
+	return {
+		exists: Object.prototype.hasOwnProperty.call(values, registryKey),
+		wallpapers: Array.isArray(registryValue) ? (registryValue as string[]) : [],
+	};
 }
 
 /**
@@ -393,7 +406,7 @@ async function removeWallpaperFromRegistry(
 ): Promise<void> {
 	if ($i == null) return;
 
-	const syncedWallpapers = await fetchSyncedWallpapers(uaClass);
+	const { wallpapers: syncedWallpapers } = await fetchSyncedWallpapers(uaClass);
 	const nextSyncedWallpapers = syncedWallpapers.filter(
 		(entryUrl) => entryUrl !== url,
 	);
@@ -429,8 +442,11 @@ export async function loadWallpaperEntries(
 		return localEntries;
 	}
 
-	const registryWallpapers = await fetchSyncedWallpapers(uaClass);
-	const mergedEntries = mergeWithRegistry(localEntries, registryWallpapers);
+	const { exists: registryKeyExists, wallpapers: registryWallpapers } =
+		await fetchSyncedWallpapers(uaClass);
+	const mergedEntries = registryKeyExists
+		? mergeWithRegistry(localEntries, registryWallpapers)
+		: localEntries;
 	// マージ結果をローカルに書き戻し、他端末の変更を反映する
 	writeLocalWallpaperEntries(mergedEntries);
 	updateWallpapersDisplayCache(mergedEntries);


### PR DESCRIPTION
### Motivation
- 初回リロード直後にレジストリキーが未作成のケースを空配列と同一視してしまい、`synced=true` のローカル壁紙を「他端末で削除された」と誤判定して一覧から消えてしまう問題を解消するため。

### Description
- `packages/client/src/scripts/wallpaper-sync.ts` の `fetchSyncedWallpapers` を拡張し、レジストリキーの存在を示す `exists` フラグと `wallpapers` 配列を返すようにした。 
- レジストリキーが未作成 (`exists === false`) の場合はローカル状態を優先してマージ処理をスキップするようにし、初回同期時の誤削除を防止するようにした。 
- `removeWallpaperFromRegistry` とそれを呼ぶ処理を新しい取得結果形式に合わせて追従し、差分削除ロジックが正しく動作するようにした。 

### Testing
- `pnpm --filter client run lint` を実行しようとしたが、`node_modules` が未導入のため `rome` が見つからず実行できなかった（失敗）。
- `pnpm --filter client run build` を実行しようとしたが、同様に `node_modules` 未導入のため `vite` が見つからず実行できなかった（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc87f460d4832685eb1a6230ad576d)