### PR TITLE
Refactor renote-only filtering for local timeline (query and stream)

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -120,53 +120,57 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
 
 function filterRenoteOnlyForLocalTimeline(
         notes: Packed<"Note">[],
+        limit: number,
         meId?: string,
 ): Packed<"Note">[] {
         if (notes.length === 0) return notes;
 
-        const noteMap = new Map<string, Packed<"Note">>();
-        const renoteOnlyMap = new Map<string, Packed<"Note">[]>();
+        const visibleNotes: Array<Packed<"Note"> | null> = [];
+        const visibleNoteIds = new Set<string>();
+        const visibleRenoteIndexes = new Map<string, number>();
+        let visibleCount = 0;
 
         for (const note of notes) {
-                noteMap.set(note.id, note);
+                if (!isRenoteOnly(note) || (meId && note.userId === meId)) {
+                        const renoteIndex = visibleRenoteIndexes.get(note.id);
+                        if (renoteIndex !== undefined) {
+                                visibleNotes[renoteIndex] = null;
+                                visibleRenoteIndexes.delete(note.id);
+                        }
 
-                if (!isRenoteOnly(note)) continue;
+                        visibleNoteIds.add(note.id);
+                        visibleNotes.push(note);
+                        visibleCount += 1;
+                } else {
+                        const targetId = note.renote?.id;
+                        if (!targetId) {
+                                visibleNotes.push(note);
+                                visibleCount += 1;
+                        } else {
+                                if (visibleNoteIds.has(targetId)) {
+                                        continue;
+                                }
 
-                const targetId = note.renote?.id;
-                if (!targetId) continue;
+                                const visibleRenoteIndex = visibleRenoteIndexes.get(targetId);
+                                if (visibleRenoteIndex !== undefined) {
+                                        visibleNotes[visibleRenoteIndex] = null;
+                                        visibleRenoteIndexes.set(targetId, visibleNotes.length);
+                                        visibleNotes.push(note);
+                                        continue;
+                                }
 
-                if (!renoteOnlyMap.has(targetId)) {
-                        renoteOnlyMap.set(targetId, []);
-                }
-
-                renoteOnlyMap.get(targetId)!.push(note);
-        }
-
-        return notes.filter((note) => {
-                if (!isRenoteOnly(note)) return true;
-                if (meId && note.userId === meId) return true;
-
-                const targetId = note.renote?.id;
-                if (!targetId) return true;
-
-                if (noteMap.has(targetId)) {
-                        return false;
-                }
-
-                const candidates = renoteOnlyMap.get(targetId);
-                if (!candidates || candidates.length === 0) {
-                        return true;
-                }
-
-                let oldest = candidates[0];
-                for (const candidate of candidates) {
-                        if (candidate.id < oldest.id) {
-                                oldest = candidate;
+                                visibleRenoteIndexes.set(targetId, visibleNotes.length);
+                                visibleNotes.push(note);
+                                visibleCount += 1;
                         }
                 }
 
-                return note.id === oldest.id;
-        });
+                if (visibleCount >= limit) {
+                        break;
+                }
+        }
+
+        return visibleNotes.filter((note): note is Packed<"Note"> => note !== null);
 }
 
 export default define(meta, paramDef, async (ps, user) => {
@@ -329,7 +333,7 @@ export default define(meta, paramDef, async (ps, user) => {
                         });
                         rawNotes.push(...packedNotes);
 
-                        const filtered = filterRenoteOnlyForLocalTimeline(rawNotes, user?.id);
+                        const filtered = filterRenoteOnlyForLocalTimeline(rawNotes, ps.limit, user?.id);
                         if (filtered.length >= ps.limit) {
                                 return filtered.slice(0, ps.limit);
                         }
@@ -344,5 +348,5 @@ export default define(meta, paramDef, async (ps, user) => {
                 throw new ApiError(meta.errors.queryError);
         }
 
-        return filterRenoteOnlyForLocalTimeline(rawNotes, user?.id).slice(0, ps.limit);
+        return filterRenoteOnlyForLocalTimeline(rawNotes, ps.limit, user?.id);
 });

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -44,13 +44,29 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
         return !hasRenoteOnlyContent(note);
 }
 
+function rememberRecentId(targets: Set<string>, id: string): void {
+        if (targets.has(id)) {
+                targets.delete(id);
+        }
+
+        targets.add(id);
+
+        if (targets.size > RECENT_RENOTE_TARGET_LIMIT) {
+                const oldestId = targets.values().next().value;
+                if (oldestId !== undefined) {
+                        targets.delete(oldestId);
+                }
+        }
+}
+
 export default class extends Channel {
         public readonly chName = "localTimeline";
         public static shouldShare = true;
         public static requireCredential = false;
         private withBelowPublic: boolean;
         private showReplyMode: "all" | "notBotOnly" | "personalOnly";
-        private recentRenoteTargets: Map<string, string> = new Map();
+        private receivedRenoteTargetIds: Set<string> = new Set();
+        private displayedNoteIds: Set<string> = new Set();
 
 	constructor(id: string, connection: Channel["connection"]) {
 		super(id, connection);
@@ -145,11 +161,10 @@ export default class extends Channel {
 			return;
 
                 this.connection.cacheNote(note);
+                this.rememberDisplayedNote(note);
 
                 if (isRenoteOnly(note)) {
                         this.rememberRenoteOnly(note);
-                } else if (this.recentRenoteTargets.has(note.id)) {
-                        this.recentRenoteTargets.delete(note.id);
                 }
 
                 this.send("note", note);
@@ -166,34 +181,21 @@ export default class extends Channel {
                 const targetId = note.renote?.id;
                 if (!targetId) return false;
 
-                if (this.connection.hasCachedNote(targetId)) {
-                        return true;
-                }
+                return (
+                        this.displayedNoteIds.has(targetId) ||
+                        this.receivedRenoteTargetIds.has(targetId)
+                );
+        }
 
-                const existing = this.recentRenoteTargets.get(targetId);
-                if (!existing) {
-                        return false;
-                }
 
-                if (existing <= note.id) {
-                        return true;
-                }
-
-                this.recentRenoteTargets.set(targetId, note.id);
-                return false;
+        private rememberDisplayedNote(note: Packed<"Note">) {
+                rememberRecentId(this.displayedNoteIds, note.id);
         }
 
         private rememberRenoteOnly(note: Packed<"Note">) {
                 const targetId = note.renote?.id;
                 if (!targetId) return;
 
-                this.recentRenoteTargets.set(targetId, note.id);
-
-                if (this.recentRenoteTargets.size > RECENT_RENOTE_TARGET_LIMIT) {
-                        const oldestKey = this.recentRenoteTargets.keys().next().value;
-                        if (oldestKey !== undefined) {
-                                this.recentRenoteTargets.delete(oldestKey);
-                        }
-                }
+                rememberRecentId(this.receivedRenoteTargetIds, targetId);
         }
 }


### PR DESCRIPTION
### Motivation
- Ensure renote-only notes are filtered deterministically and respect the requested page `limit` when assembling the local timeline results. 
- Avoid showing duplicate renote-only entries when a renote target is already present while maintaining recent context for streaming clients. 
- Make streaming behavior consistent with the API filtering logic so clients do not receive redundant renote-only notes.

### Description
- Changed `filterRenoteOnlyForLocalTimeline` to accept a `limit` parameter and replaced the old map-based selection with a linear pass that uses `visibleNotes`, `visibleNoteIds`, and `visibleRenoteIndexes` to pick which notes to keep and stop early once `limit` is reached. 
- Updated callers to pass `ps.limit` into `filterRenoteOnlyForLocalTimeline` in the local timeline endpoint so pagination respects the new early-exit behavior. 
- In the stream channel, replaced `recentRenoteTargets: Map` with two sets `receivedRenoteTargetIds` and `displayedNoteIds`, added `rememberRecentId` helper, and added `rememberDisplayedNote` to record displayed notes. 
- Updated `shouldSkipRenoteOnly` to check both `displayedNoteIds` and `receivedRenoteTargetIds` when deciding whether to skip a renote-only note, and removed the id-comparison logic in favor of the recent-id sets.

### Testing
- Ran TypeScript build and type checks (`yarn build`), which succeeded. 
- Executed backend unit test suite (`yarn test`), including timeline-related tests, which passed. 
- Ran integration/smoke tests for the local timeline endpoint and streaming channel to verify pagination and de-duplication behavior, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a6ed674483269724af8c0d952c00)