### PR TITLE
Improve renote handling in reply filters and local/global timeline streams

### DIFF
--- a/packages/backend/src/server/api/common/generate-replies-query.ts
+++ b/packages/backend/src/server/api/common/generate-replies-query.ts
@@ -20,7 +20,7 @@ export function generateRepliesQuery(
 ) {
 	const useBotMention = applyIsBotMentionFilter === true;
 	const notReplyCond = useBotMention
-		? "(note.replyId IS NULL AND (note.isBotMention IS NOT TRUE))"
+		? "(note.replyId IS NULL AND (note.renoteId IS NOT NULL OR note.isBotMention IS NOT TRUE))"
 		: "note.replyId IS NULL";
 
 	if (me == null) {

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -120,53 +120,57 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
 
 function filterRenoteOnlyForLocalTimeline(
         notes: Packed<"Note">[],
+        limit: number,
         meId?: string,
 ): Packed<"Note">[] {
         if (notes.length === 0) return notes;
 
-        const noteMap = new Map<string, Packed<"Note">>();
-        const renoteOnlyMap = new Map<string, Packed<"Note">[]>();
+        const visibleNotes: Array<Packed<"Note"> | null> = [];
+        const visibleNoteIds = new Set<string>();
+        const visibleRenoteIndexes = new Map<string, number>();
+        let visibleCount = 0;
 
         for (const note of notes) {
-                noteMap.set(note.id, note);
+                if (!isRenoteOnly(note) || (meId && note.userId === meId)) {
+                        const renoteIndex = visibleRenoteIndexes.get(note.id);
+                        if (renoteIndex !== undefined) {
+                                visibleNotes[renoteIndex] = null;
+                                visibleRenoteIndexes.delete(note.id);
+                        }
 
-                if (!isRenoteOnly(note)) continue;
+                        visibleNoteIds.add(note.id);
+                        visibleNotes.push(note);
+                        visibleCount += 1;
+                } else {
+                        const targetId = note.renote?.id;
+                        if (!targetId) {
+                                visibleNotes.push(note);
+                                visibleCount += 1;
+                        } else {
+                                if (visibleNoteIds.has(targetId)) {
+                                        continue;
+                                }
 
-                const targetId = note.renote?.id;
-                if (!targetId) continue;
+                                const visibleRenoteIndex = visibleRenoteIndexes.get(targetId);
+                                if (visibleRenoteIndex !== undefined) {
+                                        visibleNotes[visibleRenoteIndex] = null;
+                                        visibleRenoteIndexes.set(targetId, visibleNotes.length);
+                                        visibleNotes.push(note);
+                                        continue;
+                                }
 
-                if (!renoteOnlyMap.has(targetId)) {
-                        renoteOnlyMap.set(targetId, []);
-                }
-
-                renoteOnlyMap.get(targetId)!.push(note);
-        }
-
-        return notes.filter((note) => {
-                if (!isRenoteOnly(note)) return true;
-                if (meId && note.userId === meId) return true;
-
-                const targetId = note.renote?.id;
-                if (!targetId) return true;
-
-                if (noteMap.has(targetId)) {
-                        return false;
-                }
-
-                const candidates = renoteOnlyMap.get(targetId);
-                if (!candidates || candidates.length === 0) {
-                        return true;
-                }
-
-                let oldest = candidates[0];
-                for (const candidate of candidates) {
-                        if (candidate.id < oldest.id) {
-                                oldest = candidate;
+                                visibleRenoteIndexes.set(targetId, visibleNotes.length);
+                                visibleNotes.push(note);
+                                visibleCount += 1;
                         }
                 }
 
-                return note.id === oldest.id;
-        });
+                if (visibleCount >= limit) {
+                        break;
+                }
+        }
+
+        return visibleNotes.filter((note): note is Packed<"Note"> => note !== null);
 }
 
 export default define(meta, paramDef, async (ps, user) => {
@@ -329,7 +333,7 @@ export default define(meta, paramDef, async (ps, user) => {
                         });
                         rawNotes.push(...packedNotes);
 
-                        const filtered = filterRenoteOnlyForLocalTimeline(rawNotes, user?.id);
+                        const filtered = filterRenoteOnlyForLocalTimeline(rawNotes, ps.limit, user?.id);
                         if (filtered.length >= ps.limit) {
                                 return filtered.slice(0, ps.limit);
                         }
@@ -344,5 +348,5 @@ export default define(meta, paramDef, async (ps, user) => {
                 throw new ApiError(meta.errors.queryError);
         }
 
-        return filterRenoteOnlyForLocalTimeline(rawNotes, user?.id).slice(0, ps.limit);
+        return filterRenoteOnlyForLocalTimeline(rawNotes, ps.limit, user?.id);
 });

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -48,7 +48,7 @@ export default class extends Channel {
 		if (!this.user && note.reply) {
 			return;
 		}
-		if (this.user && this.showReplyMode === "notBotOnly" && note.isBotMention && note.userId !== this.user.id) {
+		if (this.user && this.showReplyMode === "notBotOnly" && note.renoteId == null && note.isBotMention && note.userId !== this.user.id) {
 			return;
 		}
 		if (note.reply && !this.user!.showTimelineReplies) {

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -44,13 +44,29 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
         return !hasRenoteOnlyContent(note);
 }
 
+function rememberRecentId(targets: Set<string>, id: string): void {
+        if (targets.has(id)) {
+                targets.delete(id);
+        }
+
+        targets.add(id);
+
+        if (targets.size > RECENT_RENOTE_TARGET_LIMIT) {
+                const oldestId = targets.values().next().value;
+                if (oldestId !== undefined) {
+                        targets.delete(oldestId);
+                }
+        }
+}
+
 export default class extends Channel {
         public readonly chName = "localTimeline";
         public static shouldShare = true;
         public static requireCredential = false;
         private withBelowPublic: boolean;
         private showReplyMode: "all" | "notBotOnly" | "personalOnly";
-        private recentRenoteTargets: Map<string, string> = new Map();
+        private receivedRenoteTargetIds: Set<string> = new Set();
+        private displayedNoteIds: Set<string> = new Set();
 
 	constructor(id: string, connection: Channel["connection"]) {
 		super(id, connection);
@@ -94,7 +110,7 @@ export default class extends Channel {
 		if (!this.user && note.reply) {
 			return;
 		}
-		if (this.user && this.showReplyMode === "notBotOnly" && note.isBotMention && note.userId !== this.user.id) {
+		if (this.user && this.showReplyMode === "notBotOnly" && note.renoteId == null && note.isBotMention && note.userId !== this.user.id) {
 			return;
 		}
 		if (note.reply && !this.user!.showTimelineReplies) {
@@ -145,11 +161,10 @@ export default class extends Channel {
 			return;
 
                 this.connection.cacheNote(note);
+                this.rememberDisplayedNote(note);
 
                 if (isRenoteOnly(note)) {
                         this.rememberRenoteOnly(note);
-                } else if (this.recentRenoteTargets.has(note.id)) {
-                        this.recentRenoteTargets.delete(note.id);
                 }
 
                 this.send("note", note);
@@ -166,34 +181,21 @@ export default class extends Channel {
                 const targetId = note.renote?.id;
                 if (!targetId) return false;
 
-                if (this.connection.hasCachedNote(targetId)) {
-                        return true;
-                }
+                return (
+                        this.displayedNoteIds.has(targetId) ||
+                        this.receivedRenoteTargetIds.has(targetId)
+                );
+        }
 
-                const existing = this.recentRenoteTargets.get(targetId);
-                if (!existing) {
-                        return false;
-                }
 
-                if (existing <= note.id) {
-                        return true;
-                }
-
-                this.recentRenoteTargets.set(targetId, note.id);
-                return false;
+        private rememberDisplayedNote(note: Packed<"Note">) {
+                rememberRecentId(this.displayedNoteIds, note.id);
         }
 
         private rememberRenoteOnly(note: Packed<"Note">) {
                 const targetId = note.renote?.id;
                 if (!targetId) return;
 
-                this.recentRenoteTargets.set(targetId, note.id);
-
-                if (this.recentRenoteTargets.size > RECENT_RENOTE_TARGET_LIMIT) {
-                        const oldestKey = this.recentRenoteTargets.keys().next().value;
-                        if (oldestKey !== undefined) {
-                                this.recentRenoteTargets.delete(oldestKey);
-                        }
-                }
+                rememberRecentId(this.receivedRenoteTargetIds, targetId);
         }
 }


### PR DESCRIPTION
### Motivation

- Fix incorrect exclusion of renotes when applying reply/bot-mention filters so renotes are not treated as regular replies in those cases.
- Prevent renote-only posts from being unintentionally hidden from the local timeline while respecting the requested `limit`.
- Avoid duplicate suppression and unbounded memory growth in streaming channels by tracking recently received/displayed renote targets.

### Description

- Update `generate-replies-query.ts` to treat notes with `renoteId` as non-replies when `useBotMention` is true by changing the `notReplyCond` to include `note.renoteId IS NOT NULL` as a non-reply case.
- Rewrite `filterRenoteOnlyForLocalTimeline` in `local-timeline.ts` to accept a `limit` argument and use `visibleNotes`, `visibleNoteIds`, and `visibleRenoteIndexes` to select visible items incrementally and stop early when the visible count reaches `limit`.
- Change global and local timeline stream handlers to only apply the `isBotMention` suppression for non-renotes by checking `note.renoteId == null` before skipping bot-mention notes.
- Replace the `recentRenoteTargets` map with bounded `receivedRenoteTargetIds` and `displayedNoteIds` sets and add a `rememberRecentId` helper to keep a limited history (`RECENT_RENOTE_TARGET_LIMIT`), plus call `rememberDisplayedNote` when caching/sending notes and use these sets in `shouldSkipRenoteOnly`.

### Testing

- Ran TypeScript build with `yarn build` and compilation succeeded.
- Executed unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a6ed674483269724af8c0d952c00)