### PR TITLE
Add visual dividers between Post Form settings groups

### DIFF
--- a/packages/client/src/pages/settings/postform.vue
+++ b/packages/client/src/pages/settings/postform.vue
@@ -124,6 +124,7 @@
                         <FormSwitch v-model="postFormFooterButtonsTabindexMinusOne" class="_formBlock">
                                 {{ i18n.ts.postFormFooterButtonsTabindexMinusOne }}
                         </FormSwitch>
+                        <div class="postFormSectionDivider _formBlock" aria-hidden="true"></div>
                         <div class="postFormGroupLabel _formBlock">
                                 {{ i18n.ts.postFormHeaderButtons }}
                         </div>
@@ -181,6 +182,7 @@
                                         }}</span></span
                                 >
                         </FormSwitch>
+                        <div class="postFormSectionDivider _formBlock" aria-hidden="true"></div>
                         <div class="postFormGroupLabel _formBlock">
                                 {{ i18n.ts.postFormFooterButtons }}
                         </div>
@@ -513,5 +515,11 @@ definePageMetadata({
 	font-weight: 700;
 	color: var(--fg);
 	margin-top: 0.5rem;
+}
+
+.postFormSectionDivider {
+	height: 0;
+	margin: 0.75rem 0;
+	border-top: solid 0.03125rem var(--divider);
 }
 </style>


### PR DESCRIPTION
### Motivation

- Improve visual separation and clarity between header and footer button groups in the Post Form settings UI.

### Description

- Inserted `div` elements with `class="postFormSectionDivider _formBlock"` and `aria-hidden="true"` between grouped settings in `postform.vue` to create section breaks.  
- Added scoped CSS for `.postFormSectionDivider` to render a hairline divider using `border-top` and spacing.

### Testing

- No automated tests were added or run for this UI-only change; existing automated test suites were not modified by this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7852ceb248326bbce43502275e6a4)