### PR TITLE
Avoid deduplicating renotes when the renote target is remote in local timeline

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -118,6 +118,10 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
         return !hasRenoteOnlyContent(note);
 }
 
+function isRemoteRenoteTarget(note: Packed<"Note">): boolean {
+        return note.renote?.user?.host != null;
+}
+
 function filterRenoteOnlyForLocalTimeline(
         notes: Packed<"Note">[],
         limit: number,
@@ -147,7 +151,7 @@ function filterRenoteOnlyForLocalTimeline(
                                 visibleNotes.push(note);
                                 visibleCount += 1;
                         } else {
-                                if (visibleNoteIds.has(targetId)) {
+                                if (!isRemoteRenoteTarget(note) && visibleNoteIds.has(targetId)) {
                                         continue;
                                 }
 

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -44,6 +44,10 @@ function isRenoteOnly(note: Packed<"Note">): boolean {
         return !hasRenoteOnlyContent(note);
 }
 
+function isRemoteRenoteTarget(note: Packed<"Note">): boolean {
+        return note.renote?.user?.host != null;
+}
+
 function rememberRecentId(targets: Set<string>, id: string): void {
         if (targets.has(id)) {
                 targets.delete(id);
@@ -182,7 +186,8 @@ export default class extends Channel {
                 if (!targetId) return false;
 
                 return (
-                        this.displayedNoteIds.has(targetId) ||
+                        (!isRemoteRenoteTarget(note) &&
+                                this.displayedNoteIds.has(targetId)) ||
                         this.receivedRenoteTargetIds.has(targetId)
                 );
         }


### PR DESCRIPTION
### Motivation
- Renote-only items were being deduplicated/hidden when their target note was already present in the local timeline, which incorrectly suppressed renotes that reference notes hosted on remote instances.

### Description
- Added `isRemoteRenoteTarget` helper in both `local-timeline.ts` and the stream channel to detect renotes whose target `user.host` is non-null.
- Updated `filterRenoteOnlyForLocalTimeline` to skip the deduplication check when the renote target is remote, preserving remote renotes as distinct items.
- Updated the stream channel's `shouldSkipRenoteOnly` logic to avoid treating remote renote targets as already-displayed local notes.

### Testing
- Ran the TypeScript type check (`yarn tsc`) and local backend unit tests (`yarn test`) after the changes, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c78a0edf3c8326a911f163ec77e927)