### PR TITLE
Normalize music.youtube.com URLs in preview handler

### DIFF
--- a/packages/backend/src/server/web/url-preview.ts
+++ b/packages/backend/src/server/web/url-preview.ts
@@ -153,6 +153,25 @@ function isXLikeHostname(hostname: string): boolean {
 	].includes(normalized);
 }
 
+function normalizeUrlForPreview(rawUrl: string): string {
+	try {
+		const parsed = new URL(rawUrl);
+		if (
+			parsed.hostname.toLowerCase() === "music.youtube.com" &&
+			(parsed.pathname === "/watch" ||
+				parsed.pathname.startsWith("/channel/") ||
+				parsed.pathname.startsWith("/playlist") ||
+				parsed.pathname.startsWith("/@"))
+		) {
+			parsed.hostname = "www.youtube.com";
+			return parsed.toString();
+		}
+		return rawUrl;
+	} catch {
+		return rawUrl;
+	}
+}
+
 /**
  * X(Twitter) のサムネイルURLがメディア由来かどうかを判定する。
  * アイコン・汎用画像と見なせるものは false を返す。
@@ -239,8 +258,9 @@ export const urlPreviewHandler = async (ctx: Koa.Context) => {
       : `Getting preview of ${url}@${lang} ...`
   );
 
-  const redirectedUrl = await resolveShortUrlIfNeeded(url);
-  const effectiveUrl = redirectedUrl ?? url;
+  const normalizedUrl = normalizeUrlForPreview(url);
+  const redirectedUrl = await resolveShortUrlIfNeeded(normalizedUrl);
+  const effectiveUrl = redirectedUrl ?? normalizedUrl;
   const isXPreviewUrl = (() => {
 		try {
 			return isXLikeHostname(new URL(effectiveUrl).hostname);


### PR DESCRIPTION
### Motivation
- `music.youtube.com` に貼られた URL でサーバ側の URL プレビューが取得できないケースがあり、クライアント側でのフォールバック前にプレビューが出ない問題を防ぐために、music ドメインを `www.youtube.com` と同様に扱う意図で変更しました。
- 対象はプレイヤーやチャネル、プレイリストなど YouTube 本体と同等のメタ情報を参照できるパス（`/watch`, `/channel/*`, `/playlist*`, `/@*`）です。
- サマライズ処理・短縮 URL 解決・各種サービス判定に渡す前に URL を正規化して処理を一貫させることが目的です。

### Description
- `packages/backend/src/server/web/url-preview.ts` に `normalizeUrlForPreview(rawUrl: string): string` を追加しました。関数は `music.youtube.com` の特定パスを検出した場合にホスト名を `www.youtube.com` に書き換えます。
- `urlPreviewHandler` の先頭で `normalizedUrl = normalizeUrlForPreview(url)` を作成し、以降の `resolveShortUrlIfNeeded`、`effectiveUrl`、および後続のサマリ取得処理や各種 URL 判定で `normalizedUrl` / `effectiveUrl` を使うように変更しました。
- 変更によりサーバ側でも `music.youtube.com` が `www.youtube.com` と同様のメタ情報取得経路に入るため、プレビュー取得失敗が減る想定です。

### Testing
- `pnpm -C packages/backend exec eslint src/server/web/url-preview.ts` を実行しましたが、プロジェクトの ESLint 設定検出で失敗しました（ESLint の設定ファイル探索エラー）。
- `pnpm --filter backend lint` を実行しましたが、`rome` コマンドが見つからない / `node_modules` 未インストールのため実行不可で失敗しました。

変更はローカルでファイルにコミット済み（`packages/backend/src/server/web/url-preview.ts` 修正）。自動リンティング/静的解析の実行環境が整い次第、`rome` / ESLint を通した検証を推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7e5838888326b0a82acfd47d21e5)