### PR TITLE
管理人ブロックに連動したモデレーション警告の自動切替を追加

### DIFF
--- a/packages/backend/src/services/blocking/create.ts
+++ b/packages/backend/src/services/blocking/create.ts
@@ -38,6 +38,7 @@ import { getActiveWebhooks } from "@/misc/webhook-cache.js";
 import { invalidateListMembersCache } from "@/misc/antenna-members-cache.js";
 import { webhookDeliver } from "@/queue/index.js";
 import { ensureProxyFollowsListedUser } from "../user-list/ensure-proxy-follow.js";
+import { setModerationWarningByAdminBlock } from "../moderation-warning-by-admin-block.js";
 
 export default async function (blocker: User, blockee: User) {
         await Promise.all([
@@ -62,6 +63,7 @@ export default async function (blocker: User, blockee: User) {
 	} as Blocking;
 
 	await Blockings.insert(blocking);
+	await setModerationWarningByAdminBlock(blocker, blockee);
 
 	if (Users.isLocalUser(blocker) && Users.isRemoteUser(blockee)) {
 		const content = renderActivity(renderBlock(blocking));

--- a/packages/backend/src/services/blocking/delete.ts
+++ b/packages/backend/src/services/blocking/delete.ts
@@ -16,8 +16,8 @@ import renderUndo from "@/remote/activitypub/renderer/undo.js";
 import { deliver } from "@/queue/index.js";
 import Logger from "../logger.js";
 import type { CacheableUser } from "@/models/entities/user.js";
-import { User } from "@/models/entities/user.js";
 import { Blockings, Users } from "@/models/index.js";
+import { unsetModerationWarningByAdminUnblock } from "../moderation-warning-by-admin-block.js";
 
 const logger = new Logger("blocking/delete");
 
@@ -38,7 +38,8 @@ export default async function (blocker: CacheableUser, blockee: CacheableUser) {
 	blocking.blocker = blocker;
 	blocking.blockee = blockee;
 
-	Blockings.delete(blocking.id);
+	await Blockings.delete(blocking.id);
+	await unsetModerationWarningByAdminUnblock(blocker, blockee);
 
 	// リモートブロックの場合は配信
 	if (Users.isLocalUser(blocker) && Users.isRemoteUser(blockee)) {

--- a/packages/backend/src/services/moderation-warning-by-admin-block.ts
+++ b/packages/backend/src/services/moderation-warning-by-admin-block.ts
@@ -1,0 +1,46 @@
+import { Blockings, Users } from "@/models/index.js";
+import { publishInternalEvent } from "@/services/stream.js";
+import type { CacheableUser, User } from "@/models/entities/user.js";
+
+function shouldAutoModerationWarning(blocker: CacheableUser, blockee: CacheableUser): boolean {
+	return Users.isRemoteUser(blocker) && Users.isLocalUser(blockee) && blockee.isAdmin;
+}
+
+async function publishUserModerationWarningChanged(userId: User["id"]): Promise<void> {
+	await Users.invalidateMeDetailedBaseCache(userId);
+	await Users.invalidateUserShowDetailedCache(userId);
+	publishInternalEvent("localUserUpdated", { id: userId });
+}
+
+export async function setModerationWarningByAdminBlock(blocker: User, blockee: User): Promise<void> {
+	if (!shouldAutoModerationWarning(blocker, blockee)) return;
+
+	if (!blocker.isModerationWarning) {
+		await Users.update(blocker.id, { isModerationWarning: true });
+		await publishUserModerationWarningChanged(blocker.id);
+	}
+}
+
+export async function unsetModerationWarningByAdminUnblock(
+	blocker: CacheableUser,
+	blockee: CacheableUser,
+): Promise<void> {
+	if (!shouldAutoModerationWarning(blocker, blockee)) return;
+
+	const hasOtherAdminBlock =
+		(await Blockings.createQueryBuilder("blocking")
+			.innerJoin("user", "blockee", 'blockee.id = "blocking"."blockeeId"')
+			.where('"blocking"."blockerId" = :blockerId', { blockerId: blocker.id })
+			.andWhere('"blocking"."blockeeId" != :blockeeId', { blockeeId: blockee.id })
+			.andWhere('"blockee"."host" IS NULL')
+			.andWhere('"blockee"."isAdmin" = TRUE')
+			.getCount()) > 0;
+
+	if (hasOtherAdminBlock) return;
+
+	const target = await Users.findOneBy({ id: blocker.id });
+	if (target?.isModerationWarning) {
+		await Users.update(blocker.id, { isModerationWarning: false });
+		await publishUserModerationWarningChanged(blocker.id);
+	}
+}


### PR DESCRIPTION
### Motivation
- リモートユーザーがローカル管理人をブロックした/解除した際に、対象リモートユーザーの `isModerationWarning` を自動で切り替えて表示・TL判定を即時反映するため。

### Description
- 追加: `packages/backend/src/services/moderation-warning-by-admin-block.ts` を新設し、管理人ブロック時に自動で `isModerationWarning = true` にし、解除時に他管理人へのブロックが残存していなければ `false` に戻す処理を実装しました。キャッシュ無効化と `localUserUpdated` イベント発火も行います。  
- 更新: `packages/backend/src/services/blocking/create.ts` にブロック保存直後の自動ON呼び出しとして `setModerationWarningByAdminBlock` を追加しました。  
- 更新: `packages/backend/src/services/blocking/delete.ts` にブロック削除後の自動OFF呼び出しとして `unsetModerationWarningByAdminUnblock` を追加し、`Blockings.delete` を `await` するよう修正しました。  
- 副作用: 自動OFF はそのユーザーが他の管理人をまだブロックしていないことを確認するためDBクエリが追加される点と、運用上手動で付与した `isModerationWarning` を区別していない場合に自動OFF によって元の手動設定が解除される可能性がある点に注意してください（競合・同時実行によるレースも発生し得ます）。

### Testing
- 実行: `pnpm -C packages/backend lint` を試行しましたが、実行環境に `node_modules` が存在せず `rome` が見つからないため失敗しました（環境依存のためローカルでの `pnpm install` 後に再実行してください）。
- 自動テストはこの環境では実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed90feb5c8832693855df7d544347f)