### PR TITLE
fix(client): guard missing MiAuth permission params

### DIFF
--- a/packages/client/src/pages/miauth.vue
+++ b/packages/client/src/pages/miauth.vue
@@ -55,7 +55,6 @@
 </template>
 
 <script lang="ts" setup>
-import {} from "vue";
 import MkSignin from "@/components/MkSignin.vue";
 import MkButton from "@/components/MkButton.vue";
 import FormInput from "@/components/form/input.vue";
@@ -67,12 +66,17 @@ import { i18n } from "@/i18n";
 const props = defineProps<{
 	session: string;
 	callback?: string;
-	name: string;
-	icon: string;
-	permission: string; // コンマ区切り
+	name?: string;
+	icon?: string;
+	permission?: string; // コンマ区切り
 }>();
 
-const _permissions = props.permission.split(",");
+const _permissions = (props.permission ?? "")
+	.split(",")
+	.map((permission) => permission.trim())
+	.filter((permission) => permission.length > 0);
+
+const appName = props.name?.trim() || "MiAuth";
 
 let state = $ref<string | null>(null);
 let comment = $ref("");
@@ -81,7 +85,7 @@ async function accept(): Promise<void> {
 	state = "waiting";
 	await os.api("miauth/gen-token", {
 		session: props.session,
-		name: `${props.name}${comment ? ` (${comment.slice(0, 20)})` : ""}`,
+		name: `${appName}${comment ? ` (${comment.slice(0, 20)})` : ""}`,
 		iconUrl: props.icon,
 		permission: _permissions,
 	});


### PR DESCRIPTION
## Summary
- make MiAuth route props optional for `name`, `icon`, and `permission`
- prevent runtime crash when `permission` is absent by safely parsing with a default empty string
- trim and filter parsed permission entries to avoid blank permissions
- add a fallback app name (`MiAuth`) when generating token names
- remove unused empty Vue import

## Problem
When opening MiAuth with missing query props, `props.permission.split(",")` caused:
`TypeError: Cannot read properties of undefined (reading 'split')`.
This left the page blank.

## Impact
- MiAuth page no longer crashes if `permission` is omitted
- token generation still works with an empty permission list

## Potential side effects
- If a caller accidentally omits `permission`, the app now proceeds with no permissions instead of hard-failing. This may mask caller-side parameter bugs.
- Token name now falls back to `MiAuth` when `name` is empty/missing, so generated token labels may differ from previous behavior in malformed requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c251bc4c48326a4e066aa6f44dbd4)