### PR TITLE
Respect Mastodon `reactions.max_reactions` when computing max reactions per account

### DIFF
--- a/packages/backend/src/services/fetch-instance-metadata.ts
+++ b/packages/backend/src/services/fetch-instance-metadata.ts
@@ -109,6 +109,7 @@ export async function fetchInstanceMetadata(
 							updates.maintainerEmail = mastodonInfo.email || null;
 
 						// max_reactions_per_account の指定があればその値にする
+						// reactions.max_reactions の指定があればその値にする
 						// 指定が無い場合は以下の通り
 						// configurationにemoji_reactionsの設定が何かあれば 1
 						// fedibird_capabilitiesにemoji_reactionがあれば 1
@@ -116,6 +117,7 @@ export async function fetchInstanceMetadata(
 						updates.maxReactionsPerAccount =
 							mastodonInfo.configuration?.emoji_reactions
 								?.max_reactions_per_account ??
+							mastodonInfo.configuration?.reactions?.max_reactions ??
 							(mastodonInfo.configuration?.emoji_reactions ||
 							mastodonInfo.fedibird_capabilities?.includes("emoji_reaction")
 								? 1


### PR DESCRIPTION
### Motivation
- Ensure the max reactions per account is correctly determined from Mastodon instances by also checking the newer `configuration.reactions.max_reactions` field when nodeinfo does not provide a value.

### Description
- Add `mastodonInfo.configuration?.reactions?.max_reactions` as a fallback when setting `updates.maxReactionsPerAccount` and update the inline comment to document this check.

### Testing
- Ran the TypeScript build (`npm run build`) and the existing backend test suite (`npm test`); both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1663248d588326a46ad824667d71e7)